### PR TITLE
fix(config): add multi-instance support via AETHEL_HOME and --dev flag

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -67,6 +67,19 @@ Go module cache is persisted in a Docker volume (`aethel-gomod`) for fast repeat
 - Tab bar: tabs show 1-based index prefix (`1:Shell`, `2:Build`) matching Alt+1-9 shortcuts. Index hidden during rename editing
 - Auto-recovery: deleting the last tab auto-creates a new "Shell" tab; deleting the last pane in a tab auto-creates a fresh pane
 
+## Dev Mode
+
+Run a separate dev instance alongside production using `--dev` or `AETHEL_HOME`:
+
+```bash
+./aethel --dev              # Uses .aethel/ in project root (gitignored)
+./aethel-dev.sh             # Shortcut (Linux/macOS)
+./aethel-dev.ps1            # Shortcut (Windows PowerShell)
+AETHEL_HOME=/custom/path ./aethel  # Arbitrary data directory
+```
+
+`AETHEL_HOME` overrides `AethelDir()` — all derived paths (socket, PID, config, workspace, buffers, logs, shellinit) use the specified directory. The `[dev]` indicator appears in the status bar when active.
+
 ## Developer Utilities
 
 ```bash

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ Thumbs.db
 # Build
 /dist/
 /bin/
+
+# Dev instance data
+/.aethel/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Multi-instance support via `AETHEL_HOME` env var — run production and dev instances simultaneously
+- `--dev` CLI flag — uses `.aethel/` in project root for isolated dev data
+- Dev launcher scripts: `aethel-dev.sh` / `aethel-dev.ps1`
+- `[dev]` indicator in status bar when running in dev mode
+- `TestAethelDir_EnvOverride` test for env var override
+
+### Fixed
+
+- Daemon log file permission changed from `0644` to `0600` for consistency with other sensitive files
+- `resizeAllPanes()` nil guard — prevents panic when tab has no panes
+- `os.Executable()` error handling in `--dev` flag — exits with clear message instead of silent fallback
+
 ## [0.4.0] - 2026-03-14
 
 ### Added

--- a/aethel-dev.ps1
+++ b/aethel-dev.ps1
@@ -1,0 +1,2 @@
+# Launch Aethel in dev mode (uses .aethel/ in project root)
+& "$PSScriptRoot\aethel.exe" --dev @args

--- a/aethel-dev.sh
+++ b/aethel-dev.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Launch Aethel in dev mode (uses .aethel/ in project root)
+exec "$(dirname "$0")/aethel" --dev "$@"

--- a/cmd/aethel/main.go
+++ b/cmd/aethel/main.go
@@ -20,6 +20,23 @@ import (
 var version = "dev"
 
 func main() {
+	// Check for --dev flag before anything else.
+	// Sets AETHEL_HOME to .aethel/ next to the executable for isolated dev instances.
+	for i, arg := range os.Args[1:] {
+		if arg == "--dev" {
+			exe, err := os.Executable()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "--dev: cannot determine executable path: %v\n", err)
+				os.Exit(1)
+			}
+			devDir := filepath.Join(filepath.Dir(exe), ".aethel")
+			os.Setenv("AETHEL_HOME", devDir)
+			realIdx := i + 1 // i is relative to os.Args[1:]
+			os.Args = append(os.Args[:realIdx], os.Args[realIdx+1:]...)
+			break
+		}
+	}
+
 	if len(os.Args) > 1 {
 		switch os.Args[1] {
 		case "daemon":

--- a/cmd/aetheld/main.go
+++ b/cmd/aetheld/main.go
@@ -65,7 +65,7 @@ func initLogging() *os.File {
 	}
 	os.MkdirAll(logDir, 0700)
 	f, err := os.OpenFile(filepath.Join(logDir, "aetheld.log"),
-		os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+		os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
 	if err != nil {
 		return nil
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -118,6 +118,9 @@ func Load(path string) (Config, error) {
 }
 
 func AethelDir() string {
+	if dir := os.Getenv("AETHEL_HOME"); dir != "" {
+		return dir
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return ""

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -68,6 +68,13 @@ func TestAethelDir(t *testing.T) {
 	}
 }
 
+func TestAethelDir_EnvOverride(t *testing.T) {
+	t.Setenv("AETHEL_HOME", "/tmp/custom-aethel")
+	if got := config.AethelDir(); got != "/tmp/custom-aethel" {
+		t.Errorf("expected /tmp/custom-aethel, got %s", got)
+	}
+}
+
 func TestPathHelpers(t *testing.T) {
 	dir := config.AethelDir()
 	if dir == "" {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"os"
 	"strings"
 	"time"
 
@@ -101,6 +102,7 @@ type Model struct {
 	confirmKind     string                 // "pane" or "tab"
 	confirmID       string                 // ID of pane/tab to delete
 	confirmName     string                 // display name for confirmation
+	devMode         bool                   // true when AETHEL_HOME is set
 }
 
 func NewModel(client *ipc.Client, cfg config.Config, version string) Model {
@@ -108,6 +110,7 @@ func NewModel(client *ipc.Client, cfg config.Config, version string) Model {
 		client:  client,
 		cfg:     cfg,
 		version: version,
+		devMode: os.Getenv("AETHEL_HOME") != "",
 	}
 }
 
@@ -970,6 +973,9 @@ func (m Model) renderStatusBar() string {
 
 	// Right side: keybinding hints + version
 	right := "^T new | ^W pane | A-W tab | F1 help | ^Q quit | v" + m.version
+	if m.devMode {
+		right = "[dev] " + right
+	}
 
 	// Fit within width: left takes priority
 	gap := m.width - lipgloss.Width(left) - lipgloss.Width(right) - 2 // 2 for padding
@@ -1297,6 +1303,9 @@ func keyToBytes(keyMsg tea.KeyMsg) []byte {
 func (m Model) resizeAllPanes() tea.Cmd {
 	return func() tea.Msg {
 		for _, tab := range m.tabs {
+			if tab.Root == nil {
+				continue
+			}
 			for _, pane := range tab.Root.Leaves() {
 				cols := pane.Width - 2 // subtract border
 				rows := pane.Height - 2


### PR DESCRIPTION
- AETHEL_HOME env var overrides AethelDir() for all derived paths
- --dev flag sets AETHEL_HOME to .aethel/ next to the executable
- Dev launcher scripts: aethel-dev.sh/.ps1
- [dev] indicator in status bar when non-default home is active
- Daemon log file permission tightened from 0644 to 0600
- Nil guard in resizeAllPanes() prevents panic on empty tabs
- os.Executable() error handled in --dev flag