### PR TITLE
feat: add daemon lifecycle management and process detachment

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -54,6 +54,9 @@ Go module cache is persisted in a Docker volume (`aethel-gomod`) for fast repeat
 - Layout persistence: TUI sends `MsgUpdateLayout` after every state sync; daemon stores it opaquely (no broadcast to avoid feedback loop). On reconnect, `applyWorkspaceState()` deserializes the tree and prunes missing panes
 - Pane naming: `MsgUpdatePane` IPC message, `Pane.Name` field in daemon, Alt+F2 keybinding to rename active pane (mirrors F2 tab rename pattern)
 - Shell integration: Daemon auto-injects OSC 7 hooks via `internal/shellinit/` — bash (`--rcfile`), zsh (`ZDOTDIR`), PowerShell (`-File`), fish (native). Init scripts written to `~/.aethel/shellinit/` at daemon startup. PTY `SetEnv()` passes env vars to child process
+- Daemon detachment: `cmd/aethel/proc_unix.go` and `proc_windows.go` supply `daemonSysProcAttr()` via build tags — mirrors the `internal/pty/` pattern. Unix uses `Setsid`, Windows uses `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP`
+- Daemon auto-start: TUI auto-starts `aetheld --background` if not running. `findDaemonBinary()` checks PATH then the executable's own directory. PID file at `~/.aethel/aetheld.pid`, stale socket cleanup before spawn
+- Daemon shutdown: `MsgShutdown` signals via channel (not `os.Exit`) so defers in `main()` run cleanly (PID file removal, log file close)
 
 ## Documents
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Daemon process detachment — survives TUI exit on all platforms (Unix: `Setsid`, Windows: `DETACHED_PROCESS`)
+- `aethel daemon status` command — reports daemon PID and connectivity
+- PID file tracking (`~/.aethel/aetheld.pid`) for lifecycle management
+- `aetheld --background` flag — suppresses stdout/stderr for silent auto-start
+- Daemon binary co-location lookup — finds `aetheld` alongside `aethel` when not on PATH (fixes Windows Go 1.19+ LookPath)
+- Stale socket cleanup — detects dead daemon sockets and removes them before starting fresh
+
+### Fixed
+
+- Daemon dying when TUI exits on Windows (missing `DETACHED_PROCESS` creation flag)
+- `os.Exit(0)` in shutdown handler skipping deferred cleanup — replaced with channel-based signaling
+- PID file written before `~/.aethel/` directory guaranteed to exist
+
 ## [0.2.0] - 2026-03-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for development guidelines.
 | **M2: Persistence** | In Progress | Output replay, layout persistence, shell integration, mouse, scrollback, tab colors, renaming |
 | **M3: Resume Engine** | Planned | Regex scrapers, token extraction, AI session resume |
 | **M4: Plugin System** | Planned | TOML plugins, typed panes, hot-reload |
-| **M5: Polish** | Planned | JSON transformer, observability, encrypted tokens |
+| **M5: Polish** | Planned | JSON transformer, observability, encrypted tokens, OS service integration (`aethel service install` — systemd/launchd/Task Scheduler) |
 
 ## License
 

--- a/cmd/aethel/main.go
+++ b/cmd/aethel/main.go
@@ -6,7 +6,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"runtime/debug"
+	"strings"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -34,47 +36,75 @@ func main() {
 
 func handleDaemon() {
 	if len(os.Args) < 3 {
-		fmt.Fprintln(os.Stderr, "usage: aethel daemon [start|stop]")
+		fmt.Fprintln(os.Stderr, "usage: aethel daemon [start|stop|status]")
 		os.Exit(1)
 	}
 
 	switch os.Args[2] {
 	case "start":
-		startDaemon()
+		startDaemon(false)
 	case "stop":
 		stopDaemon()
+	case "status":
+		daemonStatus()
 	default:
 		fmt.Fprintf(os.Stderr, "unknown daemon command: %s\n", os.Args[2])
 		os.Exit(1)
 	}
 }
 
-func startDaemon() {
+func findDaemonBinary() string {
+	// 1. Check PATH first
+	if p, err := exec.LookPath("aetheld"); err == nil {
+		return p
+	}
+
+	// 2. Check alongside the running executable
+	if exe, err := os.Executable(); err == nil {
+		dir := filepath.Dir(exe)
+		candidate := filepath.Join(dir, "aetheld")
+		if runtime.GOOS == "windows" {
+			candidate += ".exe"
+		}
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+	}
+
+	// 3. Fallback — let OS try
+	return "aetheld"
+}
+
+func startDaemon(quiet bool) {
 	sockPath := config.SocketPath()
 
-	// Check if daemon is already running
+	// Probe existing socket — if daemon is dead, clean up stale
 	if client, err := ipc.NewClient(sockPath); err == nil {
 		client.Close()
-		fmt.Println("daemon already running")
+		if !quiet {
+			fmt.Println("daemon already running")
+		}
 		return
+	} else if _, statErr := os.Stat(sockPath); statErr == nil {
+		// Socket exists but daemon isn't responding → stale
+		os.Remove(sockPath)
 	}
 
-	// Find aetheld binary
-	aetheld, err := exec.LookPath("aetheld")
-	if err != nil {
-		aetheld = "aetheld"
-	}
-
-	cmd := exec.Command(aetheld)
+	aetheld := findDaemonBinary()
+	cmd := exec.Command(aetheld, "--background")
 	cmd.Stdout = nil
 	cmd.Stderr = nil
+	cmd.SysProcAttr = daemonSysProcAttr()
 	if err := cmd.Start(); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to start daemon: %v\n", err)
 		os.Exit(1)
 	}
 
+	pid := cmd.Process.Pid
 	cmd.Process.Release()
-	fmt.Printf("daemon started (pid %d)\n", cmd.Process.Pid)
+	if !quiet {
+		fmt.Printf("daemon started (pid %d)\n", pid)
+	}
 }
 
 func stopDaemon() {
@@ -86,9 +116,32 @@ func stopDaemon() {
 	}
 	defer client.Close()
 
-	msg, _ := ipc.NewMessage(ipc.MsgShutdown, nil)
-	client.Send(msg)
+	msg, err := ipc.NewMessage(ipc.MsgShutdown, nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create shutdown message: %v\n", err)
+		os.Exit(1)
+	}
+	if err := client.Send(msg); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to send shutdown: %v\n", err)
+		os.Exit(1)
+	}
 	fmt.Println("daemon stopped")
+}
+
+func daemonStatus() {
+	sockPath := config.SocketPath()
+	client, err := ipc.NewClient(sockPath)
+	if err != nil {
+		fmt.Println("daemon not running")
+		os.Exit(1)
+	}
+	client.Close()
+
+	if pidData, err := os.ReadFile(config.PidPath()); err == nil {
+		fmt.Printf("daemon running (pid %s)\n", strings.TrimSpace(string(pidData)))
+	} else {
+		fmt.Println("daemon running")
+	}
 }
 
 func launchTUI() {
@@ -124,12 +177,17 @@ func launchTUI() {
 	log.Printf("config loaded, AutoStart=%v", cfg.Daemon.AutoStart)
 
 	// Try connecting; auto-start if needed
+	const (
+		daemonStartRetries  = 20
+		daemonRetryInterval = 100 * time.Millisecond
+	)
+
 	client, err := ipc.NewClient(sockPath)
 	if err != nil && cfg.Daemon.AutoStart {
 		log.Printf("daemon not reachable, auto-starting...")
-		startDaemon()
-		for i := 0; i < 20; i++ {
-			time.Sleep(100 * time.Millisecond)
+		startDaemon(true) // quiet — no stdout during TUI launch
+		for i := 0; i < daemonStartRetries; i++ {
+			time.Sleep(daemonRetryInterval)
 			client, err = ipc.NewClient(sockPath)
 			if err == nil {
 				break

--- a/cmd/aethel/proc_unix.go
+++ b/cmd/aethel/proc_unix.go
@@ -1,0 +1,11 @@
+//go:build !windows
+
+package main
+
+import "syscall"
+
+func daemonSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{
+		Setsid: true,
+	}
+}

--- a/cmd/aethel/proc_windows.go
+++ b/cmd/aethel/proc_windows.go
@@ -1,0 +1,13 @@
+//go:build windows
+
+package main
+
+import "syscall"
+
+const _DETACHED_PROCESS = 0x00000008
+
+func daemonSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP | _DETACHED_PROCESS,
+	}
+}

--- a/cmd/aetheld/main.go
+++ b/cmd/aetheld/main.go
@@ -11,9 +11,21 @@ import (
 )
 
 func main() {
+	background := len(os.Args) > 1 && os.Args[1] == "--background"
+
 	logFile := initLogging()
 	if logFile != nil {
 		defer logFile.Close()
+	}
+
+	if background {
+		devNull, err := os.Open(os.DevNull)
+		if err != nil {
+			log.Printf("warning: could not open %s: %v", os.DevNull, err)
+		} else {
+			os.Stdout = devNull
+			os.Stderr = devNull
+		}
 	}
 
 	cfg := config.Default()
@@ -37,6 +49,10 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Write PID file after Start() ensures ~/.aethel/ exists
+	writePIDFile()
+	defer removePIDFile()
+
 	log.Printf("aetheld ready (pid %d)", os.Getpid())
 	fmt.Printf("aetheld ready (pid %d). Press Ctrl+C to stop.\n", os.Getpid())
 	d.Wait()
@@ -56,4 +72,20 @@ func initLogging() *os.File {
 	log.SetOutput(f)
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 	return f
+}
+
+func writePIDFile() {
+	dir := config.AethelDir()
+	if dir == "" {
+		log.Println("warning: cannot determine aethel dir, skipping PID file")
+		return
+	}
+	path := config.PidPath()
+	if err := os.WriteFile(path, []byte(fmt.Sprintf("%d", os.Getpid())), 0600); err != nil {
+		log.Printf("warning: failed to write PID file: %v", err)
+	}
+}
+
+func removePIDFile() {
+	os.Remove(config.PidPath())
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -130,3 +130,7 @@ func ConfigPath() string {
 func SocketPath() string {
 	return filepath.Join(AethelDir(), "aetheld.sock")
 }
+
+func PidPath() string {
+	return filepath.Join(AethelDir(), "aetheld.pid")
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -67,3 +67,29 @@ func TestAethelDir(t *testing.T) {
 		t.Error("expected non-empty aethel dir")
 	}
 }
+
+func TestPathHelpers(t *testing.T) {
+	dir := config.AethelDir()
+	if dir == "" {
+		t.Skip("cannot determine home directory")
+	}
+
+	tests := []struct {
+		name     string
+		fn       func() string
+		expected string
+	}{
+		{"SocketPath", config.SocketPath, filepath.Join(dir, "aetheld.sock")},
+		{"ConfigPath", config.ConfigPath, filepath.Join(dir, "config.toml")},
+		{"PidPath", config.PidPath, filepath.Join(dir, "aetheld.pid")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.fn()
+			if got != tt.expected {
+				t.Errorf("got %s, want %s", got, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -16,9 +16,10 @@ import (
 )
 
 type Daemon struct {
-	cfg     config.Config
-	server  *ipc.Server
-	session *SessionManager
+	cfg      config.Config
+	server   *ipc.Server
+	session  *SessionManager
+	shutdown chan struct{}
 }
 
 func New(cfg config.Config) *Daemon {
@@ -28,8 +29,9 @@ func New(cfg config.Config) *Daemon {
 		bufSize = 500 * 512 // 256KB default
 	}
 	return &Daemon{
-		cfg:     cfg,
-		session: NewSessionManager(bufSize),
+		cfg:      cfg,
+		session:  NewSessionManager(bufSize),
+		shutdown: make(chan struct{}),
 	}
 }
 
@@ -57,8 +59,12 @@ func (d *Daemon) Start() error {
 func (d *Daemon) Wait() {
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
-	<-sigCh
-	log.Println("shutting down...")
+	select {
+	case <-sigCh:
+		log.Println("shutting down (signal)...")
+	case <-d.shutdown:
+		log.Println("shutting down (IPC)...")
+	}
 	d.Stop()
 }
 
@@ -100,8 +106,7 @@ func (d *Daemon) handleMessage(conn *ipc.Conn, msg *ipc.Message) {
 	case ipc.MsgResizePane:
 		d.handleResizePane(msg)
 	case ipc.MsgShutdown:
-		d.Stop()
-		os.Exit(0)
+		close(d.shutdown)
 	}
 }
 


### PR DESCRIPTION
- Fix daemon dying when TUI exits (DETACHED_PROCESS on Windows, Setsid on Unix)
- Add findDaemonBinary() to locate aetheld alongside the running executable
- Add --background flag for silent daemon startup with PID file tracking
- Add stale socket detection and cleanup before spawning new daemon
- Add 'aethel daemon status' command
- Replace os.Exit(0) in MsgShutdown with channel signal so defers run cleanly
- Fix PID file permissions (0644 -> 0600) and error handling throughout