### PR TITLE
feat(tui): add pane focus mode (M6)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -119,6 +119,6 @@ AETHEL_HOME=/custom/path ./aethel  # Arbitrary data directory
 - **M3 (Done):** Resume engine — preassign_id strategy for Claude Code, session_scrape for tools with output tokens, rerun for SSH/Stripe
 - **M4 (Done):** Plugin system — typed panes, TOML plugins, plugin registry, error handlers, pane creation dialog (Ctrl+N), 4 built-in plugins: terminal + claude-code (production), ssh + stripe (POC)
 - **M5:** Polish — JSON transformer, observability, encrypted tokens
-- **M6:** Pane Focus — full-window focus mode for single pane
+- **M6 (Done):** Pane Focus — F11 toggles active pane full-screen (`TabModel.focusMode`). Layout tree stays intact; `Resize()`/`View()` skip non-active panes. Pane nav disabled in focus. Split/close auto-exit focus. `[focus]` in status bar. Not persisted
 - **M7:** Pane Notes — side-by-side note-taking linked to panes
 - **M8 (Done):** Bubble Tea v2 + Lipgloss v2 migration — declarative View, typed mouse events, platform-native clipboard (Win32/pbcopy/xclip), text selection (keyboard + mouse), bracketed paste

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -119,6 +119,6 @@ AETHEL_HOME=/custom/path ./aethel  # Arbitrary data directory
 - **M3 (Done):** Resume engine — preassign_id strategy for Claude Code, session_scrape for tools with output tokens, rerun for SSH/Stripe
 - **M4 (Done):** Plugin system — typed panes, TOML plugins, plugin registry, error handlers, pane creation dialog (Ctrl+N), 4 built-in plugins: terminal + claude-code (production), ssh + stripe (POC)
 - **M5:** Polish — JSON transformer, observability, encrypted tokens
-- **M6 (Done):** Pane Focus — F11 toggles active pane full-screen (`TabModel.focusMode`). Layout tree stays intact; `Resize()`/`View()` skip non-active panes. Pane nav disabled in focus. Split/close auto-exit focus. `[focus]` in status bar. Not persisted
+- **M6 (Done):** Pane Focus — Ctrl+E toggles active pane full-screen (`TabModel.focusMode`). Layout tree stays intact; `Resize()`/`View()` skip non-active panes. `* FOCUS *` in pane top border, `[focus]` in status bar. Pane nav disabled in focus. Split/close auto-exit focus. Not persisted
 - **M7:** Pane Notes — side-by-side note-taking linked to panes
 - **M8 (Done):** Bubble Tea v2 + Lipgloss v2 migration — declarative View, typed mouse events, platform-native clipboard (Win32/pbcopy/xclip), text selection (keyboard + mouse), bracketed paste

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Pane focus mode (M6)** — F11 toggles active pane to full-screen; other panes keep running in background; `[focus]` status bar indicator; splits/close auto-exit focus
-- `focus_pane` keybinding config field (default `f11`)
+- **Pane focus mode (M6)** — Ctrl+E toggles active pane to full-screen; other panes keep running in background; `* FOCUS *` border label; `[focus]` status bar indicator; splits/close auto-exit focus
+- `focus_pane` keybinding config field (default `ctrl+e`)
 
 ## [0.8.0] - 2026-03-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Pane focus mode (M6)** — F11 toggles active pane to full-screen; other panes keep running in background; `[focus]` status bar indicator; splits/close auto-exit focus
+- `focus_pane` keybinding config field (default `f11`)
+
 ## [0.8.0] - 2026-03-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for development guidelines.
 | **M3: Resume Engine** | Done | Regex scrapers, token extraction, AI session resume via pre-assigned UUIDs |
 | **M4: Plugin System** | Done | TOML plugins, typed panes, pane creation dialog, error handlers, window size persistence |
 | **M5: Polish** | Planned | JSON transformer, observability, encrypted tokens, OS service integration |
-| **M6: Pane Focus** | Planned | Full-window focus mode for single pane |
+| **M6: Pane Focus** | Done | F11 toggles active pane full-screen, other panes keep running |
 | **M7: Pane Notes** | Planned | Side-by-side note-taking linked to panes |
 | **M8: Bubble Tea v2** | Done | Bubble Tea v2/Lipgloss v2 migration, text selection, clipboard, editor enhancements |
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ aethel
 | `Alt+C` | Cycle tab color |
 | `Alt+PgUp` / `Alt+PgDn` | Scroll page up/down |
 | `Ctrl+V` | Paste from clipboard |
+| `Ctrl+E` | Toggle focus mode |
 | `Shift+Arrows` | Select text |
 | `Enter` | Copy selection |
 | `Ctrl+Q` | Quit |
@@ -175,6 +176,7 @@ cycle_tab_color = "alt+c"
 scroll_page_up = "alt+pgup"
 scroll_page_down = "alt+pgdown"
 paste = "ctrl+v"
+focus_pane = "ctrl+e"
 ```
 
 ## Project Structure
@@ -220,7 +222,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for development guidelines.
 | **M3: Resume Engine** | Done | Regex scrapers, token extraction, AI session resume via pre-assigned UUIDs |
 | **M4: Plugin System** | Done | TOML plugins, typed panes, pane creation dialog, error handlers, window size persistence |
 | **M5: Polish** | Planned | JSON transformer, observability, encrypted tokens, OS service integration |
-| **M6: Pane Focus** | Done | F11 toggles active pane full-screen, other panes keep running |
+| **M6: Pane Focus** | Done | Ctrl+E toggles active pane full-screen, other panes keep running |
 | **M7: Pane Notes** | Planned | Side-by-side note-taking linked to panes |
 | **M8: Bubble Tea v2** | Done | Bubble Tea v2/Lipgloss v2 migration, text selection, clipboard, editor enhancements |
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -86,12 +86,12 @@ Key changes:
 ---
 
 ### M6: Pane Focus Mode
-> Full-window focus for single pane (F11 toggle).
+> Full-window focus for single pane (Ctrl+E toggle).
 
-F11 toggles the active pane to fill the entire tab content area. Other panes keep running in the background, receiving PTY output. The layout tree stays intact — focus mode is a pure rendering toggle on `TabModel.focusMode`.
+Ctrl+E toggles the active pane to fill the entire tab content area. Other panes keep running in the background, receiving PTY output. The layout tree stays intact — focus mode is a pure rendering toggle on `TabModel.focusMode`.
 
 Key behaviors:
-- **F11** toggles focus on/off (configurable via `focus_pane` keybinding)
+- **Ctrl+E** toggles focus on/off (configurable via `focus_pane` keybinding)
 - Active pane resized to full tab dimensions; VT emulator + daemon PTY updated
 - `[focus]` indicator in status bar
 - Pane navigation (Tab/Shift+Tab) disabled in focus mode

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -85,19 +85,22 @@ Key changes:
 
 ---
 
-## Planned
-
 ### M6: Pane Focus Mode
+> Full-window focus for single pane (F11 toggle).
 
-Switch the active pane to full-window mode, hiding all other panes. Gives the user maximum screen space for focused work in a single pane.
+F11 toggles the active pane to fill the entire tab content area. Other panes keep running in the background, receiving PTY output. The layout tree stays intact — focus mode is a pure rendering toggle on `TabModel.focusMode`.
 
-**Behavior:**
-- Keybinding (e.g., `Alt+F` or `F11`) toggles focus mode on/off
-- In focus mode: active pane fills the entire tab content area (no splits visible)
-- Other panes remain alive in the background — they continue running, receiving PTY output
-- Status bar shows a focus indicator (e.g., `[focus]`)
-- Exiting focus mode restores the previous split layout exactly
-- Focus state is NOT persisted — exiting Aethel always returns to normal layout
+Key behaviors:
+- **F11** toggles focus on/off (configurable via `focus_pane` keybinding)
+- Active pane resized to full tab dimensions; VT emulator + daemon PTY updated
+- `[focus]` indicator in status bar
+- Pane navigation (Tab/Shift+Tab) disabled in focus mode
+- Split (Alt+H/V) and close (Ctrl+W) auto-exit focus mode
+- Focus state is NOT persisted — restarting Aethel returns to normal layout
+
+---
+
+## Planned
 
 ### M7: Pane Notes
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -110,7 +110,7 @@ func Default() Config {
 			Paste:           "ctrl+v",
 			JSONTransform:   "ctrl+j",
 			QuickActions:    "ctrl+a",
-			FocusPane:       "f11",
+			FocusPane:       "ctrl+e",
 		},
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -64,6 +64,7 @@ type KeybindingsConfig struct {
 	Paste           string `toml:"paste"`
 	JSONTransform   string `toml:"json_transform"`
 	QuickActions    string `toml:"quick_actions"`
+	FocusPane       string `toml:"focus_pane"`
 }
 
 func Default() Config {
@@ -109,6 +110,7 @@ func Default() Config {
 			Paste:           "ctrl+v",
 			JSONTransform:   "ctrl+j",
 			QuickActions:    "ctrl+a",
+			FocusPane:       "f11",
 		},
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -23,6 +23,9 @@ func TestLoadDefaults(t *testing.T) {
 	if cfg.Keybindings.NewTab != "ctrl+t" {
 		t.Errorf("expected new_tab=ctrl+t, got %s", cfg.Keybindings.NewTab)
 	}
+	if cfg.Keybindings.FocusPane != "ctrl+e" {
+		t.Errorf("expected focus_pane=ctrl+e, got %s", cfg.Keybindings.FocusPane)
+	}
 }
 
 func TestLoadFromFile(t *testing.T) {

--- a/internal/tui/dialog.go
+++ b/internal/tui/dialog.go
@@ -160,6 +160,7 @@ func shortcutsList(m *Model) []struct{ key, desc string } {
 		{kb.ScrollPageUp, "Scroll page up"},
 		{kb.ScrollPageDown, "Scroll page down"},
 		{kb.Paste, "Paste clipboard"},
+		{kb.FocusPane, "Toggle focus mode"},
 		{"Ctrl+N", "New typed pane"},
 		{"Alt+1..9", "Switch to tab N"},
 		{"F1", "Help / About"},

--- a/internal/tui/dialog.go
+++ b/internal/tui/dialog.go
@@ -23,14 +23,44 @@ const dialogWidth = 50
 const disclaimerWidth = 60
 
 // disclaimerTips are shown randomly in the startup disclaimer dialog.
-var disclaimerTips = []struct{ title, body string }{
-	{"Quick Navigation", "Ctrl+Arrow jumps words, Ctrl+Alt+Arrow jumps 3 words.\nCtrl+Up/Down jumps paragraphs in the editor."},
-	{"Split Panes", "Alt+H splits horizontal, Alt+V splits vertical.\nTab/Shift+Tab cycles between panes."},
-	{"Typed Panes", "Ctrl+N creates panes with specific tools (SSH, Claude Code).\nPlugins are configurable via F1 > Plugins."},
-	{"Session Persistence", "Your workspace survives reboots -- tabs, panes, and scroll\nhistory are automatically saved and restored."},
-	{"Pane Management", "F2 renames tabs, Alt+F2 renames panes.\nCtrl+W closes pane, Alt+W closes tab."},
-	{"Text Selection", "Shift+Arrows selects text, Enter copies to clipboard.\nCtrl+V pastes. Works in terminal panes and editors."},
-	{"Customization", "Edit ~/.aethel/config.toml to change keybindings,\nscroll speed, and other preferences. Press F1 for help."},
+// Each body line is rendered as a bullet point.
+var disclaimerTips = []struct {
+	title string
+	items []string
+}{
+	{"Quick Navigation", []string{
+		"Ctrl+Arrow jumps words",
+		"Ctrl+Alt+Arrow jumps 3 words",
+		"Ctrl+Up/Down jumps paragraphs",
+	}},
+	{"Split Panes", []string{
+		"Alt+H splits horizontal",
+		"Alt+V splits vertical",
+		"Tab/Shift+Tab cycles between panes",
+	}},
+	{"Typed Panes", []string{
+		"Ctrl+N creates typed panes (SSH, Claude)",
+		"Plugins configurable via F1 > Plugins",
+	}},
+	{"Session Persistence", []string{
+		"Workspace survives reboots",
+		"Tabs, panes, and history auto-restored",
+	}},
+	{"Pane Management", []string{
+		"F2 renames tabs, Alt+F2 renames panes",
+		"Ctrl+W closes pane, Alt+W closes tab",
+		"Ctrl+E toggles focus mode",
+	}},
+	{"Text Selection", []string{
+		"Shift+Arrows selects text",
+		"Enter copies selection to clipboard",
+		"Ctrl+V pastes from clipboard",
+	}},
+	{"Customization", []string{
+		"Edit ~/.aethel/config.toml for settings",
+		"All keybindings are configurable",
+		"Press F1 for help and shortcuts",
+	}},
 }
 
 var (
@@ -482,8 +512,8 @@ func (m Model) renderDisclaimerDialog() string {
 	tip := disclaimerTips[m.disclaimerTipIdx]
 	b.WriteString(dialogSelected.Render("  Tip: " + tip.title))
 	b.WriteByte('\n')
-	for _, line := range strings.Split(tip.body, "\n") {
-		b.WriteString(dialogNormal.Render("  " + line))
+	for _, item := range tip.items {
+		b.WriteString(dialogNormal.Render("    - " + item))
 		b.WriteByte('\n')
 	}
 	b.WriteByte('\n')

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -277,7 +277,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.selection == nil {
 				// No drag — treat as click for pane focus
 				tab := m.activeTabModel()
-				if tab != nil && tab.Root != nil {
+				if tab != nil && tab.Root != nil && !tab.FocusMode() {
 					tabH := m.height - chromeHeight
 					if pane := tab.Root.FindPaneAt(m.mouseStartX, m.mouseStartY, 0, 1, m.width, tabH); pane != nil {
 						if old := tab.ActivePaneModel(); old != nil {
@@ -413,10 +413,11 @@ func (m Model) View() tea.View {
 		if m.activeTab < len(m.tabs) {
 			tab := m.tabs[m.activeTab]
 			tab.Resize(m.width, tabH)
-			// Pass selection to panes for rendering
+			// Pass per-frame state to panes for rendering
 			if tab.Root != nil {
 				for _, pane := range tab.Root.Leaves() {
 					pane.activeSel = m.selection
+					pane.focusMode = tab.FocusMode() && pane.ID == tab.ActivePane
 				}
 			}
 			sections = append(sections, tab.View())
@@ -521,13 +522,13 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 
 	case key == kb.SplitHorizontal:
 		if tab := m.activeTabModel(); tab != nil && tab.FocusMode() {
-			tab.focusMode = false
+			tab.ExitFocus()
 		}
 		return m, m.splitPane(SplitHorizontal)
 
 	case key == kb.SplitVertical:
 		if tab := m.activeTabModel(); tab != nil && tab.FocusMode() {
-			tab.focusMode = false
+			tab.ExitFocus()
 		}
 		return m, m.splitPane(SplitVertical)
 
@@ -592,6 +593,7 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	case key == kb.FocusPane:
 		if tab := m.activeTabModel(); tab != nil && tab.Root != nil {
 			tab.ToggleFocus()
+			m.resizeTabs()
 			return m, tea.Batch(tea.ClearScreen, m.resizeAllPanes())
 		}
 		return m, nil
@@ -810,7 +812,7 @@ func (m *Model) applyWorkspaceState(state WorkspaceStateMsg) []string {
 
 		// Exit focus mode if the tree was reduced to a single pane or empty.
 		if tab.FocusMode() && (tab.Root == nil || tab.Root.IsLeaf()) {
-			tab.focusMode = false
+			tab.ExitFocus()
 		}
 
 		// Add panes the daemon has but the tree doesn't.

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -520,9 +520,15 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m, tea.ClearScreen
 
 	case key == kb.SplitHorizontal:
+		if tab := m.activeTabModel(); tab != nil && tab.FocusMode() {
+			tab.focusMode = false
+		}
 		return m, m.splitPane(SplitHorizontal)
 
 	case key == kb.SplitVertical:
+		if tab := m.activeTabModel(); tab != nil && tab.FocusMode() {
+			tab.focusMode = false
+		}
 		return m, m.splitPane(SplitVertical)
 
 	case key == kb.RenameTab:
@@ -569,19 +575,26 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case key == kb.NextPane:
-		if tab := m.activeTabModel(); tab != nil {
+		if tab := m.activeTabModel(); tab != nil && !tab.FocusMode() {
 			tab.NextPane()
 		}
 		return m, nil
 
 	case key == kb.PrevPane:
-		if tab := m.activeTabModel(); tab != nil {
+		if tab := m.activeTabModel(); tab != nil && !tab.FocusMode() {
 			tab.PrevPane()
 		}
 		return m, nil
 
 	case key == kb.Paste:
 		return m, m.pasteClipboard()
+
+	case key == kb.FocusPane:
+		if tab := m.activeTabModel(); tab != nil && tab.Root != nil {
+			tab.ToggleFocus()
+			return m, tea.Batch(tea.ClearScreen, m.resizeAllPanes())
+		}
+		return m, nil
 
 	case key == "ctrl+n":
 		m.dialog = dialogCreatePane
@@ -793,6 +806,11 @@ func (m *Model) applyWorkspaceState(state WorkspaceStateMsg) []string {
 					tab.RemovePane(id)
 				}
 			}
+		}
+
+		// Exit focus mode if the tree was reduced to a single pane or empty.
+		if tab.FocusMode() && (tab.Root == nil || tab.Root.IsLeaf()) {
+			tab.focusMode = false
 		}
 
 		// Add panes the daemon has but the tree doesn't.
@@ -1281,6 +1299,9 @@ func (m Model) renderStatusBar() string {
 				}
 			}
 			left = fmt.Sprintf("%s  %s", displayPath, paneInfo)
+			if tab.FocusMode() {
+				left = "[focus] " + left
+			}
 			if pane.scrollBack > 0 {
 				left += fmt.Sprintf("  ↑%d", pane.scrollBack)
 			}

--- a/internal/tui/pane.go
+++ b/internal/tui/pane.go
@@ -36,6 +36,7 @@ type PaneModel struct {
 	resumeStart   time.Time           // when resuming/preparing started (minimum display duration)
 	spinnerFrame  int                 // current frame index in spinnerFrames
 	activeSel     *Selection          // set by Model before View() for selection rendering
+	focusMode     bool                // set by Model before View() when in focus mode
 }
 
 func NewPaneModel(id string, bufSize int) *PaneModel {
@@ -155,12 +156,12 @@ func (p *PaneModel) View() string {
 	body := bodyStyle.Render(content)
 
 	// Manual top border: CWD on the left, pane name on the right.
-	topLine := buildTopBorder(p.Width, p.CWD, p.Name, borderColor, p.ghost, p.resuming, p.preparing, p.spinnerFrame)
+	topLine := buildTopBorder(p.Width, p.CWD, p.Name, borderColor, p.ghost, p.resuming, p.preparing, p.focusMode, p.spinnerFrame)
 
 	return topLine + "\n" + body
 }
 
-func buildTopBorder(width int, cwd, name string, color color.Color, ghost, resuming, preparing bool, spinnerFrame int) string {
+func buildTopBorder(width int, cwd, name string, color color.Color, ghost, resuming, preparing, focus bool, spinnerFrame int) string {
 	if ghost {
 		if name == "" {
 			name = "restored"
@@ -217,6 +218,27 @@ func buildTopBorder(width int, cwd, name string, color color.Color, ghost, resum
 	dashes := innerW - leftLen - rightLen
 	if dashes < 0 {
 		dashes = 0
+	}
+
+	// Focus mode: center "* FOCUS *" relative to the full border width
+	if focus {
+		focusLabel := "* FOCUS *"
+		focusLen := len([]rune(focusLabel))
+		if dashes >= focusLen+2 {
+			// Center position relative to full innerW, then subtract left/right label offsets
+			centerPos := (innerW - focusLen) / 2
+			leftDash := centerPos - leftLen
+			if leftDash < 1 {
+				leftDash = 1
+			}
+			rightDash := dashes - focusLen - leftDash
+			if rightDash < 0 {
+				rightDash = 0
+			}
+			return style.Render(b.TopLeft + leftLabel +
+				strings.Repeat(b.Top, leftDash) + focusLabel + strings.Repeat(b.Top, rightDash) +
+				rightLabel + b.TopRight)
+		}
 	}
 
 	return style.Render(b.TopLeft + leftLabel + strings.Repeat(b.Top, dashes) + rightLabel + b.TopRight)

--- a/internal/tui/pane_test.go
+++ b/internal/tui/pane_test.go
@@ -1,0 +1,56 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+)
+
+func TestBuildTopBorderFocus(t *testing.T) {
+	color := lipgloss.Color("57")
+
+	tests := []struct {
+		name      string
+		width     int
+		focus     bool
+		wantLabel bool
+	}{
+		{"focus wide", 60, true, true},
+		{"focus narrow fits", 20, true, true},
+		{"focus too narrow", 12, true, false},
+		{"no focus wide", 60, false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildTopBorder(tt.width, "", "", color, false, false, false, tt.focus, 0)
+			hasLabel := strings.Contains(result, "* FOCUS *")
+			if hasLabel != tt.wantLabel {
+				t.Errorf("width=%d focus=%v: hasLabel=%v, want %v", tt.width, tt.focus, hasLabel, tt.wantLabel)
+			}
+		})
+	}
+}
+
+func TestBuildTopBorderFocusCentered(t *testing.T) {
+	color := lipgloss.Color("57")
+	result := buildTopBorder(40, "", "", color, false, false, false, true, 0)
+
+	// Find the focus label position — dashes should be roughly equal on both sides
+	idx := strings.Index(result, "* FOCUS *")
+	if idx < 0 {
+		t.Fatal("focus label not found")
+	}
+
+	// The label should be roughly centered (within 1 char tolerance due to odd widths)
+	before := result[:idx]
+	after := result[idx+len("* FOCUS *"):]
+	// Count only border characters (─), not corner chars
+	leftDashes := strings.Count(before, "─")
+	rightDashes := strings.Count(after, "─")
+	diff := leftDashes - rightDashes
+	if diff < -1 || diff > 1 {
+		t.Errorf("label not centered: left dashes=%d, right dashes=%d", leftDashes, rightDashes)
+	}
+}

--- a/internal/tui/tab.go
+++ b/internal/tui/tab.go
@@ -9,7 +9,7 @@ type TabModel struct {
 	ActivePane string      // pane ID of the active pane
 	Width      int
 	Height     int
-	focusMode  bool // true = active pane fills entire tab (F11)
+	focusMode  bool // true = active pane fills entire tab
 }
 
 func NewTabModel(id, name string) *TabModel {
@@ -114,8 +114,17 @@ func (t *TabModel) View() string {
 }
 
 // ToggleFocus toggles pane focus mode on/off.
+// No-op on single-pane tabs (already fills the tab).
 func (t *TabModel) ToggleFocus() {
+	if t.Root != nil && t.Root.IsLeaf() {
+		return
+	}
 	t.focusMode = !t.focusMode
+}
+
+// ExitFocus exits focus mode if active.
+func (t *TabModel) ExitFocus() {
+	t.focusMode = false
 }
 
 // FocusMode returns whether focus mode is active.

--- a/internal/tui/tab.go
+++ b/internal/tui/tab.go
@@ -9,6 +9,7 @@ type TabModel struct {
 	ActivePane string      // pane ID of the active pane
 	Width      int
 	Height     int
+	focusMode  bool // true = active pane fills entire tab (F11)
 }
 
 func NewTabModel(id, name string) *TabModel {
@@ -78,6 +79,22 @@ func (t *TabModel) activeIndex(leaves []*PaneModel) int {
 func (t *TabModel) Resize(w, h int) {
 	t.Width = w
 	t.Height = h
+	if t.focusMode {
+		if pane := t.ActivePaneModel(); pane != nil {
+			pane.Width = w
+			pane.Height = h
+			cols := w - 2
+			rows := h - 2
+			if cols < 1 {
+				cols = 1
+			}
+			if rows < 1 {
+				rows = 1
+			}
+			pane.ResizeVT(cols, rows)
+		}
+		return
+	}
 	if t.Root != nil {
 		resizeNode(t.Root, w, h)
 	}
@@ -88,7 +105,22 @@ func (t *TabModel) View() string {
 	if t.Root == nil {
 		return ""
 	}
+	if t.focusMode {
+		if pane := t.ActivePaneModel(); pane != nil {
+			return pane.View()
+		}
+	}
 	return renderNode(t.Root)
+}
+
+// ToggleFocus toggles pane focus mode on/off.
+func (t *TabModel) ToggleFocus() {
+	t.focusMode = !t.focusMode
+}
+
+// FocusMode returns whether focus mode is active.
+func (t *TabModel) FocusMode() bool {
+	return t.focusMode
 }
 
 // SplitAtPane splits the pane with the given ID, inserting a placeholder

--- a/internal/tui/tab_test.go
+++ b/internal/tui/tab_test.go
@@ -1,0 +1,110 @@
+package tui
+
+import "testing"
+
+func TestToggleFocus_SinglePane_NoOp(t *testing.T) {
+	tab := NewTabModel("t1", "Test")
+	tab.Root = NewLeaf(newTestPane("p1"))
+	tab.ActivePane = "p1"
+
+	// Single-pane tab: ToggleFocus should be a no-op
+	tab.ToggleFocus()
+	if tab.FocusMode() {
+		t.Error("focus should not activate on single-pane tab")
+	}
+}
+
+func TestToggleFocus_MultiPane_TogglesOnOff(t *testing.T) {
+	tab := NewTabModel("t1", "Test")
+	left := newTestPane("p1")
+	right := newTestPane("p2")
+	tab.Root = NewLeaf(left)
+	tab.Root.SplitLeaf("p1", SplitHorizontal)
+	tab.Root.Right.Pane = right
+	tab.ActivePane = "p1"
+
+	// Multi-pane: ToggleFocus should activate
+	tab.ToggleFocus()
+	if !tab.FocusMode() {
+		t.Error("focus should be active after toggle")
+	}
+
+	// Toggle again: should deactivate
+	tab.ToggleFocus()
+	if tab.FocusMode() {
+		t.Error("focus should be inactive after second toggle")
+	}
+}
+
+func TestExitFocus_DeactivatesFocusMode(t *testing.T) {
+	tab := NewTabModel("t1", "Test")
+	left := newTestPane("p1")
+	right := newTestPane("p2")
+	tab.Root = NewLeaf(left)
+	tab.Root.SplitLeaf("p1", SplitHorizontal)
+	tab.Root.Right.Pane = right
+	tab.ActivePane = "p1"
+
+	tab.ToggleFocus()
+	if !tab.FocusMode() {
+		t.Fatal("focus should be active")
+	}
+
+	tab.ExitFocus()
+	if tab.FocusMode() {
+		t.Error("focus should be inactive after ExitFocus")
+	}
+}
+
+// Use NewPaneModel (not newTestPane) because Resize needs a VT emulator.
+func TestResize_FocusMode_ActivePaneGetsFullDimensions(t *testing.T) {
+	tab := NewTabModel("t1", "Test")
+	p1 := NewPaneModel("p1", 1024)
+	p2 := NewPaneModel("p2", 1024)
+	tab.Root = NewLeaf(p1)
+	tab.Root.SplitLeaf("p1", SplitHorizontal)
+	tab.Root.Right.Pane = p2
+	tab.ActivePane = "p1"
+
+	// Normal resize: both panes get partial width
+	tab.Resize(100, 40)
+	if p1.Width == 100 {
+		t.Error("in normal mode, pane should not get full width")
+	}
+
+	// Focus resize: active pane gets full dimensions
+	tab.ToggleFocus()
+	tab.Resize(100, 40)
+	if p1.Width != 100 {
+		t.Errorf("in focus mode, active pane width: got %d, want 100", p1.Width)
+	}
+	if p1.Height != 40 {
+		t.Errorf("in focus mode, active pane height: got %d, want 40", p1.Height)
+	}
+}
+
+// Use NewPaneModel (not newTestPane) because View calls pane.View() which needs VT.
+func TestView_FocusMode_RendersSinglePane(t *testing.T) {
+	tab := NewTabModel("t1", "Test")
+	p1 := NewPaneModel("p1", 1024)
+	p2 := NewPaneModel("p2", 1024)
+	tab.Root = NewLeaf(p1)
+	tab.Root.SplitLeaf("p1", SplitHorizontal)
+	tab.Root.Right.Pane = p2
+	tab.ActivePane = "p1"
+
+	// Resize so panes can render
+	tab.Resize(80, 24)
+
+	// Normal view should contain content from both panes
+	normalView := tab.View()
+
+	// Focus view should be different (only one pane)
+	tab.ToggleFocus()
+	tab.Resize(80, 24)
+	focusView := tab.View()
+
+	if normalView == focusView {
+		t.Error("focus view should differ from normal view (single pane vs split)")
+	}
+}

--- a/scripts/rebuild.ps1
+++ b/scripts/rebuild.ps1
@@ -16,15 +16,15 @@ foreach ($name in @("aetheld", "aethel")) {
     }
 }
 
-# 2. Reset state (unless -SkipReset)
-if (-not $SkipReset) {
-    $aethelDir = Join-Path $env:USERPROFILE ".aethel"
-    Remove-Item -Path (Join-Path $aethelDir "workspace.json") -Force -ErrorAction SilentlyContinue
-    Remove-Item -Path (Join-Path $aethelDir "workspace.json.bak") -Force -ErrorAction SilentlyContinue
-    Remove-Item -Path (Join-Path $aethelDir "buffers") -Recurse -Force -ErrorAction SilentlyContinue
-    Remove-Item -Path (Join-Path $aethelDir "aetheld.pid") -Force -ErrorAction SilentlyContinue
-    Write-Host "State reset"
-}
+## 2. Reset state (unless -SkipReset)
+#if (-not $SkipReset) {
+#    $aethelDir = Join-Path $env:USERPROFILE ".aethel"
+#    Remove-Item -Path (Join-Path $aethelDir "workspace.json") -Force -ErrorAction SilentlyContinue
+#    Remove-Item -Path (Join-Path $aethelDir "workspace.json.bak") -Force -ErrorAction SilentlyContinue
+#    Remove-Item -Path (Join-Path $aethelDir "buffers") -Recurse -Force -ErrorAction SilentlyContinue
+#    Remove-Item -Path (Join-Path $aethelDir "aetheld.pid") -Force -ErrorAction SilentlyContinue
+#    Write-Host "State reset"
+#}
 
 # 3. Delete old executables
 Remove-Item -Path (Join-Path $ProjectDir "aethel.exe") -Force -ErrorAction SilentlyContinue


### PR DESCRIPTION
F11 toggles the active pane to fill the entire tab area. Other panes keep running in the background. Layout tree stays intact — focus is a pure rendering toggle on TabModel.focusMode.

- Pane navigation (Tab/Shift+Tab) disabled in focus mode
- Split (Alt+H/V) and close (Ctrl+W) auto-exit focus mode
- [focus] indicator in status bar
- Focus exits when tree reduces to single pane
- Not persisted — fresh start always shows normal layout