### PR TITLE
feat(plugin): add M4 pane plugin system with typed panes and session …

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -26,6 +26,7 @@ Client-daemon model:
 - `internal/persist/` — Atomic workspace/buffer persistence (JSON snapshots, binary ghost buffers)
 - `internal/pty/` — Cross-platform PTY (build tags: `linux || darwin || freebsd`, `windows`)
 - `internal/shellinit/` — Automatic OSC 7 shell integration (embedded init scripts, `//go:embed`)
+- `internal/plugin/` — Pane plugin system (registry, built-ins, TOML loading, scraper)
 - `internal/tui/` — Bubble Tea model, tabs, panes, layout tree, styles
 
 ## Building
@@ -59,13 +60,17 @@ Go module cache is persisted in a Docker volume (`aethel-gomod`) for fast repeat
 - Daemon auto-start: TUI auto-starts `aetheld --background` if not running. `findDaemonBinary()` checks PATH then the executable's own directory. PID file at `~/.aethel/aetheld.pid`, stale socket cleanup before spawn
 - Daemon shutdown: `MsgShutdown` signals via channel (not `os.Exit`) so defers in `main()` run cleanly (PID file removal, log file close)
 - Persistence: `internal/persist/` handles atomic file I/O — `snapshot.go` for workspace JSON (write `.tmp` → rotate to `.bak` → rename), `ghostbuf.go` for per-pane binary buffers. Both use temp+rename for crash safety
-- Workspace restore: On daemon start, `restoreWorkspace()` loads `~/.aethel/workspace.json`, reconstructs tabs/panes, loads ghost buffers from `~/.aethel/buffers/`, then `respawnShells()` spawns new shell processes with saved CWD
+- Workspace restore: On daemon start, `restoreWorkspace()` loads `~/.aethel/workspace.json`, reconstructs tabs/panes, loads ghost buffers from `~/.aethel/buffers/`, then `respawnPanes()` spawns processes per plugin type with saved CWD and resume strategy
 - Snapshot triggers: periodic timer (configurable `snapshot_interval`, default 30s) + immediate on structural changes (create/destroy tab/pane) with 1s debounce + final flush on daemon stop
-- Dialog system: `internal/tui/dialog.go` — modal dialogs with `dialogScreen` iota (`dialogAbout`, `dialogSettings`, `dialogShortcuts`, `dialogConfirm`). F1 opens About dialog. Settings editor mutates `m.cfg` in-memory (session-only). Confirm dialog used for pane/tab close (Ctrl+W / Alt+W)
+- Dialog system: `internal/tui/dialog.go` — modal dialogs with `dialogScreen` iota (`dialogAbout`, `dialogSettings`, `dialogShortcuts`, `dialogConfirm`, `dialogCreatePane`, `dialogPluginError`). F1 opens About dialog. Ctrl+N opens typed pane creation dialog (two-step: category → plugin). Settings editor mutates `m.cfg` in-memory (session-only). Confirm dialog used for pane/tab close (Ctrl+W / Alt+W)
 - Output coalescing: `streamPTYOutput()` uses goroutine + 2ms timer to batch rapid PTY output before IPC broadcast, preventing visual tearing with interactive TUI tools
 - Ghost buffer dimming: `PaneOutputPayload.Ghost` flag distinguishes replay from live output. Panes show muted border + "restored" label until first live output clears the flag. Controlled by `GhostBufferConfig.Dimmed` (default true)
 - Tab bar: tabs show 1-based index prefix (`1:Shell`, `2:Build`) matching Alt+1-9 shortcuts. Index hidden during rename editing
 - Auto-recovery: deleting the last tab auto-creates a new "Shell" tab; deleting the last pane in a tab auto-creates a fresh pane
+- Plugin system: `internal/plugin/` — pane types defined via `PanePlugin` struct. 4 built-in plugins (terminal, claude-code, stripe, ssh) in `builtin.go`. User TOML plugins in `~/.aethel/plugins/` override built-ins. `Registry` manages loading, detection (`DetectCmd`), and lookup. Session scraper in `flushPaneOutput` extracts values from PTY output via regex. Error handlers match output patterns and send `MsgPluginError` to show help dialogs
+- Pane type fields: `Pane.Type` (plugin name, default "terminal"), `Pane.PluginState` (scraped key-values), `Pane.InstanceName`, `Pane.InstanceArgs`. All persisted in workspace JSON, backward compatible (missing `type` → "terminal")
+- Resume strategies: `cwd_only` (terminal), `rerun` (stripe, ssh), `preassign_id` (claude-code), `session_scrape`, `none`. Dispatched in `spawnPane()` with `restoring` flag
+- Window size persistence: `~/.aethel/window.json` stores cols, rows, pixel dimensions, and maximized state. Saved on TUI exit, restored on launch via platform-specific code (`cmd/aethel/window_windows.go` uses Win32 `MoveWindow`/`ShowWindow`, `cmd/aethel/window_unix.go` uses xterm resize sequence). Follows the same build-tag file-split pattern as `proc_unix.go`/`proc_windows.go`
 
 ## Dev Mode
 
@@ -101,6 +106,9 @@ AETHEL_HOME=/custom/path ./aethel  # Arbitrary data directory
 
 - **M1 (Done):** Foundation — daemon, TUI, IPC, PTY, tabs, splits, shell integration, mouse, scrollback, daemon lifecycle
 - **M2 (Done):** Persistence — workspace snapshots, ghost buffer persistence, shell respawn, reboot-proof sessions
-- **M3:** Resume engine — regex scrapers, AI session resume
-- **M4:** Plugin system — TOML plugins, typed panes
+- **M3 (Done):** Resume engine — preassign_id strategy for Claude Code, session_scrape for tools with output tokens, rerun for SSH/Stripe
+- **M4 (Done):** Plugin system — typed panes, TOML plugins, plugin registry, error handlers, pane creation dialog (Ctrl+N), 4 built-in plugins: terminal + claude-code (production), ssh + stripe (POC)
 - **M5:** Polish — JSON transformer, observability, encrypted tokens
+- **M6:** Pane Focus — full-window focus mode for single pane
+- **M7:** Pane Notes — side-by-side note-taking linked to panes
+- **M8:** Bubble Tea v2 migration

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -263,16 +263,15 @@ Each init script sources the user's original shell config first, then appends th
 │   └── zsh/
 │       ├── .zshenv
 │       └── .zshrc
-├── state/
-│   ├── workspace.json
-│   └── workspace.json.bak
-├── data/
-│   └── aethel.db           # SQLite (planned)
-├── plugins/                 # (planned)
-│   ├── ai.toml
-│   ├── build.toml
-│   ├── infrastructure.toml
-│   └── webhook.toml
-└── secrets/                 # (planned)
+├── workspace.json              # Tab/pane/layout state
+├── workspace.json.bak          # Previous snapshot (rollback)
+├── buffers/                    # Ghost buffer binary files
+│   └── pane-XXXXXXXX.bin
+├── window.json                 # Window size/position persistence
+├── plugins/                    # User TOML plugin definitions
+│   └── *.toml
+├── notes/                      # Pane notes (planned)
+│   └── pane-XXXXXXXX.txt
+└── secrets/                    # (planned)
     └── tokens.enc
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Plugin system** — typed panes with 4 built-in plugins: Terminal, Claude Code (AI), Stripe (webhook), SSH (remote)
+- `internal/plugin/` package — plugin structs, registry, TOML loading, regex scraper, error handler matching
+- TOML plugin format — user-created plugins in `~/.aethel/plugins/*.toml` with command, persistence, error handlers, and instances
+- Plugin registry with `DetectAvailability()` — checks PATH for plugin binaries at startup
+- Pane creation dialog (`Ctrl+N`) — three-step flow: category → plugin → split direction (horizontal, vertical, replace)
+- Atomic pane replacement via `ReplacePane()` — swap pane type in-place without layout disruption
+- **Session resume for Claude Code** — pre-assigned UUID via `--session-id`, resumed with `--resume` after daemon restart
+- `preassign_id` persistence strategy — generate UUID at pane creation, store in `PluginState`, resume on restore
+- `session_scrape` persistence strategy — regex scraper extracts tokens from PTY output for resume
+- `rerun` persistence strategy — re-execute same command + args on restore (SSH, Stripe)
+- Error handler system — match PTY output against regex patterns, show help dialogs (e.g., SSH auth failure, missing API key)
+- `MsgPluginError` IPC message — daemon-to-TUI error notification with modal dialog display
+- Resuming/preparing spinner — animated braille indicator (`⠹ resuming...` / `⠹ preparing...`) on pane border during startup
+- Window size persistence — save/restore terminal dimensions via `~/.aethel/window.json`
+- Platform-specific window restore — Win32 `MoveWindow`/`ShowWindow` on Windows, xterm sequence on Unix
+- Maximized window state detection and restoration via `IsZoomed`/`SW_MAXIMIZE`
+- `PluginsDir()` and `WindowStatePath()` config path helpers
+- Plugin state fields on `Pane` struct — `Type`, `PluginState`, `InstanceName`, `InstanceArgs`
+- Workspace JSON backward compatibility — missing `type` defaults to `"terminal"`
+
+### Changed
+
+- `spawnShell()` replaced with generalized `spawnPane()` — dispatches by plugin type and resume strategy
+- `respawnShells()` replaced with `respawnPanes()` — fallback to terminal shell on plugin spawn failure
+- Ghost buffer replay skipped for TUI app panes (`preassign_id`, `session_scrape`) — prevents cursor state pollution
+- Aethel cursor overlay disabled for non-terminal panes — TUI apps render their own cursor
+- `CreatePanePayload` extended with `Type`, `InstanceName`, `InstanceArgs`, `ReplacePaneID`
+- `NewModel()` accepts plugin registry parameter
+- Status bar updated with `^N pane` hint
+
+### Fixed
+
+- Regex compilation uses `regexp.Compile` (not `MustCompile`) — invalid TOML patterns log errors instead of crashing daemon
+- Nil guard in `ScrapeOutput`/`MatchError` for uncompiled patterns
+- Data race on `Pane.PluginState` — protected with `PluginMu` mutex
+- `hitTestTab` missing tab index prefix — click targets now match rendered tab widths
+- Scraped values truncated in log output — prevents leaking tokens/secrets
+- Error handler patterns anchored — `Permission denied (publickey` and `error.*API key` avoid false matches
+- `loadPluginTOML` validates strategy, cmd, and error handler action fields
+- `loadPluginTOML` defaults `DisplayName` to `Name` and `Category` to `"tools"` when empty
+- Layout `resizeNode` nil guard for placeholder nodes during pane replacement
+- `ExpandResumeArgs` returns nil when placeholders are unresolved — prevents passing literal `{session_id}` to tools
+- `window_windows.go` bounds-checks pixel dimensions and `GetWindowRect` return value
+- `saveWindowSize` logs `WriteFile` errors
+
 ## [0.4.1] - 2026-03-14
 
 ### Added

--- a/PRD.md
+++ b/PRD.md
@@ -583,7 +583,7 @@ All three platforms supported from day one. Go's cross-compilation makes this fe
 
 ## 7. Milestones
 
-### M1: Foundation — Daemon + Shell + TUI
+### M1: Foundation — Daemon + Shell + TUI (Done)
 
 > **Goal:** `aethel` launches a daemon, opens a Bubble Tea TUI with one tab and one pane running a shell. Basic split support.
 
@@ -600,7 +600,7 @@ All three platforms supported from day one. Go's cross-compilation makes this fe
 
 **Exit criteria:** User can launch `aethel`, create tabs, split panes, and run shell commands on all three platforms.
 
-### M2: Persistence — Reboot-Proof Sessions
+### M2: Persistence — Reboot-Proof Sessions (Done)
 
 > **Goal:** Close `aethel`, reboot, run `aethel` again — tabs, panes, and layout are restored. Ghost buffers show previous output instantly.
 
@@ -609,44 +609,47 @@ All three platforms supported from day one. Go's cross-compilation makes this fe
 - State snapshotting (JSON) on interval + structural changes
 - Atomic writes with `.bak` rollback
 - Workspace re-hydration on startup
-- Ghost buffer system (SQLite-backed)
+- Ghost buffer system (file-backed binary snapshots)
 - Visual distinction for ghost buffer content (dimmed)
 - `aetheld` auto-start on first client invocation
 - Daemon graceful shutdown with state persist
 
 **Exit criteria:** Full reboot cycle — close everything, restart OS, run `aethel` — workspace layout and ghost buffer content are restored within 30 seconds.
 
-### M3: Resume Engine — AI Sessions Survive Reboots
+### M3: Resume Engine — AI Sessions Survive Reboots (Done)
 
 > **Goal:** Claude Code session IDs are automatically scraped and sessions resume on re-hydration.
 
 **Deliverables:**
 
 - Regex scraper framework watching PTY output
-- Token extraction and storage (SQLite)
+- Token extraction and storage (workspace JSON `plugin_state`)
 - Resume command template execution on re-hydration
-- Built-in `ai` plugin with Claude Code patterns
-- Fallback to plain shell when no tokens captured
+- `preassign_id` strategy for Claude Code (UUID pre-assigned via `--session-id`)
+- `session_scrape` strategy for tools that emit session IDs in output
+- `rerun` strategy for SSH/Stripe (re-execute same command)
+- Fallback to plain shell when resume args can't be resolved
 
 **Exit criteria:** Start a Claude Code session, reboot, run `aethel` — Claude session resumes automatically with the previous conversation context.
 
-### M4: Plugin System + Typed Panes
+### M4: Plugin System + Typed Panes (Done)
 
 > **Goal:** Users can define custom pane types. Ship with 4 built-in plugins.
 
 **Deliverables:**
 
 - Plugin loader from `~/.aethel/plugins/*.toml`
-- Plugin validation with clear error messages
-- Plugin hot-reload
-- Built-in plugins: `ai`, `webhook`, `infrastructure`, `build`
-- Border color rules based on output patterns
-- Status line rendering per pane type
-- Quick actions menu per pane type
-- Pane auto-naming from process / plugin config
-- `aethel plugin list/validate` commands
+- Plugin validation with clear error messages (strategy, cmd, action, regex)
+- Plugin registry with auto-detection (`exec.LookPath`)
+- Built-in plugins: Terminal (production), Claude Code (production), SSH (POC), Stripe (POC)
+- Error handler pattern matching on PTY output with help dialogs
+- Pane creation dialog (`Ctrl+N`) — category, plugin, split direction
+- Atomic pane replacement (`ReplacePane`)
+- `preassign_id` persistence strategy for UUID-based resume
+- Resuming/preparing spinner indicator on pane border
+- Window size persistence across restarts (Win32 API / xterm)
 
-**Exit criteria:** User creates a custom plugin TOML, assigns it to a pane, and sees custom border colors, status line, and quick actions — all without restarting the daemon.
+**Exit criteria:** User creates a custom plugin TOML, assigns it to a pane, and the plugin launches with correct persistence strategy. Claude Code sessions resume after hard restart.
 
 ### M5: Polish — Advanced UI + Developer Experience
 

--- a/README.md
+++ b/README.md
@@ -49,20 +49,22 @@ Full mouse support — click tabs to switch, click panes to focus, scroll wheel 
 
 Rename tabs (F2) and panes (Alt+F2). Cycle through 8 tab colors (Alt+C) for visual distinction. Clipboard paste (Ctrl+V) with cross-platform support.
 
-### AI Session Resume (Planned)
+### AI Session Resume
 
-A regex-based scraper watches terminal output for session IDs. When you restart, Aethel executes `claude --resume <session-id>` automatically — no manual copy-paste.
+Claude Code sessions resume automatically after reboot. Aethel assigns a UUID to each AI pane at creation and uses `claude --resume <session-id>` on restart — no manual copy-paste. Other tools can use regex scraping or command re-run strategies.
 
-### Typed Panes via Plugins (Planned)
+### Typed Panes via Plugins
 
-Panes aren't just shells. Each pane type is a TOML plugin that defines:
+Panes aren't just shells. Press `Ctrl+N` to create a typed pane from 4 built-in plugins:
 
-- **Scraper patterns** — extract tokens from terminal output
-- **Resume templates** — auto-restart tools with captured context
-- **Border color rules** — red on errors, green on success
-- **Quick actions** — one-key shortcuts per pane type
+| Plugin | Description | Resume Strategy |
+|--------|-------------|-----------------|
+| **Terminal** | System shell | Restore working directory |
+| **Claude Code** | AI coding assistant | UUID-based session resume |
+| **SSH** | Remote connection (POC) | Re-run same command |
+| **Stripe** | Webhook listener (POC) | Re-run same command |
 
-Ships with 4 built-in plugins: `ai`, `webhook`, `infrastructure`, `build`. Create your own without recompiling.
+Create your own plugins as TOML files in `~/.aethel/plugins/` without recompiling. Plugins define commands, error handlers, persistence strategies, and pre-configured instances.
 
 ### Cross-Platform
 
@@ -79,7 +81,7 @@ aethel (TUI Client)
             ▼
 aetheld (Daemon)
     ├── PTY session management
-    ├── State persistence (JSON + SQLite)
+    ├── State persistence (JSON snapshots)
     ├── Resume engine (regex scrapers)
     └── Plugin registry (TOML definitions)
 ```
@@ -118,7 +120,9 @@ aethel
 | Key | Action |
 |---|---|
 | `Ctrl+T` | New tab |
+| `Ctrl+N` | New typed pane (plugin dialog) |
 | `Ctrl+W` | Close active pane |
+| `Alt+W` | Close active tab |
 | `Alt+H` | Split horizontal |
 | `Alt+V` | Split vertical |
 | `Tab` / `Shift+Tab` | Navigate panes |
@@ -178,6 +182,7 @@ internal/
 ├── daemon/          # Session management, message routing
 ├── ipc/             # Length-prefixed JSON protocol, client/server
 ├── persist/         # Atomic workspace/buffer persistence (JSON + binary)
+├── plugin/          # Pane plugin system (registry, TOML loading, scraper)
 ├── pty/             # Cross-platform PTY (Unix + Windows)
 ├── ringbuf/         # Circular byte buffer for PTY output history
 ├── shellinit/       # Automatic shell integration (OSC 7 injection)
@@ -204,10 +209,15 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for development guidelines.
 | Milestone | Status | Description |
 |---|---|---|
 | **M1: Foundation** | Done | Daemon, TUI, IPC, PTY, tabs, splits, shell integration, mouse, scrollback, daemon lifecycle |
-| **M2: Persistence** | In Progress | Workspace snapshots, ghost buffer persistence, shell respawn, reboot-proof sessions |
-| **M3: Resume Engine** | Planned | Regex scrapers, token extraction, AI session resume |
-| **M4: Plugin System** | Planned | TOML plugins, typed panes, hot-reload |
-| **M5: Polish** | Planned | JSON transformer, observability, encrypted tokens, OS service integration (`aethel service install` — systemd/launchd/Task Scheduler) |
+| **M2: Persistence** | Done | Workspace snapshots, ghost buffer persistence, shell respawn, reboot-proof sessions |
+| **M3: Resume Engine** | Done | Regex scrapers, token extraction, AI session resume via pre-assigned UUIDs |
+| **M4: Plugin System** | Done | TOML plugins, typed panes, pane creation dialog, error handlers, window size persistence |
+| **M5: Polish** | Planned | JSON transformer, observability, encrypted tokens, OS service integration |
+| **M6: Pane Focus** | Planned | Full-window focus mode for single pane |
+| **M7: Pane Notes** | Planned | Side-by-side note-taking linked to panes |
+| **M8: Bubble Tea v2** | Planned | Migration to Bubble Tea v2 for improved key handling |
+
+See [ROADMAP.md](ROADMAP.md) for detailed progress and feature descriptions.
 
 ## License
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,100 @@
+# Aethel Roadmap
+
+Detailed progress tracker and future plans for Aethel.
+
+## Completed
+
+### M1: Foundation
+> Daemon, TUI, IPC, PTY, tabs, splits, shell integration, mouse, scrollback, daemon lifecycle.
+
+All core infrastructure is in place. The client-daemon architecture works across Linux, macOS, and Windows. Shell integration auto-injects OSC 7 hooks for CWD tracking. Binary split tree enables arbitrarily nested pane layouts.
+
+### M2: Persistence
+> Workspace snapshots, ghost buffer persistence, shell respawn, reboot-proof sessions.
+
+Workspace state (tabs, panes, layout, CWD) persists to `~/.aethel/workspace.json` with atomic writes and `.bak` rollback. Ghost buffers capture PTY output to binary files. On daemon restart, shells respawn with saved CWD and ghost buffers replay instantly.
+
+### M3: Resume Engine
+> Regex scrapers, token extraction, AI session resume.
+
+Session resume infrastructure is complete. The `preassign_id` strategy generates a UUID at pane creation, passes it via `--session-id`, and resumes with `--resume` after daemon restart. The `session_scrape` strategy extracts tokens from PTY output via regex for tools that don't support pre-assigned IDs. The `rerun` strategy re-executes the same command + args. Fallback to shell when resume args can't be resolved.
+
+### M4: Plugin System
+> Typed panes with TOML plugins, plugin registry, pane creation dialog.
+
+The plugin system is fully operational. 4 built-in plugins ship with Aethel:
+
+| Plugin | Status | Persistence |
+|--------|--------|-------------|
+| **Terminal** | Production | `cwd_only` — restore working directory |
+| **Claude Code** | Production | `preassign_id` — UUID-based session resume |
+| **SSH** | POC | `rerun` — reconnect with same args |
+| **Stripe** | POC | `rerun` — re-listen with same webhook URL |
+
+Key capabilities:
+- **TOML plugin format** — user-created plugins in `~/.aethel/plugins/*.toml`
+- **Plugin registry** with auto-detection (`exec.LookPath`)
+- **Pane creation dialog** (`Ctrl+N`) — three-step: category, plugin, split direction
+- **Error handlers** — regex patterns match PTY output and show help dialogs
+- **Atomic pane replacement** — swap pane type in-place
+- **Resuming/preparing spinner** — animated border indicator during pane startup
+- **Window size persistence** — save/restore terminal dimensions across restarts
+
+---
+
+## In Progress
+
+### M5: Polish
+> Production-quality UX. JSON transformer, observability, encrypted tokens.
+
+**Planned deliverables:**
+- JSON transformer (`Ctrl+J`) — format and highlight JSON in terminal output
+- Observability commands — `aethel status`, session metrics, log level control
+- Encrypted token storage — OS keyring integration for sensitive scraped values
+- Tab dock positions (top/bottom/left/right)
+- OS service integration (`aethel service install` — systemd/launchd/Task Scheduler)
+
+---
+
+## Planned
+
+### M6: Pane Focus Mode
+
+Switch the active pane to full-window mode, hiding all other panes. Gives the user maximum screen space for focused work in a single pane.
+
+**Behavior:**
+- Keybinding (e.g., `Alt+F` or `F11`) toggles focus mode on/off
+- In focus mode: active pane fills the entire tab content area (no splits visible)
+- Other panes remain alive in the background — they continue running, receiving PTY output
+- Status bar shows a focus indicator (e.g., `[focus]`)
+- Exiting focus mode restores the previous split layout exactly
+- Focus state is NOT persisted — exiting Aethel always returns to normal layout
+
+### M7: Pane Notes
+
+Side-by-side note-taking mode linked to individual panes. When enabled, the window splits into the active pane (left) and a text editor (right) where the user can write notes about their work.
+
+**Behavior:**
+- Keybinding (e.g., `Alt+N`) toggles notes mode on/off for the active pane
+- In notes mode: all other panes are hidden; the screen shows active pane (left) + text editor (right)
+- Notes are stored as plain text files in `~/.aethel/notes/<pane-id>.txt`
+- Notes are linked to the pane — after hard restart, opening notes for the same pane shows previous notes
+- The text editor supports basic editing: type, backspace, enter, arrow keys, scroll
+- Notes persist independently from workspace state — they survive pane destruction and can be browsed later
+- Exiting notes mode restores the previous layout
+
+### M8: Bubble Tea v2 Migration
+
+Migrate from Bubble Tea v1 to v2 when it becomes stable.
+
+**Motivation:**
+- v2 has improved key handling (shift/ctrl modifiers distinguishable)
+- Better performance and rendering
+- Built-in spinner and other components
+- Breaking API changes — requires updating all TUI code
+
+**Approach:**
+- Wait for v2 stable release
+- Update import paths and adapt to new API
+- Leverage new key modifier support to enable `Ctrl+Shift+W` and similar bindings
+- Replace custom spinner with built-in component

--- a/cmd/aethel/main.go
+++ b/cmd/aethel/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -14,6 +15,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/artyomsv/aethel/internal/config"
 	"github.com/artyomsv/aethel/internal/ipc"
+	"github.com/artyomsv/aethel/internal/plugin"
 	"github.com/artyomsv/aethel/internal/tui"
 )
 
@@ -219,12 +221,29 @@ func launchTUI() {
 	defer client.Close()
 	log.Print("connected to daemon")
 
-	model := tui.NewModel(client, cfg, version)
+	// Initialize plugin registry for the TUI (detection runs in the TUI process
+	// so the dialog knows which plugins are available)
+	reg := plugin.NewRegistry()
+	if err := reg.LoadFromDir(config.PluginsDir()); err != nil {
+		log.Printf("warning: load plugins: %v", err)
+	}
+	reg.DetectAvailability()
+
+	// Restore window size from previous session
+	restoreWindowSize()
+
+	model := tui.NewModel(client, cfg, version, reg)
 	p := tea.NewProgram(model, tea.WithAltScreen(), tea.WithMouseCellMotion())
-	if _, err := p.Run(); err != nil {
+	finalModel, err := p.Run()
+	if err != nil {
 		log.Printf("TUI error: %v", err)
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
+	}
+
+	// Save window size for next launch
+	if m, ok := finalModel.(tui.Model); ok {
+		saveWindowSize(m)
 	}
 	log.Print("TUI exited normally")
 }
@@ -232,4 +251,55 @@ func launchTUI() {
 func fileExists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
+}
+
+// windowState is persisted to ~/.aethel/window.json.
+type windowState struct {
+	Cols        int  `json:"cols"`
+	Rows        int  `json:"rows"`
+	PixelWidth  int  `json:"pixel_width,omitempty"`
+	PixelHeight int  `json:"pixel_height,omitempty"`
+	Maximized   bool `json:"maximized,omitempty"`
+}
+
+func loadWindowState() *windowState {
+	data, err := os.ReadFile(config.WindowStatePath())
+	if err != nil {
+		return nil
+	}
+	var ws windowState
+	if err := json.Unmarshal(data, &ws); err != nil {
+		return nil
+	}
+	if ws.Cols <= 0 || ws.Rows <= 0 {
+		return nil
+	}
+	return &ws
+}
+
+func restoreWindowSize() {
+	ws := loadWindowState()
+	if ws == nil {
+		return
+	}
+	restoreWindowSizePlatform(ws)
+}
+
+func saveWindowSize(m tui.Model) {
+	cols, rows := m.WindowSize()
+	if cols <= 0 || rows <= 0 {
+		return
+	}
+	ws := windowState{Cols: cols, Rows: rows}
+	// Get pixel dimensions for Windows MoveWindow
+	saveWindowSizePlatform(&ws)
+	data, err := json.Marshal(ws)
+	if err != nil {
+		return
+	}
+	if err := os.WriteFile(config.WindowStatePath(), data, 0600); err != nil {
+		log.Printf("save window state: %v", err)
+		return
+	}
+	log.Printf("saved window size: %dx%d (pixels: %dx%d)", ws.Cols, ws.Rows, ws.PixelWidth, ws.PixelHeight)
 }

--- a/cmd/aethel/window_unix.go
+++ b/cmd/aethel/window_unix.go
@@ -1,0 +1,20 @@
+//go:build !windows
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+)
+
+func restoreWindowSizePlatform(ws *windowState) {
+	// Xterm resize sequence: ESC[8;rows;colst
+	// Supported by iTerm2, GNOME Terminal, most modern Unix terminals.
+	fmt.Fprintf(os.Stdout, "\x1b[8;%d;%dt", ws.Rows, ws.Cols)
+	log.Printf("restored window size: %dx%d (xterm sequence)", ws.Cols, ws.Rows)
+}
+
+func saveWindowSizePlatform(ws *windowState) {
+	// No pixel dimensions needed on Unix — xterm sequence uses cols/rows.
+}

--- a/cmd/aethel/window_windows.go
+++ b/cmd/aethel/window_windows.go
@@ -1,0 +1,82 @@
+//go:build windows
+
+package main
+
+import (
+	"log"
+	"syscall"
+	"unsafe"
+)
+
+var (
+	kernel32         = syscall.NewLazyDLL("kernel32.dll")
+	user32           = syscall.NewLazyDLL("user32.dll")
+	getConsoleWindow = kernel32.NewProc("GetConsoleWindow")
+	getWindowRect    = user32.NewProc("GetWindowRect")
+	moveWindow       = user32.NewProc("MoveWindow")
+	showWindow       = user32.NewProc("ShowWindow")
+	isZoomed         = user32.NewProc("IsZoomed")
+)
+
+const swMaximize = 3 // SW_MAXIMIZE
+
+type rect struct {
+	Left, Top, Right, Bottom int32
+}
+
+func restoreWindowSizePlatform(ws *windowState) {
+	hwnd, _, _ := getConsoleWindow.Call()
+	if hwnd == 0 {
+		return
+	}
+
+	if ws.Maximized {
+		showWindow.Call(hwnd, swMaximize)
+		log.Printf("restored window: maximized")
+		return
+	}
+
+	if ws.PixelWidth <= 0 || ws.PixelHeight <= 0 ||
+		ws.PixelWidth > 32767 || ws.PixelHeight > 32767 {
+		return
+	}
+
+	// Get current position to preserve X/Y
+	var r rect
+	ret, _, _ := getWindowRect.Call(hwnd, uintptr(unsafe.Pointer(&r)))
+	if ret == 0 {
+		return // GetWindowRect failed
+	}
+
+	ret, _, err := moveWindow.Call(
+		hwnd,
+		uintptr(int64(r.Left)),
+		uintptr(int64(r.Top)),
+		uintptr(ws.PixelWidth),
+		uintptr(ws.PixelHeight),
+		1, // repaint
+	)
+	if ret == 0 {
+		log.Printf("MoveWindow failed: %v", err)
+	} else {
+		log.Printf("restored window size: %dx%d pixels", ws.PixelWidth, ws.PixelHeight)
+	}
+}
+
+func saveWindowSizePlatform(ws *windowState) {
+	hwnd, _, _ := getConsoleWindow.Call()
+	if hwnd == 0 {
+		return
+	}
+
+	// Check if maximized
+	ret, _, _ := isZoomed.Call(hwnd)
+	ws.Maximized = ret != 0
+
+	var r rect
+	ret, _, _ = getWindowRect.Call(hwnd, uintptr(unsafe.Pointer(&r)))
+	if ret != 0 {
+		ws.PixelWidth = int(r.Right - r.Left)
+		ws.PixelHeight = int(r.Bottom - r.Top)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -147,3 +147,11 @@ func WorkspacePath() string {
 func BufferDir() string {
 	return filepath.Join(AethelDir(), "buffers")
 }
+
+func PluginsDir() string {
+	return filepath.Join(AethelDir(), "plugins")
+}
+
+func WindowStatePath() string {
+	return filepath.Join(AethelDir(), "window.json")
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -7,14 +7,15 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
-	"runtime"
 	"sync"
 	"syscall"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/artyomsv/aethel/internal/config"
 	"github.com/artyomsv/aethel/internal/ipc"
 	"github.com/artyomsv/aethel/internal/persist"
+	"github.com/artyomsv/aethel/internal/plugin"
 	apty "github.com/artyomsv/aethel/internal/pty"
 	"github.com/artyomsv/aethel/internal/ringbuf"
 	"github.com/artyomsv/aethel/internal/shellinit"
@@ -24,6 +25,7 @@ type Daemon struct {
 	cfg      config.Config
 	server   *ipc.Server
 	session  *SessionManager
+	registry *plugin.Registry
 	shutdown chan struct{}
 	restored bool // true if workspace was loaded from disk
 
@@ -37,9 +39,13 @@ func New(cfg config.Config) *Daemon {
 	if bufSize <= 0 {
 		bufSize = 500 * 512 // 256KB default
 	}
+
+	reg := plugin.NewRegistry()
+
 	return &Daemon{
 		cfg:      cfg,
 		session:  NewSessionManager(bufSize),
+		registry: reg,
 		shutdown: make(chan struct{}),
 	}
 }
@@ -54,6 +60,12 @@ func (d *Daemon) Start() error {
 		log.Printf("warning: failed to write shell init scripts: %v", err)
 	}
 
+	// Load user plugins and detect availability
+	if err := d.registry.LoadFromDir(config.PluginsDir()); err != nil {
+		log.Printf("warning: failed to load plugins: %v", err)
+	}
+	d.registry.DetectAvailability()
+
 	// Restore workspace from disk if available
 	if err := d.restoreWorkspace(); err != nil {
 		log.Printf("warning: failed to restore workspace: %v", err)
@@ -66,9 +78,9 @@ func (d *Daemon) Start() error {
 		return fmt.Errorf("start IPC server: %w", err)
 	}
 
-	// Respawn shells for restored panes
+	// Respawn panes for restored workspace
 	if d.restored {
-		d.respawnShells()
+		d.respawnPanes()
 	}
 
 	log.Printf("aetheld started, listening on %s", sockPath)
@@ -252,13 +264,43 @@ func (d *Daemon) restoreWorkspace() error {
 				}
 				cwd, _ := paneData["cwd"].(string)
 				name, _ := paneData["name"].(string)
+				paneType, _ := paneData["type"].(string)
+				if paneType == "" {
+					paneType = "terminal" // backward compatible
+				}
+				instanceName, _ := paneData["instance_name"].(string)
+
+				// Restore plugin state
+				var pluginState map[string]string
+				if ps, ok := paneData["plugin_state"].(map[string]any); ok {
+					pluginState = make(map[string]string, len(ps))
+					for k, v := range ps {
+						if s, ok := v.(string); ok {
+							pluginState[k] = s
+						}
+					}
+				}
+
+				// Restore instance args
+				var instanceArgs []string
+				if ia, ok := paneData["instance_args"].([]any); ok {
+					for _, a := range ia {
+						if s, ok := a.(string); ok {
+							instanceArgs = append(instanceArgs, s)
+						}
+					}
+				}
 
 				pane := &Pane{
-					ID:        paneID,
-					TabID:     tabID,
-					CWD:       cwd,
-					Name:      name,
-					OutputBuf: ringbuf.NewRingBuffer(d.session.bufSize),
+					ID:           paneID,
+					TabID:        tabID,
+					CWD:          cwd,
+					Name:         name,
+					Type:         paneType,
+					PluginState:  pluginState,
+					InstanceName: instanceName,
+					InstanceArgs: instanceArgs,
+					OutputBuf:    ringbuf.NewRingBuffer(d.session.bufSize),
 				}
 
 				// Load ghost buffer from disk
@@ -303,8 +345,9 @@ func isValidHexID(id, prefix string) bool {
 	return true
 }
 
-// respawnShells starts a shell process in each pane that was restored from disk.
-func (d *Daemon) respawnShells() {
+// respawnPanes starts a process in each pane that was restored from disk,
+// dispatching to the appropriate resume strategy based on plugin type.
+func (d *Daemon) respawnPanes() {
 	for _, tab := range d.session.Tabs() {
 		for _, pane := range d.session.Panes(tab.ID) {
 			if pane.PTY != nil {
@@ -321,10 +364,18 @@ func (d *Daemon) respawnShells() {
 				}
 			}
 
-			if err := d.spawnShell(pane, ptySession); err != nil {
-				log.Printf("respawn shell for pane %s: %v", pane.ID, err)
+			if err := d.spawnPane(pane, ptySession, true); err != nil {
+				log.Printf("respawn pane %s (type=%s): %v — falling back to terminal", pane.ID, pane.Type, err)
+				pane.Type = "terminal"
+				ptySession2 := apty.New()
+				if pane.CWD != "" {
+					ptySession2.SetCWD(pane.CWD)
+				}
+				if err := d.spawnPane(pane, ptySession2, false); err != nil {
+					log.Printf("fallback shell for pane %s also failed: %v", pane.ID, err)
+				}
 			} else {
-				log.Printf("respawned shell in pane %s (cwd: %s)", pane.ID, pane.CWD)
+				log.Printf("respawned pane %s (type=%s, cwd=%s)", pane.ID, pane.Type, pane.CWD)
 			}
 		}
 	}
@@ -376,9 +427,10 @@ func (d *Daemon) handleAttach(conn *ipc.Conn, msg *ipc.Message) {
 		tab := d.session.CreateTab("Shell")
 		cwd, _ := os.Getwd()
 		pane, _ := d.session.CreatePane(tab.ID, cwd)
+		pane.Type = "terminal"
 
 		ptySession := apty.NewWithSize(cols, rows)
-		if err := d.spawnShell(pane, ptySession); err != nil {
+		if err := d.spawnPane(pane, ptySession, false); err != nil {
 			log.Printf("failed to start PTY: %v", err)
 		}
 	}
@@ -387,11 +439,21 @@ func (d *Daemon) handleAttach(conn *ipc.Conn, msg *ipc.Message) {
 	resp, _ := ipc.NewMessage(ipc.MsgWorkspaceState, state)
 	conn.Send(resp)
 
-	// Replay buffered output so reconnecting clients see previous terminal content
+	// Replay buffered output so reconnecting clients see previous terminal content.
+	// Skip ghost replay for panes that use resume strategies (preassign_id,
+	// session_scrape) — these are TUI apps that re-render from scratch on resume,
+	// so old ghost data just pollutes cursor state.
 	for _, tab := range d.session.Tabs() {
 		for _, pane := range d.session.Panes(tab.ID) {
 			if pane.OutputBuf == nil {
 				continue
+			}
+			// Skip ghost replay for panes that resume with a fresh TUI
+			if p := d.registry.Get(pane.Type); p != nil {
+				switch p.Persistence.Strategy {
+				case "preassign_id", "session_scrape":
+					continue
+				}
 			}
 			history := pane.OutputBuf.Bytes()
 			if len(history) == 0 {
@@ -417,9 +479,10 @@ func (d *Daemon) handleCreateTab(conn *ipc.Conn, msg *ipc.Message) {
 	// Every tab needs a default pane with a shell
 	cwd, _ := os.Getwd()
 	pane, _ := d.session.CreatePane(tab.ID, cwd)
+	pane.Type = "terminal"
 
 	ptySession := apty.New()
-	if err := d.spawnShell(pane, ptySession); err != nil {
+	if err := d.spawnPane(pane, ptySession, false); err != nil {
 		log.Printf("failed to start PTY for new tab: %v", err)
 	}
 
@@ -437,8 +500,9 @@ func (d *Daemon) handleDestroyTab(msg *ipc.Message) {
 		tab := d.session.CreateTab("Shell")
 		cwd, _ := os.Getwd()
 		pane, _ := d.session.CreatePane(tab.ID, cwd)
+		pane.Type = "terminal"
 		ptySession := apty.NewWithSize(80, 24)
-		if err := d.spawnShell(pane, ptySession); err != nil {
+		if err := d.spawnPane(pane, ptySession, false); err != nil {
 			log.Printf("failed to start replacement shell: %v", err)
 		}
 	}
@@ -485,15 +549,55 @@ func (d *Daemon) handleCreatePane(msg *ipc.Message) {
 		cwd, _ = os.Getwd()
 	}
 
+	// Determine pane type
+	paneType := payload.Type
+	if paneType == "" {
+		paneType = "terminal"
+	}
+
+	// Replace mode: atomically swap old pane for new one
+	if payload.ReplacePaneID != "" {
+		d.handleReplacePane(payload, cwd, paneType)
+		return
+	}
+
 	pane, err := d.session.CreatePane(payload.TabID, cwd)
 	if err != nil {
 		log.Printf("create pane error: %v", err)
 		return
 	}
 
+	pane.Type = paneType
+	pane.InstanceName = payload.InstanceName
+	pane.InstanceArgs = payload.InstanceArgs
+
 	ptySession := apty.New()
-	if err := d.spawnShell(pane, ptySession); err != nil {
+	if err := d.spawnPane(pane, ptySession, false); err != nil {
 		log.Printf("start PTY error: %v", err)
+		return
+	}
+	d.broadcastState()
+	d.snapshotDebounced()
+}
+
+func (d *Daemon) handleReplacePane(payload ipc.CreatePanePayload, cwd, paneType string) {
+	newPane := d.session.NewPane(cwd)
+	newPane.Type = paneType
+	newPane.InstanceName = payload.InstanceName
+	newPane.InstanceArgs = payload.InstanceArgs
+
+	// Atomically swap old → new in the tab's pane list
+	if err := d.session.ReplacePane(payload.ReplacePaneID, newPane); err != nil {
+		log.Printf("replace pane: swap error: %v", err)
+		return
+	}
+
+	ptySession := apty.New()
+	if err := d.spawnPane(newPane, ptySession, false); err != nil {
+		log.Printf("replace pane: start PTY error: %v, removing dead pane", err)
+		d.session.DestroyPane(newPane.ID)
+		d.broadcastState()
+		d.snapshotDebounced()
 		return
 	}
 	d.broadcastState()
@@ -517,8 +621,9 @@ func (d *Daemon) handleDestroyPane(msg *ipc.Message) {
 		if panes := d.session.Panes(tabID); len(panes) == 0 {
 			cwd, _ := os.Getwd()
 			if newPane, err := d.session.CreatePane(tabID, cwd); err == nil {
+				newPane.Type = "terminal"
 				ptySession := apty.New()
-				if err := d.spawnShell(newPane, ptySession); err != nil {
+				if err := d.spawnPane(newPane, ptySession, false); err != nil {
 					log.Printf("failed to start replacement shell: %v", err)
 				}
 			}
@@ -641,9 +746,41 @@ func (d *Daemon) streamPTYOutput(paneID string, pty apty.Session) {
 }
 
 func (d *Daemon) flushPaneOutput(paneID string, data []byte) {
-	if pane := d.session.Pane(paneID); pane != nil && pane.OutputBuf != nil {
+	pane := d.session.Pane(paneID)
+	if pane == nil {
+		return
+	}
+	if pane.OutputBuf != nil {
 		pane.OutputBuf.Write(data)
 	}
+
+	// Scrape plugin state from output (e.g., session IDs)
+	if pane.Type != "" && pane.Type != "terminal" {
+		p := d.registry.Get(pane.Type)
+		if scraped := plugin.ScrapeOutput(p, data); scraped != nil {
+			pane.PluginMu.Lock()
+			if pane.PluginState == nil {
+				pane.PluginState = make(map[string]string)
+			}
+			for k, v := range scraped {
+				pane.PluginState[k] = v
+				log.Printf("pane %s: scraped %s=%.8s...", paneID, k, v)
+			}
+			pane.PluginMu.Unlock()
+		}
+
+		// Check for error patterns
+		if eh := plugin.MatchError(p, data); eh != nil && eh.Action == "dialog" {
+			message := plugin.ExpandMessage(eh.Message, pane.InstanceArgs)
+			errMsg, _ := ipc.NewMessage(ipc.MsgPluginError, ipc.PluginErrorPayload{
+				PaneID:  paneID,
+				Title:   eh.Title,
+				Message: message,
+			})
+			d.server.Broadcast(errMsg)
+		}
+	}
+
 	msg, _ := ipc.NewMessage(ipc.MsgPaneOutput, ipc.PaneOutputPayload{
 		PaneID: paneID,
 		Data:   data,
@@ -685,6 +822,25 @@ func (d *Daemon) buildWorkspaceState() map[string]any {
 			if pane.Name != "" {
 				paneData["name"] = pane.Name
 			}
+			if pane.Type != "" && pane.Type != "terminal" {
+				paneData["type"] = pane.Type
+			}
+			pane.PluginMu.Lock()
+			if len(pane.PluginState) > 0 {
+				// Copy to avoid holding lock during JSON marshal
+				ps := make(map[string]string, len(pane.PluginState))
+				for k, v := range pane.PluginState {
+					ps[k] = v
+				}
+				paneData["plugin_state"] = ps
+			}
+			pane.PluginMu.Unlock()
+			if pane.InstanceName != "" {
+				paneData["instance_name"] = pane.InstanceName
+			}
+			if len(pane.InstanceArgs) > 0 {
+				paneData["instance_args"] = pane.InstanceArgs
+			}
 			paneList = append(paneList, paneData)
 		}
 	}
@@ -696,33 +852,91 @@ func (d *Daemon) buildWorkspaceState() map[string]any {
 	}
 }
 
-func (d *Daemon) spawnShell(pane *Pane, ptySession apty.Session) error {
-	shell := defaultShell()
-	cfg := shellinit.Configure(shell, config.AethelDir())
-	if cfg != nil {
-		ptySession.SetEnv(cfg.Env)
-		if err := ptySession.Start(cfg.Cmd, cfg.Args...); err != nil {
-			return err
+// spawnPane launches the appropriate process for a pane based on its plugin type.
+// When restoring is true, resume strategies are applied (e.g., --resume for session_scrape).
+func (d *Daemon) spawnPane(pane *Pane, ptySession apty.Session, restoring bool) error {
+	// Default type
+	if pane.Type == "" {
+		pane.Type = "terminal"
+	}
+
+	p := d.registry.Get(pane.Type)
+	if p == nil {
+		p = d.registry.Get("terminal") // fallback
+	}
+
+	cmd := p.Command.Cmd
+	args := append([]string{}, p.Command.Args...) // copy
+
+	// Instance-specific args override base args
+	if len(pane.InstanceArgs) > 0 {
+		args = pane.InstanceArgs
+	}
+
+	// Pre-assign ID strategy: generate UUID on fresh start
+	if !restoring && p.Persistence.Strategy == "preassign_id" {
+		pane.PluginMu.Lock()
+		if pane.PluginState == nil {
+			pane.PluginState = make(map[string]string)
 		}
-	} else {
-		if err := ptySession.Start(shell); err != nil {
-			return err
+		if pane.PluginState["session_id"] == "" {
+			pane.PluginState["session_id"] = uuid.New().String()
 		}
+		pane.PluginMu.Unlock()
+		if len(p.Persistence.StartArgs) > 0 {
+			startArgs := plugin.ExpandResumeArgs(p.Persistence.StartArgs, pane.PluginState)
+			if startArgs != nil {
+				args = append(args, startArgs...)
+			}
+		}
+	}
+
+	// Resume logic for restoration
+	if restoring {
+		switch p.Persistence.Strategy {
+		case "preassign_id", "session_scrape":
+			if len(p.Persistence.ResumeArgs) > 0 && len(pane.PluginState) > 0 {
+				args = plugin.ExpandResumeArgs(p.Persistence.ResumeArgs, pane.PluginState)
+			}
+		case "rerun":
+			// args already set from InstanceArgs above
+		case "none":
+			// Don't restore — but we still spawn for now (pane exists in workspace)
+		// "cwd_only": just start fresh with CWD (default behavior)
+		}
+	}
+
+	// Shell integration (only for terminal-type panes)
+	if p.Command.ShellIntegration {
+		shellCfg := shellinit.Configure(cmd, config.AethelDir())
+		if shellCfg != nil {
+			ptySession.SetEnv(shellCfg.Env)
+			cmd = shellCfg.Cmd
+			args = shellCfg.Args
+		}
+	}
+
+	// Plugin-specific env vars
+	if len(p.Command.Env) > 0 {
+		ptySession.SetEnv(p.Command.Env)
+	}
+
+	// Initialize plugin state map
+	pane.PluginMu.Lock()
+	if pane.PluginState == nil {
+		pane.PluginState = make(map[string]string)
+	}
+	pane.PluginMu.Unlock()
+
+	// Resolve command to absolute path so CWD doesn't interfere with lookup
+	if resolved, err := exec.LookPath(cmd); err == nil {
+		cmd = resolved
+	}
+
+	if err := ptySession.Start(cmd, args...); err != nil {
+		return err
 	}
 	pane.PTY = ptySession
 	go d.streamPTYOutput(pane.ID, ptySession)
 	return nil
-}
-
-func defaultShell() string {
-	if runtime.GOOS == "windows" {
-		if ps, err := exec.LookPath("pwsh.exe"); err == nil {
-			return ps
-		}
-		return "cmd.exe"
-	}
-	if shell := os.Getenv("SHELL"); shell != "" {
-		return shell
-	}
-	return "/bin/sh"
 }

--- a/internal/daemon/session.go
+++ b/internal/daemon/session.go
@@ -19,12 +19,17 @@ type Tab struct {
 }
 
 type Pane struct {
-	ID        string
-	TabID     string
-	CWD       string
-	Name      string // User-set name (empty = use CWD)
-	PTY       apty.Session
-	OutputBuf *ringbuf.RingBuffer // Captures PTY output for replay on reconnect
+	ID           string
+	TabID        string
+	CWD          string
+	Name         string // User-set name (empty = use CWD)
+	PTY          apty.Session
+	OutputBuf    *ringbuf.RingBuffer // Captures PTY output for replay on reconnect
+	Type         string              // Plugin name (default: "terminal")
+	PluginState  map[string]string   // Scraped values (e.g., "session_id": "abc123")
+	PluginMu     sync.Mutex          // Protects PluginState from concurrent access
+	InstanceName string              // Which instance config was used
+	InstanceArgs []string            // Args used to start (for rerun strategy)
 }
 
 type SessionManager struct {
@@ -115,6 +120,48 @@ func (sm *SessionManager) CreatePane(tabID string, cwd string) (*Pane, error) {
 	sm.panes[id] = pane
 	tab.Panes = append(tab.Panes, id)
 	return pane, nil
+}
+
+// NewPane creates a Pane object with a unique ID and ring buffer, but does
+// NOT add it to any tab. Use with ReplacePane for atomic swaps.
+func (sm *SessionManager) NewPane(cwd string) *Pane {
+	id := "pane-" + uuid.New().String()[:8]
+	return &Pane{
+		ID:        id,
+		CWD:       cwd,
+		OutputBuf: ringbuf.NewRingBuffer(sm.bufSize),
+	}
+}
+
+// ReplacePane atomically swaps an old pane for a new one at the same
+// position in the tab's pane list. The old pane's PTY is closed.
+func (sm *SessionManager) ReplacePane(oldPaneID string, newPane *Pane) error {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	oldPane, ok := sm.panes[oldPaneID]
+	if !ok {
+		return fmt.Errorf("pane not found: %s", oldPaneID)
+	}
+
+	if oldPane.PTY != nil {
+		oldPane.PTY.Close()
+	}
+
+	// Replace in tab's pane list at the same index
+	if tab, ok := sm.tabs[oldPane.TabID]; ok {
+		for i, id := range tab.Panes {
+			if id == oldPaneID {
+				tab.Panes[i] = newPane.ID
+				break
+			}
+		}
+	}
+
+	newPane.TabID = oldPane.TabID
+	delete(sm.panes, oldPaneID)
+	sm.panes[newPane.ID] = newPane
+	return nil
 }
 
 func (sm *SessionManager) DestroyPane(paneID string) error {

--- a/internal/ipc/protocol.go
+++ b/internal/ipc/protocol.go
@@ -35,6 +35,9 @@ const (
 	// State sync (Daemon -> Client)
 	MsgWorkspaceState = "workspace_state"
 	MsgStateUpdate    = "state_update"
+
+	// Plugin (Daemon -> Client)
+	MsgPluginError = "plugin_error"
 )
 
 // Message is the wire format for IPC communication.
@@ -51,8 +54,12 @@ type AttachPayload struct {
 }
 
 type CreatePanePayload struct {
-	TabID string `json:"tab_id"`
-	CWD   string `json:"cwd"`
+	TabID         string   `json:"tab_id"`
+	CWD           string   `json:"cwd"`
+	Type          string   `json:"type,omitempty"`
+	InstanceName  string   `json:"instance_name,omitempty"`
+	InstanceArgs  []string `json:"instance_args,omitempty"`
+	ReplacePaneID string   `json:"replace_pane_id,omitempty"`
 }
 
 type DestroyPanePayload struct {
@@ -103,6 +110,12 @@ type UpdatePanePayload struct {
 type UpdateLayoutPayload struct {
 	TabID  string          `json:"tab_id"`
 	Layout json.RawMessage `json:"layout"`
+}
+
+type PluginErrorPayload struct {
+	PaneID  string `json:"pane_id"`
+	Title   string `json:"title"`
+	Message string `json:"message"`
 }
 
 // NewMessage creates a Message with a typed payload.

--- a/internal/plugin/builtin.go
+++ b/internal/plugin/builtin.go
@@ -1,0 +1,177 @@
+package plugin
+
+import (
+	"os"
+	"os/exec"
+	"runtime"
+)
+
+// builtinTerminal returns the terminal plugin definition.
+func builtinTerminal() *PanePlugin {
+	instances := detectShells()
+	return &PanePlugin{
+		Name:        "terminal",
+		DisplayName: "Terminal",
+		Category:    "terminal",
+		Description: "System shell",
+		Command: CommandConfig{
+			Cmd:              defaultShell(),
+			ShellIntegration: true,
+		},
+		Persistence: PersistenceConfig{
+			Strategy: "cwd_only",
+		},
+		Instances: instances,
+		Available: true, // always available
+	}
+}
+
+// builtinClaudeCode returns the Claude Code plugin definition.
+func builtinClaudeCode() *PanePlugin {
+	return &PanePlugin{
+		Name:        "claude-code",
+		DisplayName: "Claude Code",
+		Category:    "ai",
+		Description: "AI coding assistant",
+		Command: CommandConfig{
+			Cmd:       "claude",
+			DetectCmd: "claude --version",
+		},
+		Persistence: PersistenceConfig{
+			Strategy:   "preassign_id",
+			StartArgs:  []string{"--session-id", "{session_id}"},
+			ResumeArgs: []string{"--resume", "{session_id}"},
+		},
+		ErrorHandlers: []ErrorHandler{
+			{
+				Pattern: `(?i)error.*API key not found|ANTHROPIC_API_KEY.*not set`,
+				Title:   "API Key Missing",
+				Message: "Set ANTHROPIC_API_KEY in your environment or run 'claude auth'.",
+				Action:  "dialog",
+			},
+		},
+	}
+}
+
+// builtinStripe returns the Stripe CLI plugin definition.
+func builtinStripe() *PanePlugin {
+	return &PanePlugin{
+		Name:        "stripe",
+		DisplayName: "Stripe",
+		Category:    "tools",
+		Description: "Stripe webhook listener",
+		Command: CommandConfig{
+			Cmd:       "stripe",
+			Args:      []string{"listen"},
+			DetectCmd: "stripe --version",
+		},
+		Persistence: PersistenceConfig{
+			Strategy: "rerun",
+		},
+		ErrorHandlers: []ErrorHandler{
+			{
+				Pattern: `not logged in|login required`,
+				Title:   "Stripe Authentication Required",
+				Message: "Run 'stripe login' in a terminal pane first.",
+				Action:  "dialog",
+			},
+		},
+	}
+}
+
+// builtinSSH returns the SSH plugin definition.
+func builtinSSH() *PanePlugin {
+	return &PanePlugin{
+		Name:        "ssh",
+		DisplayName: "SSH",
+		Category:    "remote",
+		Description: "Remote SSH connection",
+		Command: CommandConfig{
+			Cmd:       "ssh",
+			DetectCmd: "ssh -V",
+		},
+		Persistence: PersistenceConfig{
+			Strategy: "rerun",
+		},
+		ErrorHandlers: []ErrorHandler{
+			{
+				Pattern: `Permission denied \(publickey`,
+				Title:   "SSH Authentication Failed",
+				Message: "SSH key not configured for this host.\n\n1. Generate:  ssh-keygen -t ed25519\n2. Copy key:  ssh-copy-id user@host\n3. Retry",
+				Action:  "dialog",
+			},
+			{
+				Pattern: `Host key verification failed`,
+				Title:   "Unknown Host",
+				Message: "Run: ssh-keyscan <host> >> ~/.ssh/known_hosts",
+				Action:  "dialog",
+			},
+			{
+				Pattern: `Connection refused|No route to host`,
+				Title:   "Connection Failed",
+				Message: "Cannot reach host. Check that the server is running and the address is correct.",
+				Action:  "dialog",
+			},
+		},
+	}
+}
+
+// builtinPlugins returns all built-in plugin definitions.
+func builtinPlugins() []*PanePlugin {
+	return []*PanePlugin{
+		builtinTerminal(),
+		builtinClaudeCode(),
+		builtinStripe(),
+		builtinSSH(),
+	}
+}
+
+func defaultShell() string {
+	if runtime.GOOS == "windows" {
+		if ps, err := exec.LookPath("pwsh.exe"); err == nil {
+			return ps
+		}
+		return "cmd.exe"
+	}
+	if shell := os.Getenv("SHELL"); shell != "" {
+		return shell
+	}
+	return "/bin/sh"
+}
+
+// detectShells returns InstanceConfig entries for shells found on the system.
+func detectShells() []InstanceConfig {
+	var instances []InstanceConfig
+
+	type shellDef struct {
+		name, display, cmd string
+	}
+
+	candidates := []shellDef{
+		{"bash", "Bash", "bash"},
+		{"zsh", "Zsh", "zsh"},
+		{"fish", "Fish", "fish"},
+		{"pwsh", "PowerShell", "pwsh"},
+		{"cmd", "Command Prompt", "cmd.exe"},
+	}
+	if runtime.GOOS == "windows" {
+		candidates = []shellDef{
+			{"pwsh", "PowerShell", "pwsh.exe"},
+			{"powershell", "Windows PowerShell", "powershell.exe"},
+			{"cmd", "Command Prompt", "cmd.exe"},
+			{"bash", "Git Bash", "bash"},
+		}
+	}
+
+	for _, c := range candidates {
+		if _, err := exec.LookPath(c.cmd); err == nil {
+			instances = append(instances, InstanceConfig{
+				Name:        c.name,
+				DisplayName: c.display,
+				Args:        []string{}, // use default shell args
+			})
+		}
+	}
+
+	return instances
+}

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -1,0 +1,96 @@
+package plugin
+
+import "regexp"
+
+// PanePlugin defines a pane type with its command, persistence strategy,
+// and optional error handlers.
+type PanePlugin struct {
+	Name          string
+	DisplayName   string
+	Category      string
+	Description   string
+	Command       CommandConfig
+	Persistence   PersistenceConfig
+	Display       DisplayConfig
+	Instances     []InstanceConfig
+	ErrorHandlers []ErrorHandler
+	Available     bool // set at startup by running detect cmd
+}
+
+// CommandConfig describes how to launch the plugin's process.
+type CommandConfig struct {
+	Cmd              string
+	Args             []string
+	Env              []string
+	DetectCmd        string
+	ShellIntegration bool
+}
+
+// PersistenceConfig describes how to restore the pane after daemon restart.
+type PersistenceConfig struct {
+	Strategy   string // "none", "cwd_only", "rerun", "session_scrape", "preassign_id"
+	StartArgs  []string // template args for fresh start (e.g., ["--session-id", "{session_id}"])
+	ResumeArgs []string
+	Scrapers   []ScrapePattern
+}
+
+// ScrapePattern extracts named values from PTY output via regex.
+type ScrapePattern struct {
+	Name     string
+	Pattern  string
+	compiled *regexp.Regexp
+}
+
+// Compile pre-compiles the regex pattern. Must be called before concurrent use.
+// Returns an error if the pattern is invalid (instead of panicking).
+func (sp *ScrapePattern) Compile() error {
+	re, err := regexp.Compile(sp.Pattern)
+	if err != nil {
+		return err
+	}
+	sp.compiled = re
+	return nil
+}
+
+// Compiled returns the compiled regex, or nil if compilation failed.
+func (sp *ScrapePattern) Compiled() *regexp.Regexp {
+	return sp.compiled
+}
+
+// InstanceConfig is a pre-configured variant of a plugin (e.g., a specific SSH host).
+type InstanceConfig struct {
+	Name        string
+	DisplayName string
+	Args        []string
+	Env         []string
+}
+
+// DisplayConfig controls visual appearance of the pane.
+type DisplayConfig struct {
+	BorderColor string
+}
+
+// ErrorHandler matches PTY output patterns and triggers help dialogs.
+type ErrorHandler struct {
+	Pattern  string
+	Title    string
+	Message  string
+	Action   string // "dialog" | "log"
+	compiled *regexp.Regexp
+}
+
+// Compile pre-compiles the regex pattern. Must be called before concurrent use.
+// Returns an error if the pattern is invalid (instead of panicking).
+func (eh *ErrorHandler) Compile() error {
+	re, err := regexp.Compile(eh.Pattern)
+	if err != nil {
+		return err
+	}
+	eh.compiled = re
+	return nil
+}
+
+// Compiled returns the compiled regex, or nil if compilation failed.
+func (eh *ErrorHandler) Compiled() *regexp.Regexp {
+	return eh.compiled
+}

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -1,0 +1,432 @@
+package plugin
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRegistryBuiltins(t *testing.T) {
+	r := NewRegistry()
+
+	// All 4 built-ins should be present
+	names := []string{"terminal", "claude-code", "stripe", "ssh"}
+	for _, name := range names {
+		if r.Get(name) == nil {
+			t.Errorf("built-in plugin %q not found", name)
+		}
+	}
+}
+
+func TestRegistryTerminalAlwaysAvailable(t *testing.T) {
+	r := NewRegistry()
+	r.DetectAvailability()
+
+	terminal := r.Get("terminal")
+	if terminal == nil {
+		t.Fatal("terminal plugin missing")
+	}
+	if !terminal.Available {
+		t.Error("terminal plugin should always be available")
+	}
+}
+
+func TestRegistryByCategory(t *testing.T) {
+	r := NewRegistry()
+	cats := r.ByCategory()
+
+	if _, ok := cats["terminal"]; !ok {
+		t.Error("missing terminal category")
+	}
+	if _, ok := cats["ai"]; !ok {
+		t.Error("missing ai category")
+	}
+	if _, ok := cats["tools"]; !ok {
+		t.Error("missing tools category")
+	}
+	if _, ok := cats["remote"]; !ok {
+		t.Error("missing remote category")
+	}
+}
+
+func TestRegistryGet(t *testing.T) {
+	r := NewRegistry()
+
+	p := r.Get("terminal")
+	if p == nil {
+		t.Fatal("terminal plugin not found")
+	}
+	if p.DisplayName != "Terminal" {
+		t.Errorf("expected display name 'Terminal', got %q", p.DisplayName)
+	}
+	if p.Persistence.Strategy != "cwd_only" {
+		t.Errorf("expected strategy 'cwd_only', got %q", p.Persistence.Strategy)
+	}
+}
+
+func TestRegistryGetNonExistent(t *testing.T) {
+	r := NewRegistry()
+	if r.Get("nonexistent") != nil {
+		t.Error("expected nil for nonexistent plugin")
+	}
+}
+
+func TestScrapeOutput(t *testing.T) {
+	p := &PanePlugin{
+		Persistence: PersistenceConfig{
+			Strategy: "session_scrape",
+			Scrapers: []ScrapePattern{
+				{Name: "session_id", Pattern: `Session: ([a-zA-Z0-9_-]+)`},
+			},
+		},
+	}
+	compilePatterns(p)
+
+	data := []byte("Starting session\nSession: abc-123-def\nReady.")
+	result := ScrapeOutput(p, data)
+	if result == nil {
+		t.Fatal("expected scraped result")
+	}
+	if result["session_id"] != "abc-123-def" {
+		t.Errorf("expected session_id 'abc-123-def', got %q", result["session_id"])
+	}
+}
+
+func TestScrapeOutputNoMatch(t *testing.T) {
+	p := &PanePlugin{
+		Persistence: PersistenceConfig{
+			Strategy: "session_scrape",
+			Scrapers: []ScrapePattern{
+				{Name: "session_id", Pattern: `Session: ([a-zA-Z0-9_-]+)`},
+			},
+		},
+	}
+	compilePatterns(p)
+
+	data := []byte("Just some regular output with no session info")
+	result := ScrapeOutput(p, data)
+	if result != nil {
+		t.Errorf("expected nil result, got %v", result)
+	}
+}
+
+func TestScrapeOutputNilPlugin(t *testing.T) {
+	result := ScrapeOutput(nil, []byte("data"))
+	if result != nil {
+		t.Error("expected nil for nil plugin")
+	}
+}
+
+func TestMatchError(t *testing.T) {
+	p := builtinSSH()
+	// Pre-compile handlers
+	for i := range p.ErrorHandlers {
+		p.ErrorHandlers[i].Compile()
+	}
+
+	data := []byte("ssh: connect to host: Permission denied (publickey)")
+	eh := MatchError(p, data)
+	if eh == nil {
+		t.Fatal("expected error handler match")
+	}
+	if eh.Title != "SSH Authentication Failed" {
+		t.Errorf("expected title 'SSH Authentication Failed', got %q", eh.Title)
+	}
+}
+
+func TestClaudeCodePreassignStrategy(t *testing.T) {
+	p := builtinClaudeCode()
+	if p.Persistence.Strategy != "preassign_id" {
+		t.Errorf("expected strategy 'preassign_id', got %q", p.Persistence.Strategy)
+	}
+	if len(p.Persistence.StartArgs) != 2 || p.Persistence.StartArgs[0] != "--session-id" {
+		t.Errorf("expected StartArgs [--session-id {session_id}], got %v", p.Persistence.StartArgs)
+	}
+	if len(p.Persistence.ResumeArgs) != 2 || p.Persistence.ResumeArgs[0] != "--resume" {
+		t.Errorf("expected ResumeArgs [--resume {session_id}], got %v", p.Persistence.ResumeArgs)
+	}
+	if len(p.Persistence.Scrapers) != 0 {
+		t.Errorf("expected no scrapers for preassign_id, got %d", len(p.Persistence.Scrapers))
+	}
+}
+
+func TestExpandResumeArgsUnresolved(t *testing.T) {
+	template := []string{"--resume", "{session_id}"}
+	state := map[string]string{"other_key": "value"}
+	result := ExpandResumeArgs(template, state)
+	if result != nil {
+		t.Errorf("expected nil for unresolved placeholder, got %v", result)
+	}
+}
+
+func TestDetectAvailabilityWithDetectCmd(t *testing.T) {
+	r := NewRegistry()
+	// Claude Code has detect cmd "claude --version" — DetectAvailability
+	// extracts "claude" and checks LookPath. We just verify it doesn't panic.
+	r.DetectAvailability()
+
+	// Terminal should always be available
+	if !r.Get("terminal").Available {
+		t.Error("terminal should always be available")
+	}
+}
+
+func TestCompileInvalidPattern(t *testing.T) {
+	sp := ScrapePattern{Name: "bad", Pattern: `[invalid`}
+	err := sp.Compile()
+	if err == nil {
+		t.Error("expected error for invalid regex")
+	}
+	if sp.Compiled() != nil {
+		t.Error("compiled should be nil after failed compile")
+	}
+
+	eh := ErrorHandler{Pattern: `[also-invalid`, Action: "dialog"}
+	err = eh.Compile()
+	if err == nil {
+		t.Error("expected error for invalid regex")
+	}
+}
+
+func TestMatchErrorNoMatch(t *testing.T) {
+	p := builtinSSH()
+	compilePatterns(p)
+	data := []byte("Connected to server successfully")
+	eh := MatchError(p, data)
+	if eh != nil {
+		t.Errorf("expected no match, got %q", eh.Title)
+	}
+}
+
+func TestExpandResumeArgs(t *testing.T) {
+	template := []string{"--resume", "{session_id}"}
+	state := map[string]string{"session_id": "abc123"}
+
+	result := ExpandResumeArgs(template, state)
+	if len(result) != 2 {
+		t.Fatalf("expected 2 args, got %d", len(result))
+	}
+	if result[0] != "--resume" {
+		t.Errorf("expected '--resume', got %q", result[0])
+	}
+	if result[1] != "abc123" {
+		t.Errorf("expected 'abc123', got %q", result[1])
+	}
+}
+
+func TestExpandResumeArgsEmpty(t *testing.T) {
+	result := ExpandResumeArgs(nil, nil)
+	if result != nil {
+		t.Error("expected nil for nil template")
+	}
+
+	result = ExpandResumeArgs([]string{"--arg"}, nil)
+	if result != nil {
+		t.Error("expected nil when state is nil")
+	}
+}
+
+func TestExpandMessage(t *testing.T) {
+	msg := "Cannot reach {host} on port {port} as {user}"
+	args := []string{"-p", "2222", "deploy@staging.example.com"}
+
+	result := ExpandMessage(msg, args)
+	if result != "Cannot reach staging.example.com on port 2222 as deploy" {
+		t.Errorf("unexpected expansion: %q", result)
+	}
+}
+
+func TestExpandMessageEmpty(t *testing.T) {
+	result := ExpandMessage("hello {host}", nil)
+	if result != "hello {host}" {
+		t.Errorf("expected no expansion with nil args, got %q", result)
+	}
+}
+
+func TestExtractConnectionVars(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want map[string]string
+	}{
+		{
+			name: "user@host",
+			args: []string{"user@host.com"},
+			want: map[string]string{"user": "user", "host": "host.com"},
+		},
+		{
+			name: "user@host with port flag",
+			args: []string{"-p", "2222", "deploy@staging.com"},
+			want: map[string]string{"user": "deploy", "host": "staging.com", "port": "2222"},
+		},
+		{
+			name: "bare hostname",
+			args: []string{"myserver.com"},
+			want: map[string]string{"host": "myserver.com"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractConnectionVars(tt.args)
+			for k, want := range tt.want {
+				if got[k] != want {
+					t.Errorf("key %q: got %q, want %q", k, got[k], want)
+				}
+			}
+		})
+	}
+}
+
+func TestLoadFromDir(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write a test TOML plugin
+	toml := `
+[plugin]
+name = "test-tool"
+display_name = "Test Tool"
+category = "tools"
+description = "A test plugin"
+
+[command]
+cmd = "echo"
+args = ["hello"]
+detect = "echo ok"
+
+[persistence]
+strategy = "rerun"
+
+[[error_handlers]]
+pattern = "error occurred"
+title = "Test Error"
+message = "Something went wrong"
+action = "dialog"
+
+[[instances]]
+name = "default"
+display_name = "Default"
+args = ["--default"]
+`
+	if err := os.WriteFile(filepath.Join(dir, "test-tool.toml"), []byte(toml), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := NewRegistry()
+	if err := r.LoadFromDir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	p := r.Get("test-tool")
+	if p == nil {
+		t.Fatal("test-tool plugin not loaded")
+	}
+	if p.DisplayName != "Test Tool" {
+		t.Errorf("expected display name 'Test Tool', got %q", p.DisplayName)
+	}
+	if p.Command.Cmd != "echo" {
+		t.Errorf("expected cmd 'echo', got %q", p.Command.Cmd)
+	}
+	if p.Persistence.Strategy != "rerun" {
+		t.Errorf("expected strategy 'rerun', got %q", p.Persistence.Strategy)
+	}
+	if len(p.ErrorHandlers) != 1 {
+		t.Fatalf("expected 1 error handler, got %d", len(p.ErrorHandlers))
+	}
+	if p.ErrorHandlers[0].Title != "Test Error" {
+		t.Errorf("expected error title 'Test Error', got %q", p.ErrorHandlers[0].Title)
+	}
+	if len(p.Instances) != 1 {
+		t.Fatalf("expected 1 instance, got %d", len(p.Instances))
+	}
+	if p.Instances[0].Name != "default" {
+		t.Errorf("expected instance name 'default', got %q", p.Instances[0].Name)
+	}
+}
+
+func TestLoadFromDirOverride(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write a TOML that overrides the built-in terminal plugin
+	toml := `
+[plugin]
+name = "terminal"
+display_name = "Custom Terminal"
+category = "terminal"
+
+[command]
+cmd = "zsh"
+shell_integration = true
+
+[persistence]
+strategy = "cwd_only"
+`
+	if err := os.WriteFile(filepath.Join(dir, "terminal.toml"), []byte(toml), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := NewRegistry()
+	if err := r.LoadFromDir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	p := r.Get("terminal")
+	if p == nil {
+		t.Fatal("terminal plugin missing after override")
+	}
+	if p.DisplayName != "Custom Terminal" {
+		t.Errorf("expected override display name 'Custom Terminal', got %q", p.DisplayName)
+	}
+	if p.Command.Cmd != "zsh" {
+		t.Errorf("expected override cmd 'zsh', got %q", p.Command.Cmd)
+	}
+}
+
+func TestLoadFromDirNonExistent(t *testing.T) {
+	r := NewRegistry()
+	err := r.LoadFromDir("/nonexistent/path")
+	if err != nil {
+		t.Errorf("expected nil error for missing dir, got %v", err)
+	}
+}
+
+func TestCategoryOrder(t *testing.T) {
+	order := CategoryOrder()
+	if len(order) != 4 {
+		t.Fatalf("expected 4 categories, got %d", len(order))
+	}
+	if order[0].Key != "terminal" {
+		t.Errorf("expected first category 'terminal', got %q", order[0].Key)
+	}
+}
+
+func TestScrapePatternCompile(t *testing.T) {
+	sp := ScrapePattern{
+		Name:    "test",
+		Pattern: `Session: (\w+)`,
+	}
+	sp.Compile()
+	re := sp.Compiled()
+	if re == nil {
+		t.Fatal("compiled regex should not be nil")
+	}
+	// Should return same instance on second call
+	re2 := sp.Compiled()
+	if re != re2 {
+		t.Error("expected same regex instance on second call")
+	}
+}
+
+func TestErrorHandlerCompile(t *testing.T) {
+	eh := ErrorHandler{
+		Pattern: `error: (.+)`,
+		Title:   "Error",
+		Message: "Something happened",
+		Action:  "dialog",
+	}
+	eh.Compile()
+	re := eh.Compiled()
+	if re == nil {
+		t.Fatal("compiled regex should not be nil")
+	}
+}

--- a/internal/plugin/registry.go
+++ b/internal/plugin/registry.go
@@ -1,0 +1,287 @@
+package plugin
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/BurntSushi/toml"
+)
+
+// Registry holds all known plugins (built-in + user TOML).
+type Registry struct {
+	plugins map[string]*PanePlugin
+	mu      sync.RWMutex
+}
+
+// NewRegistry creates a registry pre-loaded with built-in plugins.
+func NewRegistry() *Registry {
+	r := &Registry{
+		plugins: make(map[string]*PanePlugin),
+	}
+	for _, p := range builtinPlugins() {
+		compilePatterns(p)
+		r.plugins[p.Name] = p
+	}
+	return r
+}
+
+// compilePatterns pre-compiles all regex patterns in a plugin so they
+// are safe for concurrent use from PTY output goroutines.
+func compilePatterns(p *PanePlugin) {
+	for i := range p.Persistence.Scrapers {
+		if err := p.Persistence.Scrapers[i].Compile(); err != nil {
+			log.Printf("plugin %s: invalid scrape pattern %q: %v", p.Name, p.Persistence.Scrapers[i].Pattern, err)
+		}
+	}
+	for i := range p.ErrorHandlers {
+		if err := p.ErrorHandlers[i].Compile(); err != nil {
+			log.Printf("plugin %s: invalid error pattern %q: %v", p.Name, p.ErrorHandlers[i].Pattern, err)
+		}
+	}
+}
+
+// Get returns a plugin by name, or nil if not found.
+func (r *Registry) Get(name string) *PanePlugin {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.plugins[name]
+}
+
+// All returns all registered plugins.
+func (r *Registry) All() []*PanePlugin {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	result := make([]*PanePlugin, 0, len(r.plugins))
+	for _, p := range r.plugins {
+		result = append(result, p)
+	}
+	return result
+}
+
+// ByCategory returns plugins grouped by category.
+func (r *Registry) ByCategory() map[string][]*PanePlugin {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	cats := make(map[string][]*PanePlugin)
+	for _, p := range r.plugins {
+		cats[p.Category] = append(cats[p.Category], p)
+	}
+	return cats
+}
+
+// AvailableByCategory returns only available plugins grouped by category.
+func (r *Registry) AvailableByCategory() map[string][]*PanePlugin {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	cats := make(map[string][]*PanePlugin)
+	for _, p := range r.plugins {
+		if p.Available {
+			cats[p.Category] = append(cats[p.Category], p)
+		}
+	}
+	return cats
+}
+
+// CategoryOrder returns the display order for categories.
+func CategoryOrder() []struct{ Key, Label string } {
+	return []struct{ Key, Label string }{
+		{"terminal", "Terminal"},
+		{"ai", "AI Assistant"},
+		{"tools", "Tools"},
+		{"remote", "Remote"},
+	}
+}
+
+// LoadFromDir loads all *.toml plugin files from dir.
+// TOML plugins override built-ins with the same name.
+func (r *Registry) LoadFromDir(dir string) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // No plugins dir is fine
+		}
+		return fmt.Errorf("read plugins dir: %w", err)
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".toml") {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		p, err := loadPluginTOML(path)
+		if err != nil {
+			log.Printf("skip plugin %s: %v", e.Name(), err)
+			continue
+		}
+		compilePatterns(p)
+		r.plugins[p.Name] = p
+		log.Printf("loaded plugin: %s from %s", p.Name, e.Name())
+	}
+
+	return nil
+}
+
+// DetectAvailability checks whether each plugin's tool is installed by
+// looking up the binary on PATH. Terminal is always available.
+func (r *Registry) DetectAvailability() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for _, p := range r.plugins {
+		if p.Name == "terminal" {
+			p.Available = true
+			continue
+		}
+
+		// Determine which binary to look for:
+		// prefer the detect command's binary (first word), fall back to cmd.
+		bin := p.Command.Cmd
+		if p.Command.DetectCmd != "" {
+			if parts := strings.Fields(p.Command.DetectCmd); len(parts) > 0 {
+				bin = parts[0]
+			}
+		}
+
+		if _, err := exec.LookPath(bin); err == nil {
+			p.Available = true
+		}
+	}
+}
+
+// tomlPlugin is the on-disk representation of a plugin TOML file.
+type tomlPlugin struct {
+	Plugin struct {
+		Name        string `toml:"name"`
+		DisplayName string `toml:"display_name"`
+		Category    string `toml:"category"`
+		Description string `toml:"description"`
+	} `toml:"plugin"`
+	Command struct {
+		Cmd              string   `toml:"cmd"`
+		Args             []string `toml:"args"`
+		Env              []string `toml:"env"`
+		Detect           string   `toml:"detect"`
+		ShellIntegration bool     `toml:"shell_integration"`
+	} `toml:"command"`
+	Persistence struct {
+		Strategy   string `toml:"strategy"`
+		StartArgs  []string `toml:"start_args"`
+		ResumeArgs []string `toml:"resume_args"`
+		Scrape     []struct {
+			Name    string `toml:"name"`
+			Pattern string `toml:"pattern"`
+		} `toml:"scrape"`
+	} `toml:"persistence"`
+	Display struct {
+		BorderColor string `toml:"border_color"`
+	} `toml:"display"`
+	Instances []struct {
+		Name        string   `toml:"name"`
+		DisplayName string   `toml:"display_name"`
+		Args        []string `toml:"args"`
+		Env         []string `toml:"env"`
+	} `toml:"instances"`
+	ErrorHandlers []struct {
+		Pattern string `toml:"pattern"`
+		Title   string `toml:"title"`
+		Message string `toml:"message"`
+		Action  string `toml:"action"`
+	} `toml:"error_handlers"`
+}
+
+func loadPluginTOML(path string) (*PanePlugin, error) {
+	var tp tomlPlugin
+	if _, err := toml.DecodeFile(path, &tp); err != nil {
+		return nil, fmt.Errorf("decode TOML: %w", err)
+	}
+
+	if tp.Plugin.Name == "" {
+		return nil, fmt.Errorf("plugin name is required")
+	}
+	if tp.Command.Cmd == "" {
+		return nil, fmt.Errorf("plugin %q: command.cmd is required", tp.Plugin.Name)
+	}
+	switch tp.Persistence.Strategy {
+	case "", "none", "cwd_only", "rerun", "session_scrape", "preassign_id":
+		// valid
+	default:
+		return nil, fmt.Errorf("plugin %q: unknown strategy %q", tp.Plugin.Name, tp.Persistence.Strategy)
+	}
+
+	displayName := tp.Plugin.DisplayName
+	if displayName == "" {
+		displayName = tp.Plugin.Name
+	}
+	category := tp.Plugin.Category
+	if category == "" {
+		category = "tools"
+	}
+
+	p := &PanePlugin{
+		Name:        tp.Plugin.Name,
+		DisplayName: displayName,
+		Category:    category,
+		Description: tp.Plugin.Description,
+		Command: CommandConfig{
+			Cmd:              tp.Command.Cmd,
+			Args:             tp.Command.Args,
+			Env:              tp.Command.Env,
+			DetectCmd:        tp.Command.Detect,
+			ShellIntegration: tp.Command.ShellIntegration,
+		},
+		Persistence: PersistenceConfig{
+			Strategy:   tp.Persistence.Strategy,
+			StartArgs:  tp.Persistence.StartArgs,
+			ResumeArgs: tp.Persistence.ResumeArgs,
+		},
+		Display: DisplayConfig{
+			BorderColor: tp.Display.BorderColor,
+		},
+	}
+
+	// Convert scrapers
+	for _, s := range tp.Persistence.Scrape {
+		p.Persistence.Scrapers = append(p.Persistence.Scrapers, ScrapePattern{
+			Name:    s.Name,
+			Pattern: s.Pattern,
+		})
+	}
+
+	// Convert instances
+	for _, inst := range tp.Instances {
+		p.Instances = append(p.Instances, InstanceConfig{
+			Name:        inst.Name,
+			DisplayName: inst.DisplayName,
+			Args:        inst.Args,
+			Env:         inst.Env,
+		})
+	}
+
+	// Convert error handlers
+	for _, eh := range tp.ErrorHandlers {
+		action := eh.Action
+		switch action {
+		case "dialog", "log", "":
+			// valid
+		default:
+			log.Printf("plugin %q: unknown error handler action %q, defaulting to log", tp.Plugin.Name, action)
+			action = "log"
+		}
+		p.ErrorHandlers = append(p.ErrorHandlers, ErrorHandler{
+			Pattern: eh.Pattern,
+			Title:   eh.Title,
+			Message: eh.Message,
+			Action:  action,
+		})
+	}
+
+	return p, nil
+}

--- a/internal/plugin/scraper.go
+++ b/internal/plugin/scraper.go
@@ -1,0 +1,122 @@
+package plugin
+
+import "strings"
+
+// ScrapeOutput checks PTY output data against a plugin's scrape patterns
+// and returns any matched key-value pairs.
+func ScrapeOutput(p *PanePlugin, data []byte) map[string]string {
+	if p == nil || len(p.Persistence.Scrapers) == 0 {
+		return nil
+	}
+
+	var result map[string]string
+	for i := range p.Persistence.Scrapers {
+		sp := &p.Persistence.Scrapers[i]
+		re := sp.Compiled()
+		if re == nil {
+			continue
+		}
+		matches := re.FindSubmatch(data)
+		if len(matches) > 1 {
+			if result == nil {
+				result = make(map[string]string)
+			}
+			result[sp.Name] = string(matches[1])
+		}
+	}
+	return result
+}
+
+// MatchError checks PTY output against a plugin's error handlers.
+// Returns the first matching handler, or nil if none match.
+func MatchError(p *PanePlugin, data []byte) *ErrorHandler {
+	if p == nil || len(p.ErrorHandlers) == 0 {
+		return nil
+	}
+
+	for i := range p.ErrorHandlers {
+		eh := &p.ErrorHandlers[i]
+		re := eh.Compiled()
+		if re == nil {
+			continue
+		}
+		if re.Match(data) {
+			return eh
+		}
+	}
+	return nil
+}
+
+// ExpandResumeArgs replaces {key} placeholders in resume args with
+// scraped values from plugin state. Returns nil if any placeholder
+// remains unresolved (missing state value).
+func ExpandResumeArgs(template []string, state map[string]string) []string {
+	if len(template) == 0 || len(state) == 0 {
+		return nil
+	}
+
+	result := make([]string, len(template))
+	for i, arg := range template {
+		expanded := arg
+		for k, v := range state {
+			expanded = strings.ReplaceAll(expanded, "{"+k+"}", v)
+		}
+		// Check for unresolved placeholders
+		if strings.Contains(expanded, "{") && strings.Contains(expanded, "}") {
+			return nil
+		}
+		result[i] = expanded
+	}
+	return result
+}
+
+// ExpandMessage replaces {key} placeholders in error messages with
+// values from instance args. Supports {host}, {user}, {port} extracted
+// from common argument patterns.
+func ExpandMessage(msg string, instanceArgs []string) string {
+	if len(instanceArgs) == 0 {
+		return msg
+	}
+
+	// Try to extract user@host:port from args
+	vars := extractConnectionVars(instanceArgs)
+	for k, v := range vars {
+		msg = strings.ReplaceAll(msg, "{"+k+"}", v)
+	}
+	return msg
+}
+
+// extractConnectionVars parses connection-style args (e.g., "user@host")
+// into named variables.
+func extractConnectionVars(args []string) map[string]string {
+	vars := make(map[string]string)
+
+	for i, arg := range args {
+		// Skip flags
+		if strings.HasPrefix(arg, "-") {
+			// Check if next arg is a port number for -p flag
+			if arg == "-p" && i+1 < len(args) {
+				vars["port"] = args[i+1]
+			}
+			continue
+		}
+
+		// Try user@host pattern
+		if strings.Contains(arg, "@") {
+			parts := strings.SplitN(arg, "@", 2)
+			vars["user"] = parts[0]
+			host := parts[1]
+			if colonIdx := strings.Index(host, ":"); colonIdx >= 0 {
+				vars["host"] = host[:colonIdx]
+				vars["port"] = host[colonIdx+1:]
+			} else {
+				vars["host"] = host
+			}
+		} else if _, exists := vars["host"]; !exists {
+			// Bare hostname
+			vars["host"] = arg
+		}
+	}
+
+	return vars
+}

--- a/internal/tui/dialog.go
+++ b/internal/tui/dialog.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -10,6 +11,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/artyomsv/aethel/internal/ipc"
+	"github.com/artyomsv/aethel/internal/plugin"
 )
 
 const dialogWidth = 50
@@ -132,6 +134,7 @@ func shortcutsList(m *Model) []struct{ key, desc string } {
 		{kb.ScrollPageUp, "Scroll page up"},
 		{kb.ScrollPageDown, "Scroll page down"},
 		{kb.Paste, "Paste clipboard"},
+		{"Ctrl+N", "New typed pane"},
 		{"Alt+1..9", "Switch to tab N"},
 		{"F1", "Help / About"},
 	}
@@ -149,6 +152,10 @@ func (m Model) handleDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleShortcutsKey(msg)
 	case dialogConfirm:
 		return m.handleConfirmKey(msg)
+	case dialogCreatePane:
+		return m.handleCreatePaneKey(msg)
+	case dialogPluginError:
+		return m.handlePluginErrorKey(msg)
 	}
 	return m, nil
 }
@@ -279,6 +286,10 @@ func (m Model) renderDialog() string {
 		content = m.renderShortcutsDialog()
 	case dialogConfirm:
 		content = m.renderConfirmDialog()
+	case dialogCreatePane:
+		content = m.renderCreatePaneDialog()
+	case dialogPluginError:
+		content = m.renderPluginErrorDialog()
 	}
 
 	box := dialogBorder.Width(dialogWidth).Render(content)
@@ -386,4 +397,316 @@ func boolStr(v bool) string {
 		return "✓"
 	}
 	return "✗"
+}
+
+// --- Pane creation dialog ---
+
+// createPaneCategories returns the ordered list of categories with their plugins
+// for the pane creation dialog.
+func (m *Model) createPaneCategories() []struct {
+	key     string
+	label   string
+	plugins []*plugin.PanePlugin
+} {
+	if m.pluginRegistry == nil {
+		return nil
+	}
+	byCategory := m.pluginRegistry.AvailableByCategory()
+	order := plugin.CategoryOrder()
+
+	var result []struct {
+		key     string
+		label   string
+		plugins []*plugin.PanePlugin
+	}
+	for _, cat := range order {
+		plugins := byCategory[cat.Key]
+		if len(plugins) == 0 {
+			continue
+		}
+		// Sort plugins by display name for consistency
+		sort.Slice(plugins, func(i, j int) bool {
+			return plugins[i].DisplayName < plugins[j].DisplayName
+		})
+		result = append(result, struct {
+			key     string
+			label   string
+			plugins []*plugin.PanePlugin
+		}{cat.Key, cat.Label, plugins})
+	}
+
+	// Add any categories not in the standard order
+	for cat, plugins := range byCategory {
+		found := false
+		for _, o := range order {
+			if o.Key == cat {
+				found = true
+				break
+			}
+		}
+		if !found {
+			sort.Slice(plugins, func(i, j int) bool {
+				return plugins[i].DisplayName < plugins[j].DisplayName
+			})
+			result = append(result, struct {
+				key     string
+				label   string
+				plugins []*plugin.PanePlugin
+			}{cat, cat, plugins})
+		}
+	}
+	return result
+}
+
+func (m Model) handleCreatePaneKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	key := msg.String()
+
+	switch key {
+	case "esc":
+		if m.createPaneStep > 0 {
+			// Go back one step
+			m.createPaneStep--
+			m.dialogCursor = 0
+			return m, nil
+		}
+		m.dialog = dialogNone
+		m.createPaneStep = 0
+		return m, nil
+
+	case "up", "k":
+		if m.dialogCursor > 0 {
+			m.dialogCursor--
+		}
+		return m, nil
+
+	case "down", "j":
+		items := m.createPaneItemCount()
+		if m.dialogCursor < items-1 {
+			m.dialogCursor++
+		}
+		return m, nil
+
+	case "enter":
+		return m.handleCreatePaneSelect()
+	}
+
+	return m, nil
+}
+
+func (m *Model) createPaneItemCount() int {
+	cats := m.createPaneCategories()
+	switch m.createPaneStep {
+	case 0:
+		return len(cats)
+	case 1:
+		if m.selectedCategory < len(cats) {
+			return len(cats[m.selectedCategory].plugins)
+		}
+	case 2:
+		return 3 // Horizontal, Vertical, Replace
+	}
+	return 0
+}
+
+func (m Model) handleCreatePaneSelect() (tea.Model, tea.Cmd) {
+	cats := m.createPaneCategories()
+
+	if m.createPaneStep == 0 {
+		// Selected a category
+		if m.dialogCursor < len(cats) {
+			m.selectedCategory = m.dialogCursor
+			m.createPaneStep = 1
+			m.dialogCursor = 0
+		}
+		return m, nil
+	}
+
+	if m.createPaneStep == 1 {
+		// Selected a plugin — advance to split direction
+		if m.selectedCategory >= len(cats) {
+			return m, nil
+		}
+		plugins := cats[m.selectedCategory].plugins
+		if m.dialogCursor >= len(plugins) {
+			return m, nil
+		}
+		m.selectedPlugin = plugins[m.dialogCursor].Name
+		m.createPaneStep = 2
+		m.dialogCursor = 0
+		return m, nil
+	}
+
+	// Step 2: selected placement
+	pluginName := m.selectedPlugin
+	m.dialog = dialogNone
+	m.createPaneStep = 0
+
+	tab := m.activeTabModel()
+	if tab == nil {
+		return m, nil
+	}
+	pane := tab.ActivePaneModel()
+	if pane == nil {
+		return m, nil
+	}
+
+	tabID := tab.ID
+	client := m.client
+
+	// Option 2: Replace current pane
+	if m.dialogCursor == 2 {
+		oldPaneID := pane.ID
+
+		// Turn the current leaf into a placeholder so the new pane
+		// fills the same layout position.
+		if leaf := tab.Root.FindLeaf(oldPaneID); leaf != nil {
+			leaf.Pane = nil
+			if m.pendingSplit == nil {
+				m.pendingSplit = make(map[string]*LayoutNode)
+			}
+			m.pendingSplit[tab.ID] = leaf
+		}
+
+		return m, func() tea.Msg {
+			msg, _ := ipc.NewMessage(ipc.MsgCreatePane, ipc.CreatePanePayload{
+				TabID:         tabID,
+				Type:          pluginName,
+				ReplacePaneID: oldPaneID,
+			})
+			client.Send(msg)
+			return nil
+		}
+	}
+
+	// Options 0/1: Split horizontal or vertical
+	var dir SplitDir
+	if m.dialogCursor == 0 {
+		dir = SplitHorizontal
+	} else {
+		dir = SplitVertical
+	}
+
+	placeholder := tab.SplitAtPane(pane.ID, dir)
+	if placeholder == nil {
+		return m, nil
+	}
+
+	if m.pendingSplit == nil {
+		m.pendingSplit = make(map[string]*LayoutNode)
+	}
+	m.pendingSplit[tab.ID] = placeholder
+
+	return m, func() tea.Msg {
+		msg, _ := ipc.NewMessage(ipc.MsgCreatePane, ipc.CreatePanePayload{
+			TabID: tabID,
+			Type:  pluginName,
+		})
+		client.Send(msg)
+		return nil
+	}
+}
+
+func (m Model) renderCreatePaneDialog() string {
+	var b strings.Builder
+
+	cats := m.createPaneCategories()
+
+	switch m.createPaneStep {
+	case 0:
+		// Step 0: Select category
+		b.WriteString(dialogTitle.Render("New Pane"))
+		b.WriteString("\n\n")
+
+		for i, cat := range cats {
+			cursor := "  "
+			style := dialogNormal
+			if i == m.dialogCursor {
+				cursor = "> "
+				style = dialogSelected
+			}
+			b.WriteString(cursor + style.Render(cat.label) + "\n")
+		}
+
+		if len(cats) == 0 {
+			b.WriteString("  " + dialogSubtle.Render("No plugins available") + "\n")
+		}
+
+		b.WriteByte('\n')
+		b.WriteString(dialogSubtle.Render("Esc cancel"))
+
+	case 1:
+		// Step 1: Select plugin within category
+		if m.selectedCategory < len(cats) {
+			cat := cats[m.selectedCategory]
+			b.WriteString(dialogTitle.Render(cat.label))
+			b.WriteString("\n\n")
+
+			for i, p := range cat.plugins {
+				cursor := "  "
+				style := dialogNormal
+				if i == m.dialogCursor {
+					cursor = "> "
+					style = dialogSelected
+				}
+				line := style.Render(p.DisplayName)
+				if p.Description != "" {
+					line += "  " + dialogSubtle.Render(p.Description)
+				}
+				b.WriteString(cursor + line + "\n")
+			}
+
+			b.WriteByte('\n')
+			b.WriteString(dialogSubtle.Render("Esc back"))
+		}
+
+	case 2:
+		// Step 2: Select split direction
+		b.WriteString(dialogTitle.Render("Split Direction"))
+		b.WriteString("\n\n")
+
+		dirs := []string{"Horizontal  (left | right)", "Vertical    (top / bottom)", "Replace current pane"}
+		for i, d := range dirs {
+			cursor := "  "
+			style := dialogNormal
+			if i == m.dialogCursor {
+				cursor = "> "
+				style = dialogSelected
+			}
+			b.WriteString(cursor + style.Render(d) + "\n")
+		}
+
+		b.WriteByte('\n')
+		b.WriteString(dialogSubtle.Render("Esc back"))
+	}
+
+	return b.String()
+}
+
+// --- Plugin error dialog ---
+
+func (m Model) handlePluginErrorKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc", "enter":
+		m.dialog = dialogNone
+		return m, nil
+	}
+	return m, nil
+}
+
+func (m Model) renderPluginErrorDialog() string {
+	var b strings.Builder
+
+	b.WriteString(dialogTitle.Render(m.pluginErrorTitle))
+	b.WriteString("\n\n")
+
+	// Render multi-line message
+	lines := strings.Split(m.pluginErrorMessage, "\n")
+	for _, line := range lines {
+		b.WriteString("  " + dialogNormal.Render(line) + "\n")
+	}
+
+	b.WriteByte('\n')
+	b.WriteString(dialogSubtle.Render("Enter/Esc dismiss"))
+
+	return b.String()
 }

--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -311,6 +311,10 @@ func resizeNode(n *LayoutNode, w, h int) {
 	if n == nil {
 		return
 	}
+	// Placeholder node (nil Pane, no children) — skip until filled.
+	if n.Pane == nil && n.Left == nil && n.Right == nil {
+		return
+	}
 	if n.IsLeaf() {
 		if w < minPaneW {
 			w = minPaneW

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -13,6 +13,7 @@ import (
 	"github.com/artyomsv/aethel/internal/clipboard"
 	"github.com/artyomsv/aethel/internal/config"
 	"github.com/artyomsv/aethel/internal/ipc"
+	"github.com/artyomsv/aethel/internal/plugin"
 )
 
 // chromeHeight is the vertical space consumed by tab bar (1) + status bar (1).
@@ -50,11 +51,25 @@ type PaneInfo struct {
 	TabID string
 	CWD   string
 	Name  string
+	Type  string
 }
 
 // resizeTickMsg fires after the debounce delay; seq tracks freshness.
 type resizeTickMsg struct {
 	seq int
+}
+
+// PluginErrorMsg is received when the daemon detects a plugin error pattern.
+type PluginErrorMsg struct {
+	PaneID  string
+	Title   string
+	Message string
+}
+
+// spinnerTickMsg advances the resuming spinner animation for a pane.
+type spinnerTickMsg struct {
+	paneID string
+	frame  int
 }
 
 var tabColors = []string{
@@ -76,6 +91,8 @@ const (
 	dialogSettings
 	dialogShortcuts
 	dialogConfirm
+	dialogCreatePane
+	dialogPluginError
 )
 
 type Model struct {
@@ -99,19 +116,33 @@ type Model struct {
 	dialogCursor    int                    // highlighted item in dialog
 	dialogEdit      bool                   // editing a settings value
 	dialogInput     string                 // text input buffer for editing
-	confirmKind     string                 // "pane" or "tab"
-	confirmID       string                 // ID of pane/tab to delete
-	confirmName     string                 // display name for confirmation
-	devMode         bool                   // true when AETHEL_HOME is set
+	confirmKind        string                 // "pane" or "tab"
+	confirmID          string                 // ID of pane/tab to delete
+	confirmName        string                 // display name for confirmation
+	devMode            bool                   // true when AETHEL_HOME is set
+	pluginRegistry     *plugin.Registry       // plugin registry (shared with daemon)
+	lastWidth          int                    // last known window width (for persistence)
+	lastHeight         int                    // last known window height (for persistence)
+	createPaneStep     int                    // 0=category, 1=plugin, 2=split direction
+	selectedCategory   int                    // selected category index in create pane dialog
+	selectedPlugin     string                 // selected plugin name in create pane dialog
+	pluginErrorTitle   string                 // title for plugin error dialog
+	pluginErrorMessage string                 // message for plugin error dialog
 }
 
-func NewModel(client *ipc.Client, cfg config.Config, version string) Model {
+func NewModel(client *ipc.Client, cfg config.Config, version string, registry *plugin.Registry) Model {
 	return Model{
-		client:  client,
-		cfg:     cfg,
-		version: version,
-		devMode: os.Getenv("AETHEL_HOME") != "",
+		client:         client,
+		cfg:            cfg,
+		version:        version,
+		devMode:        os.Getenv("AETHEL_HOME") != "",
+		pluginRegistry: registry,
 	}
+}
+
+// WindowSize returns the last known window dimensions for persistence.
+func (m Model) WindowSize() (width, height int) {
+	return m.lastWidth, m.lastHeight
 }
 
 func (m Model) Init() tea.Cmd {
@@ -125,6 +156,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		log.Printf("WindowSizeMsg: %dx%d", msg.Width, msg.Height)
 		m.pendingWidth = msg.Width
 		m.pendingHeight = msg.Height
+		m.lastWidth = msg.Width
+		m.lastHeight = msg.Height
 		m.resizeSeq++
 
 		// First resize: apply immediately for initial attach
@@ -208,11 +241,48 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, m.listenForMessages()
 
+	case spinnerTickMsg:
+		// Advance spinner frame for the resuming/preparing pane
+		for _, tab := range m.tabs {
+			if tab.Root == nil {
+				continue
+			}
+			if leaf := tab.Root.FindLeaf(msg.paneID); leaf != nil && (leaf.Pane.resuming || leaf.Pane.preparing) {
+				// Auto-clear after minimum display + no more ghost state
+				if !leaf.Pane.ghost && time.Since(leaf.Pane.resumeStart) >= 2*time.Second {
+					leaf.Pane.resuming = false
+					leaf.Pane.preparing = false
+					return m, nil
+				}
+				leaf.Pane.spinnerFrame = msg.frame
+				nextFrame := msg.frame + 1
+				paneID := msg.paneID
+				return m, tea.Tick(100*time.Millisecond, func(t time.Time) tea.Msg {
+					return spinnerTickMsg{paneID: paneID, frame: nextFrame}
+				})
+			}
+		}
+		return m, nil
+
+	case PluginErrorMsg:
+		m.dialog = dialogPluginError
+		m.pluginErrorTitle = msg.Title
+		m.pluginErrorMessage = msg.Message
+		return m, m.listenForMessages()
+
 	case WorkspaceStateMsg:
 		log.Printf("WorkspaceState: %d tabs, %d panes", len(msg.Tabs), len(msg.Panes))
-		m.applyWorkspaceState(msg)
+		newPaneIDs := m.applyWorkspaceState(msg)
 		m.resizeTabs()
-		return m, tea.Batch(m.listenForMessages(), m.resizeAllPanes(), m.sendAllLayouts())
+		cmds := []tea.Cmd{m.listenForMessages(), m.resizeAllPanes(), m.sendAllLayouts()}
+		// Start spinner ticks for newly restored panes
+		for _, paneID := range newPaneIDs {
+			id := paneID
+			cmds = append(cmds, tea.Tick(100*time.Millisecond, func(t time.Time) tea.Msg {
+				return spinnerTickMsg{paneID: id, frame: 1}
+			}))
+		}
+		return m, tea.Batch(cmds...)
 
 	case listenContinueMsg:
 		return m, m.listenForMessages()
@@ -373,6 +443,13 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case key == kb.Paste:
 		return m, m.pasteClipboard()
 
+	case key == "ctrl+n":
+		m.dialog = dialogCreatePane
+		m.dialogCursor = 0
+		m.createPaneStep = 0
+		m.selectedCategory = 0
+		return m, nil
+
 	case key == "f1":
 		m.dialog = dialogAbout
 		m.dialogCursor = 0
@@ -479,12 +556,23 @@ func (m *Model) handlePaneOutput(msg PaneOutputMsg) tea.Cmd {
 		}
 		if leaf := tab.Root.FindLeaf(msg.PaneID); leaf != nil {
 			oldCWD := leaf.Pane.CWD
-			leaf.Pane.AppendOutput(msg.Data)
 			if msg.Ghost && m.cfg.GhostBuffer.Dimmed {
 				leaf.Pane.ghost = true
 			} else if !msg.Ghost {
+				// Transitioning from ghost/restored to live output —
+				// reset VT emulator BEFORE processing data so cursor
+				// position isn't polluted by ghost buffer ANSI sequences.
+				if leaf.Pane.ghost {
+					leaf.Pane.ResetVT()
+				}
 				leaf.Pane.ghost = false
+				// Clear spinner labels after minimum display time (2s)
+				if time.Since(leaf.Pane.resumeStart) >= 2*time.Second {
+					leaf.Pane.resuming = false
+					leaf.Pane.preparing = false
+				}
 			}
+			leaf.Pane.AppendOutput(msg.Data)
 			if leaf.Pane.CWD != oldCWD && leaf.Pane.CWD != "" {
 				return m.updatePaneCWD(msg.PaneID, leaf.Pane.CWD)
 			}
@@ -494,7 +582,11 @@ func (m *Model) handlePaneOutput(msg PaneOutputMsg) tea.Cmd {
 	return nil
 }
 
-func (m *Model) applyWorkspaceState(state WorkspaceStateMsg) {
+// applyWorkspaceState rebuilds the TUI state from daemon data.
+// Returns IDs of newly created panes (for spinner activation).
+func (m *Model) applyWorkspaceState(state WorkspaceStateMsg) []string {
+	var newPaneIDs []string
+
 	// Index existing tabs and panes for preservation.
 	existingTabs := make(map[string]*TabModel)
 	existingPanes := make(map[string]*PaneModel)
@@ -522,6 +614,10 @@ func (m *Model) applyWorkspaceState(state WorkspaceStateMsg) {
 			// New tab that doesn't exist locally — try to restore layout from daemon.
 			if len(tabInfo.Layout) > 0 {
 				tab = m.restoreTabLayout(tab, tabInfo, paneMap, existingPanes)
+				// All panes in a restored tab are new
+				for _, pid := range tabInfo.Panes {
+					newPaneIDs = append(newPaneIDs, pid)
+				}
 				m.tabs = append(m.tabs, tab)
 				continue
 			}
@@ -556,6 +652,7 @@ func (m *Model) applyWorkspaceState(state WorkspaceStateMsg) {
 					if leaf := tab.Root.FindLeaf(paneID); leaf != nil {
 						leaf.Pane.Name = info.Name
 						leaf.Pane.CWD = info.CWD
+						leaf.Pane.Type = info.Type
 					}
 				}
 				continue
@@ -565,10 +662,18 @@ func (m *Model) applyWorkspaceState(state WorkspaceStateMsg) {
 			pane, ok := existingPanes[paneID]
 			if !ok {
 				pane = NewPaneModel(paneID, m.replayBufSize())
+				pane.resumeStart = time.Now()
+				if len(existingTabs) > 0 {
+					pane.preparing = true // new pane created while TUI is running
+				} else {
+					pane.resuming = true // restored pane on initial connect
+				}
+				newPaneIDs = append(newPaneIDs, paneID)
 			}
 			if info, ok := paneMap[paneID]; ok {
 				pane.Name = info.Name
 				pane.CWD = info.CWD
+				pane.Type = info.Type
 			}
 
 			// Try to fill a pending split placeholder first.
@@ -608,6 +713,7 @@ func (m *Model) applyWorkspaceState(state WorkspaceStateMsg) {
 	if m.activeTab >= len(m.tabs) {
 		m.activeTab = max(0, len(m.tabs)-1)
 	}
+	return newPaneIDs
 }
 
 // restoreTabLayout rebuilds a tab's layout tree from serialized daemon state.
@@ -621,10 +727,13 @@ func (m *Model) restoreTabLayout(tab *TabModel, tabInfo TabInfo, paneMap map[str
 		pane, ok := existingPanes[paneID]
 		if !ok {
 			pane = NewPaneModel(paneID, m.replayBufSize())
+			pane.resuming = true
+			pane.resumeStart = time.Now()
 		}
 		if info, ok := paneMap[paneID]; ok {
 			pane.Name = info.Name
 			pane.CWD = info.CWD
+			pane.Type = info.Type
 		}
 		paneModels[paneID] = pane
 	}
@@ -856,6 +965,8 @@ func (m *Model) hitTestTab(x int) int {
 		name := tab.Name
 		if m.renaming && i == m.activeTab {
 			name = m.renameInput + "▎"
+		} else {
+			name = fmt.Sprintf("%d:%s", i+1, name)
 		}
 
 		style := inactiveTabStyle
@@ -972,7 +1083,7 @@ func (m Model) renderStatusBar() string {
 	}
 
 	// Right side: keybinding hints + version
-	right := "^T new | ^W pane | A-W tab | F1 help | ^Q quit | v" + m.version
+	right := "^T tab | ^N pane | ^W close | F1 help | ^Q quit | v" + m.version
 	if m.devMode {
 		right = "[dev] " + right
 	}
@@ -1033,6 +1144,15 @@ func (m Model) listenForMessages() tea.Cmd {
 			msg.DecodePayload(&raw)
 			return parseWorkspaceState(raw)
 
+		case ipc.MsgPluginError:
+			var payload ipc.PluginErrorPayload
+			msg.DecodePayload(&payload)
+			return PluginErrorMsg{
+				PaneID:  payload.PaneID,
+				Title:   payload.Title,
+				Message: payload.Message,
+			}
+
 		default:
 			// Unknown message type — keep listening
 			return listenContinueMsg{}
@@ -1090,6 +1210,9 @@ func parseWorkspaceState(raw map[string]any) WorkspaceStateMsg {
 				}
 				if name, ok := pm["name"].(string); ok {
 					pi.Name = name
+				}
+				if typ, ok := pm["type"].(string); ok {
+					pi.Type = typ
 				}
 				state.Panes = append(state.Panes, pi)
 			}

--- a/internal/tui/pane.go
+++ b/internal/tui/pane.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"net/url"
 	"strings"
+	"time"
 
 	uv "github.com/charmbracelet/ultraviolet"
 
@@ -13,8 +14,12 @@ import (
 	"github.com/artyomsv/aethel/internal/ringbuf"
 )
 
+// spinnerFrames are braille characters cycled for the resuming indicator.
+var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+
 type PaneModel struct {
 	ID            string
+	Type          string // plugin type ("terminal", "claude-code", etc.)
 	Name          string // user-given name (empty if not set)
 	CWD           string // current working directory from daemon
 	vt            *vt.SafeEmulator
@@ -25,6 +30,10 @@ type PaneModel struct {
 	rawBuf        *ringbuf.RingBuffer // raw PTY bytes for resize replay
 	cursorVisible bool                // tracks shell's DECTCEM state
 	ghost         bool                // true while showing restored content
+	resuming      bool                // true while waiting for first live output after restore
+	preparing     bool                // true for newly created panes (not restored)
+	resumeStart   time.Time           // when resuming/preparing started (minimum display duration)
+	spinnerFrame  int                 // current frame index in spinnerFrames
 }
 
 func NewPaneModel(id string, bufSize int) *PaneModel {
@@ -51,6 +60,25 @@ func NewPaneModel(id string, bufSize int) *PaneModel {
 func (p *PaneModel) AppendOutput(data []byte) {
 	p.rawBuf.Write(data)
 	p.vt.Write(data)
+}
+
+// ResetVT creates a fresh VT emulator at the current dimensions, clearing
+// ghost buffer state so live output starts with a clean cursor position.
+func (p *PaneModel) ResetVT() {
+	w, h := p.vt.Width(), p.vt.Height()
+	em := vt.NewSafeEmulator(w, h)
+	em.SetScrollbackSize(10000)
+	em.SetCallbacks(vt.Callbacks{
+		CursorVisibility: func(visible bool) {
+			p.cursorVisible = visible
+		},
+		WorkingDirectory: func(dir string) {
+			p.CWD = parseOSC7Path(dir)
+		},
+	})
+	p.vt = em
+	p.rawBuf.Reset()
+	p.cursorVisible = true
 }
 
 func (p *PaneModel) ResizeVT(cols, rows int) {
@@ -97,7 +125,7 @@ func (p *PaneModel) View() string {
 	if p.Active {
 		borderColor = lipgloss.Color("57")
 	}
-	if p.ghost {
+	if p.ghost || p.resuming || p.preparing {
 		borderColor = lipgloss.Color("95") // muted purple — distinct but not jarring
 	}
 
@@ -123,18 +151,28 @@ func (p *PaneModel) View() string {
 	body := bodyStyle.Render(content)
 
 	// Manual top border: CWD on the left, pane name on the right.
-	topLine := buildTopBorder(p.Width, p.CWD, p.Name, borderColor, p.ghost)
+	topLine := buildTopBorder(p.Width, p.CWD, p.Name, borderColor, p.ghost, p.resuming, p.preparing, p.spinnerFrame)
 
 	return topLine + "\n" + body
 }
 
-func buildTopBorder(width int, cwd, name string, color lipgloss.TerminalColor, ghost bool) string {
+func buildTopBorder(width int, cwd, name string, color lipgloss.TerminalColor, ghost, resuming, preparing bool, spinnerFrame int) string {
 	if ghost {
 		if name == "" {
 			name = "restored"
 		} else {
 			name = name + " · restored"
 		}
+	}
+
+	// Spinner overrides the right label temporarily
+	if resuming || preparing {
+		frame := spinnerFrames[spinnerFrame%len(spinnerFrames)]
+		label := "resuming..."
+		if preparing {
+			label = "preparing..."
+		}
+		name = frame + " " + label
 	}
 
 	style := lipgloss.NewStyle().Foreground(color)
@@ -144,7 +182,7 @@ func buildTopBorder(width int, cwd, name string, color lipgloss.TerminalColor, g
 		return style.Render(b.TopLeft + b.TopRight)
 	}
 
-	// Right label: pane name (only if it fits with padding).
+	// Right label: pane name or spinner (only if it fits with padding).
 	rightLabel := ""
 	rightLen := 0
 	if name != "" && len([]rune(name))+4 <= innerW {
@@ -201,7 +239,10 @@ func (p *PaneModel) renderContent() string {
 	if p.scrollBack == 0 {
 		// Live view — use Render() for full color support
 		content := p.vt.Render()
-		if p.Active && p.cursorVisible {
+		// Only overlay cursor for terminal panes — TUI apps (Claude Code etc.)
+		// render their own cursor.
+		isTerminal := p.Type == "" || p.Type == "terminal"
+		if p.Active && p.cursorVisible && isTerminal {
 			content = p.insertCursor(content)
 		}
 		return content

--- a/techdebt/3-2-daemon-restore-and-dialog-logic-untested.md
+++ b/techdebt/3-2-daemon-restore-and-dialog-logic-untested.md
@@ -16,6 +16,8 @@ Several non-trivial functions added or changed in this PR have no direct unit te
 - `isValidHexID(id, prefix string) bool` — ID validation used by `restoreWorkspace()` to guard against corrupt snapshot data. The logic (prefix match + 8 hex chars) is easy to get wrong at boundaries.
 - `buildWorkspaceState()` — serializes the full session to a `map[string]any`. No test verifies the key names, layout embedding, or pane name omission logic.
 - `snapshotDebounced()` — debounce path (TOCTOU-safe via lock). The 1s boundary behaviour is not tested.
+- `spawnPane()` — core plugin dispatch logic (strategy selection, UUID generation for `preassign_id`, resume arg expansion, shell integration). 80+ lines with multiple branches, no unit test.
+- `DetectAvailability()` — registry method that extracts binary name from detect commands and runs `exec.LookPath`. Not directly tested.
 
 **`internal/tui/dialog.go`**
 - `handleConfirmKey()` — confirm/cancel logic for destructive pane/tab operations. The "y" path sends IPC messages; no test covers the state machine transitions.


### PR DESCRIPTION
…resume

Complete M3 (Resume Engine) and M4 (Plugin System) milestones:

- Plugin system with registry, TOML loading, 4 built-in plugins (terminal, claude-code, ssh, stripe)
- Pane creation dialog (Ctrl+N) with category/plugin/split selection
- Session resume via pre-assigned UUIDs for Claude Code
- Error handler pattern matching with help dialogs
- Atomic pane replacement (ReplacePane)
- Window size persistence (Win32 MoveWindow / xterm sequence)
- Resuming/preparing spinner on pane border
- Ghost buffer replay skipped for TUI app panes
- Platform-specific cursor handling for non-terminal panes