### PR TITLE
docs: add roadmap PRDs and notification center concept (M12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Roadmap PRDs** — 11 detailed Product Requirements Documents in `docs/roadmap/`: workspace files, MCP server, command palette, notification center, pre-built binaries, demo GIF, community plugins, process health, tmux migration, cross-pane events, session sharing
+- **Restructured ROADMAP.md** — organized into Core/Growth/Advanced categories with priority matrix, strategic pain-layer analysis, and feature synergy notes
+- **Notification center concept (M12)** — centralized event sidebar with pane navigation and history stack; PRD covers process exit detection, plugin notification handlers, and incremental integration path
+
 ## [0.9.0] - 2026-03-23
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,6 +2,8 @@
 
 Detailed progress tracker and future plans for Aethel.
 
+---
+
 ## Completed
 
 ### M1: Foundation
@@ -39,6 +41,19 @@ Key capabilities:
 - **Atomic pane replacement** — swap pane type in-place
 - **Resuming/preparing spinner** — animated border indicator during pane startup
 - **Window size persistence** — save/restore terminal dimensions across restarts
+
+### M6: Pane Focus Mode
+> Full-window focus for single pane (Ctrl+E toggle).
+
+Ctrl+E toggles the active pane to fill the entire tab content area. Other panes keep running in the background, receiving PTY output. The layout tree stays intact — focus mode is a pure rendering toggle on `TabModel.focusMode`.
+
+Key behaviors:
+- **Ctrl+E** toggles focus on/off (configurable via `focus_pane` keybinding)
+- Active pane resized to full tab dimensions; VT emulator + daemon PTY updated
+- `[focus]` indicator in status bar
+- Pane navigation (Tab/Shift+Tab) disabled in focus mode
+- Split (Alt+H/V) and close (Ctrl+W) auto-exit focus mode
+- Focus state is NOT persisted — restarting Aethel returns to normal layout
 
 ### M8: Bubble Tea v2 Migration + Text Selection
 > BT v2 + Lipgloss v2 migration, text selection, platform-native clipboard, editor enhancements.
@@ -85,22 +100,7 @@ Key changes:
 
 ---
 
-### M6: Pane Focus Mode
-> Full-window focus for single pane (Ctrl+E toggle).
-
-Ctrl+E toggles the active pane to fill the entire tab content area. Other panes keep running in the background, receiving PTY output. The layout tree stays intact — focus mode is a pure rendering toggle on `TabModel.focusMode`.
-
-Key behaviors:
-- **Ctrl+E** toggles focus on/off (configurable via `focus_pane` keybinding)
-- Active pane resized to full tab dimensions; VT emulator + daemon PTY updated
-- `[focus]` indicator in status bar
-- Pane navigation (Tab/Shift+Tab) disabled in focus mode
-- Split (Alt+H/V) and close (Ctrl+W) auto-exit focus mode
-- Focus state is NOT persisted — restarting Aethel returns to normal layout
-
----
-
-## Planned
+## Planned — Core Features
 
 ### M7: Pane Notes
 
@@ -115,3 +115,122 @@ Side-by-side note-taking mode linked to individual panes. When enabled, the wind
 - Notes persist independently from workspace state — they survive pane destruction and can be browsed later
 - Exiting notes mode restores the previous layout
 
+### M9: Project Workspace Files — [PRD](docs/roadmap/workspace-files.md)
+
+> `.aethel.toml` checked into repo — the "docker-compose.yml for dev environments."
+
+Define workspace blueprints committed to git: tabs, panes, plugins, CWDs, commands. `cd my-project && aethel` materializes the entire dev environment. Every team member gets the exact same setup. **Network effect within teams.**
+
+### M10: MCP Server — [PRD](docs/roadmap/mcp-server.md)
+
+> Make Aethel the AI's eyes and hands via Model Context Protocol.
+
+`aethel mcp` subcommand as a thin bridge: MCP JSON-RPC (stdio) ↔ daemon IPC (socket). AI assistants can read pane output, send commands, check process status, and create panes. **No other terminal multiplexer offers this** — Aethel becomes the bridge between AI and the dev environment.
+
+### M11: Command Palette — [PRD](docs/roadmap/command-palette.md)
+
+> `Ctrl+Shift+P` fuzzy-find overlay for everything.
+
+Search panes, execute commands, switch tabs, create panes, open saved instances — all from a single keyboard shortcut. Fuzzy string matching makes every feature instantly discoverable.
+
+### M12: Notification Center — [PRD](docs/roadmap/notification-center.md)
+
+> Centralized event sidebar with pane navigation and history stack.
+
+Processes emit events when they finish or need attention. A non-modal sidebar shows pending events with severity icons. Select an event to jump to the linked pane; `Alt+Backspace` returns to where you were (like browser back). Eliminates manual pane polling — the **context-switching tax** that costs developers dozens of interruptions per day. Ships incrementally: process exit detection first, plugin output patterns second, cross-pane event bus integration third.
+
+---
+
+## Planned — Growth & Adoption
+
+### Pre-Built Binaries & One-Line Install — [PRD](docs/roadmap/pre-built-binaries.md)
+
+> `curl -sSfL https://get.aethel.dev | sh` — zero friction install.
+
+goreleaser for GitHub Releases, Homebrew tap, winget/scoop manifests, install script. **Priority 1** — prerequisite for everything else. Every extra step between "I want to try this" and "it's running" loses users.
+
+### The "Holy Shit" Demo — [PRD](docs/roadmap/demo-gif.md)
+
+> 30-second GIF: 5 panes → reboot → `aethel` → everything snaps back.
+
+The entire pitch in one visual. Goes on README, Hacker News, r/programming, Twitter/X. Adoption for developer tools is driven by a single viral moment. **Priority 2** — prerequisite for marketing.
+
+### Community Plugin Registry — [PRD](docs/roadmap/community-plugins.md)
+
+> `aethel plugin install aider` — community TOML plugins via GitHub.
+
+GitHub repo as registry, `aethel plugin install/search/update` CLI. High-value plugins: Aider, lazygit, k9s, Docker Compose, ngrok, pgcli. Every plugin makes Aethel useful to a new audience.
+
+### tmux Migration Path — [PRD](docs/roadmap/tmux-migration.md)
+
+> Import keybindings and session layouts from tmux.
+
+`aethel import-keybindings tmux` reads `~/.tmux.conf`, maps to `config.toml`. `aethel import-session` snapshots a running tmux session into an Aethel workspace. tmux has millions of users — making switching painless is the fastest acquisition channel.
+
+---
+
+## Planned — Advanced Features
+
+### Smart Process Health & Auto-Restart — [PRD](docs/roadmap/process-health.md)
+
+> Green/yellow/red health indicators, auto-restart with backoff, stale detection.
+
+Elevate `error_handlers` to a first-class health monitoring system. Auto-restart crashed panes with exponential backoff, detect stale processes, fire desktop notifications. Plugin TOML `[health]` section for configuration. Moves Aethel from "terminal organizer" to "workflow orchestrator."
+
+### Cross-Pane Context Awareness — [PRD](docs/roadmap/cross-pane-events.md)
+
+> Build fails → AI pane gets a toast → one keypress sends context.
+
+Event bus connecting panes: build errors notify AI assistants, SSH auto-reconnects, test passes flash green, webhook counters badge tabs. Creates an **integrated experience** that no collection of separate terminals can match.
+
+### Session Sharing — [PRD](docs/roadmap/session-sharing.md)
+
+> `aethel serve --share` / `aethel attach --host` for pair programming.
+
+Remote workspace viewing and collaboration over TCP+TLS. Read-only by default, collaborative mode optional. tmux session sharing but with project context, typed panes, and AI session awareness.
+
+---
+
+## Priority Matrix
+
+| Priority | Feature | Effort | Impact | Category |
+|----------|---------|--------|--------|----------|
+| 1 | Pre-built binaries + one-line install | Small | Critical | Growth |
+| 2 | "Holy Shit" demo GIF/video | Small | Critical | Growth |
+| 3 | Project workspace files (`.aethel.toml`) | Medium | Very High | Core |
+| 4 | Command palette (`Ctrl+Shift+P`) | Medium | High | Core |
+| 5 | MCP server for AI integration | Medium | Very High | Core |
+| 5 | Notification center (sidebar + pane history) | Medium | High | Core |
+| 6 | Community plugin registry + 10 plugins | Medium | High | Growth |
+| 7 | Smart health monitoring + auto-restart | Medium | High | Advanced |
+| 8 | tmux keybinding import | Small | Medium | Growth |
+| 9 | Cross-pane context / event bus | Large | High | Advanced |
+| 10 | Session sharing | Large | Medium | Advanced |
+
+## Strategic Notes
+
+### The Developer Pain (Layered)
+
+| Layer | Pain | Who Feels It |
+|-------|------|-------------|
+| 1. Context destruction | Reboot = 10-15 min of manual reconstruction | Every multi-terminal developer |
+| 2. AI session loss | Losing a Claude conversation means losing reasoning context worth hours | AI-native developers (growing fast) |
+| 3. Project fragmentation | 5 terminals + 3 tools + 2 SSH = no single "project view" | Team leads, senior engineers |
+| 4. Onboarding friction | "How do I run this?" → README with 8 terminal commands | New team members, OSS contributors |
+| 5. Cross-tool blindness | AI assistant can't see the build error in the next pane | Everyone using AI coding tools |
+
+Aethel currently solves layers 1-3 well. **Layers 4-5 are where the breakout potential lives.**
+
+Items 1-2 (install + demo) cost almost nothing and are **prerequisites for everything else**. Items 3 (workspace files) and 5 (MCP) are the **strategic differentiators** — workspace files create team adoption and MCP creates the "AI-native" moat that no other multiplexer can claim.
+
+### Feature Synergies
+
+The **notification center** (M12), **process health** (advanced), and **cross-pane events** (advanced) form a layered system:
+
+| Layer | Feature | Role |
+|-------|---------|------|
+| UI | Notification Center (M12) | Sidebar, pane navigation, history stack |
+| Monitoring | Process Health | Health states, auto-restart, stale detection |
+| Orchestration | Cross-Pane Events | Event bus, pane-to-pane context passing |
+
+M12 ships first as a standalone feature (process exit + output patterns). The other two extend it when they ship — health states and cross-pane events feed into the notification center's event queue.

--- a/docs/roadmap/command-palette.md
+++ b/docs/roadmap/command-palette.md
@@ -1,0 +1,119 @@
+# Command Palette (`Ctrl+Shift+P`)
+
+| Field | Value |
+|-------|-------|
+| Priority | 4 |
+| Effort | Medium |
+| Impact | High |
+| Status | Proposed |
+| Depends on | — |
+
+## Problem
+
+Aethel has many features behind keybindings, but discoverability is poor. Users need to memorize shortcuts or open the help dialog. Power users expect a command palette (VS Code, Sublime Text, Raycast) — a single entry point for everything.
+
+## Proposed Solution
+
+A fuzzy-find overlay triggered by `Ctrl+Shift+P` that provides instant access to:
+
+- **Search panes** by name, plugin type, CWD
+- **Execute commands**: split, close, rename, resize
+- **Switch tabs/panes** instantly
+- **Create new pane** from plugin
+- **Open saved instances** (SSH connections, etc.)
+
+Cheap to implement (fuzzy string matching + existing dialog system) but makes the tool feel **polished and modern**. The single UI feature that makes power users love a tool.
+
+## User Experience
+
+```
+┌─ Command Palette ──────────────────────────────┐
+│ > split hor_                                    │
+│                                                 │
+│   Split Horizontal          Alt+H               │
+│   Split Vertical            Alt+V               │
+│   Close Pane                Ctrl+W               │
+│   Close Tab                 Alt+W                │
+│                                                 │
+│ ↑↓ Navigate  Enter Select  Esc Close            │
+└─────────────────────────────────────────────────┘
+```
+
+### Command Categories
+
+| Category | Examples |
+|----------|---------|
+| Navigation | `Go to: 1:Shell`, `Go to: 2:Build`, `Focus pane: backend` |
+| Layout | `Split horizontal`, `Split vertical`, `Toggle focus mode` |
+| Pane | `Close pane`, `Rename pane`, `New terminal`, `New claude-code` |
+| Tab | `New tab`, `Close tab`, `Rename tab`, `Cycle tab color` |
+| Plugin | `Create: SSH → production-server`, `Create: Stripe → webhooks` |
+| System | `Settings`, `Shortcuts`, `Plugins`, `About` |
+
+### Fuzzy Matching
+
+- Type fragments: `clau` matches "New claude-code pane"
+- Type shortcuts: `alt h` matches "Split horizontal (Alt+H)"
+- Type pane names: `back` matches "Go to: backend"
+- Most recently used commands float to top
+
+## Technical Approach
+
+### 1. Command Registry
+
+```go
+type PaletteCommand struct {
+    Label    string   // Display text
+    Detail   string   // Secondary text (shortcut, description)
+    Category string   // Grouping
+    Keywords []string // Additional search terms
+    Action   func()   // What to execute
+}
+```
+
+Commands are registered at startup from:
+- Static commands (split, close, rename, etc.)
+- Dynamic commands (current tabs/panes, saved instances)
+
+### 2. Fuzzy Matching
+
+Implement simple fuzzy substring scoring:
+- Exact prefix match: highest score
+- Consecutive character match: high score
+- Non-consecutive match: lower score
+- Case-insensitive
+
+Or use a lightweight Go fuzzy library.
+
+### 3. UI Integration
+
+- New `dialogPalette` state in dialog system
+- Full-width overlay with input field + scrollable results
+- `Ctrl+Shift+P` keybinding (configurable)
+- Results update on every keystroke
+- Enter executes selected command, Esc closes
+
+### 4. Files
+
+| File | Change |
+|------|--------|
+| `internal/tui/palette.go` | New — command registry, fuzzy matching, rendering |
+| `internal/tui/model.go` | Add `dialogPalette` state, keybinding handler |
+| `internal/tui/dialog.go` | Add palette to dialog switch |
+| `internal/config/config.go` | Add `command_palette` keybinding |
+
+## Success Criteria
+
+- [ ] `Ctrl+Shift+P` opens command palette overlay
+- [ ] Typing filters commands with fuzzy matching
+- [ ] Enter executes the selected command
+- [ ] All existing keybinding actions are available as commands
+- [ ] Current tabs/panes appear as "Go to" commands
+- [ ] Saved plugin instances appear as "Create" commands
+- [ ] Response feels instant (< 16ms per keystroke)
+
+## Open Questions
+
+- Should the palette support ":" prefix for direct command mode (`:split h`)?
+- MRU (most recently used) persistence across sessions?
+- Should it also search terminal output (like VS Code's "Go to Symbol")?

--- a/docs/roadmap/community-plugins.md
+++ b/docs/roadmap/community-plugins.md
@@ -1,0 +1,149 @@
+# Community Plugin Registry
+
+| Field | Value |
+|-------|-------|
+| Priority | 6 |
+| Effort | Medium |
+| Impact | High |
+| Status | Proposed |
+| Depends on | — |
+
+## Problem
+
+Aethel ships with 4 built-in plugins (terminal, claude-code, ssh, stripe). Users who want to add support for other tools must write TOML plugin files manually. There's no way to discover or share plugins. Every user reinvents the same configurations.
+
+## Proposed Solution
+
+Create a simple plugin sharing mechanism backed by a GitHub repository (`aethel-plugins`) acting as a registry. Each plugin is a `.toml` file. `aethel plugin install <name>` fetches it to `~/.aethel/plugins/`.
+
+```bash
+aethel plugin install aider       # pulls community TOML plugin
+aethel plugin install k9s
+aethel plugin install lazygit
+aethel plugin search docker
+```
+
+### High-Value Plugins to Ship or Solicit
+
+| Plugin | Resume Strategy | Value |
+|--------|----------------|-------|
+| **Aider** | `session_scrape` | 2nd most popular AI coding tool |
+| **Cline/Continue** | `rerun` | VS Code AI tools used from CLI |
+| **lazygit** | `cwd_only` | Git UI loved by terminal users |
+| **k9s** | `rerun` | Kubernetes dashboard |
+| **Docker Compose** | `rerun` | `docker compose up` with auto-restart |
+| **ngrok/localtunnel** | `rerun` | Tunnel with auto-restart |
+| **npm/cargo/go watch** | `rerun` | Build watchers |
+| **pgcli/mongosh** | `rerun` | Database CLIs |
+
+**Network effect:** Every plugin makes Aethel useful to a new audience. Plugin authors become advocates.
+
+## User Experience
+
+### Installing Plugins
+
+```bash
+# Install by name
+aethel plugin install aider
+
+# Search available plugins
+aethel plugin search database
+# Results:
+#   pgcli       - PostgreSQL CLI with auto-complete
+#   mongosh     - MongoDB Shell
+#   redis-cli   - Redis CLI
+
+# List installed plugins
+aethel plugin list
+
+# Update all plugins
+aethel plugin update
+```
+
+### Creating and Sharing Plugins
+
+```bash
+# Create a plugin from template
+aethel plugin init my-tool
+
+# Test locally
+# (edit ~/.aethel/plugins/my-tool.toml, use Ctrl+N to create pane)
+
+# Submit to registry
+# (PR to aethel-plugins repo on GitHub)
+```
+
+## Technical Approach
+
+### 1. Registry Structure
+
+GitHub repo `artyomsv/aethel-plugins`:
+
+```
+aethel-plugins/
+├── registry.json          # index: name → metadata
+├── plugins/
+│   ├── aider.toml
+│   ├── k9s.toml
+│   ├── lazygit.toml
+│   ├── docker-compose.toml
+│   ├── ngrok.toml
+│   └── pgcli.toml
+└── README.md
+```
+
+`registry.json`:
+```json
+{
+  "plugins": [
+    {
+      "name": "aider",
+      "description": "AI pair programmer",
+      "version": "1.0.0",
+      "author": "community",
+      "tags": ["ai", "coding"]
+    }
+  ]
+}
+```
+
+### 2. CLI Commands
+
+| Command | Action |
+|---------|--------|
+| `aethel plugin install <name>` | Download TOML from registry to `~/.aethel/plugins/` |
+| `aethel plugin search <query>` | Search registry.json by name/tags/description |
+| `aethel plugin list` | Show installed plugins (built-in + community) |
+| `aethel plugin update` | Re-fetch all community plugins |
+| `aethel plugin remove <name>` | Delete community plugin |
+| `aethel plugin init <name>` | Create plugin template |
+
+### 3. Implementation
+
+- Fetch `registry.json` from GitHub raw URL (cached locally)
+- Download individual TOML files on install
+- No authentication required (public repo)
+- Version tracking in `~/.aethel/plugins/.registry-cache.json`
+
+### 4. Files
+
+| File | Change |
+|------|--------|
+| `cmd/aethel/plugin.go` | New — plugin subcommand (install, search, list, update, remove) |
+| `internal/plugin/registry_remote.go` | New — GitHub registry client |
+| `internal/plugin/cache.go` | New — local cache management |
+
+## Success Criteria
+
+- [ ] `aethel plugin install aider` downloads and installs the plugin
+- [ ] `aethel plugin search ai` returns matching plugins
+- [ ] Installed plugins appear in `Ctrl+N` pane creation dialog
+- [ ] At least 5 community plugins published in registry
+- [ ] Plugin submission via PR is documented
+
+## Open Questions
+
+- Should plugins be versioned? (semver in registry.json)
+- Plugin validation before publishing? (CI checks on PR)
+- Allow plugins to declare binary dependencies? (`requires = ["aider"]`)
+- CDN caching for plugin downloads vs direct GitHub raw URLs?

--- a/docs/roadmap/cross-pane-events.md
+++ b/docs/roadmap/cross-pane-events.md
@@ -1,0 +1,135 @@
+# Cross-Pane Context Awareness
+
+| Field | Value |
+|-------|-------|
+| Priority | 9 |
+| Effort | Large |
+| Impact | High |
+| Status | Proposed |
+| Depends on | Smart Process Health (recommended) |
+
+## Problem
+
+Aethel panes are isolated — they can't react to events in other panes. A build failure in one pane doesn't notify the AI assistant in another. An SSH disconnect doesn't trigger reconnection. Test results don't update tab badges. The developer is still the message bus between their tools.
+
+This creates an **integrated experience** that no collection of separate terminals can match.
+
+## Proposed Solution
+
+Let panes react to events in other panes:
+
+| Event | Reaction |
+|-------|----------|
+| **Build fails** | AI pane gets a toast: "Build error detected. Send to Claude?" → one keypress sends the error context |
+| **SSH disconnects** | Auto-reconnect with backoff |
+| **Test passes** | Green flash on the tab, optional desktop notification |
+| **Webhook received** | Counter badge on the tab: `Stripe (47)` |
+
+## User Experience
+
+### Toast Notifications
+
+```
+┌─ claude-code ────────────────────────────┐
+│ claude > I've updated the auth           │
+│ middleware to use JWT tokens...           │
+│                                          │
+│ ┌─────────────────────────────────────┐  │
+│ │ ⚠ Build error in "backend" pane     │  │
+│ │ Press Enter to send context to AI   │  │
+│ └─────────────────────────────────────┘  │
+└──────────────────────────────────────────┘
+```
+
+### Tab Badges
+
+```
+┌─ 1:AI + Code ─┬─ 2:Backend ─┬─ 3:Stripe (12) ─┐
+```
+
+### Event-Driven Plugin Rules
+
+Plugins can subscribe to events via TOML:
+
+```toml
+[events]
+on_exit_nonzero = "notify"           # show toast in other panes
+on_output_match = "FAIL|ERROR"       # regex trigger
+on_output_match_action = "badge"     # increment tab badge
+on_disconnect = "reconnect"          # auto-reconnect behavior
+```
+
+## Technical Approach
+
+### 1. Event Bus (Daemon-Side)
+
+```go
+type PaneEvent struct {
+    SourcePane string
+    Type       EventType  // Exit, OutputMatch, Disconnect, Stale
+    Data       map[string]string
+    Timestamp  time.Time
+}
+
+type EventBus struct {
+    subscribers map[string][]EventHandler
+    ch          chan PaneEvent
+}
+```
+
+Events are emitted by:
+- Process exit monitor (exit code != 0)
+- PTY output regex scanner (configurable patterns)
+- Connection state changes (SSH disconnect)
+- Stale timer expiry
+
+### 2. Event Routing
+
+Events flow: `Pane PTY output → regex match → EventBus → subscriber panes → TUI notification`
+
+Subscriptions can be:
+- **Plugin-level**: defined in TOML (`[events]` section)
+- **Pane-level**: configured per-pane at runtime
+- **Global**: all panes receive certain events (build failures)
+
+### 3. TUI Toast System
+
+- Toast overlay rendered above pane content
+- Auto-dismiss after 5s or on keypress
+- Action key (Enter) sends event context to target pane
+- Toast queue for multiple simultaneous events
+
+### 4. Tab Badges
+
+- Counter badge in tab header: `Stripe (47)`
+- Color-coded: red for errors, green for success, grey for info
+- Cleared on tab focus or manually
+
+### 5. Files
+
+| File | Change |
+|------|--------|
+| `internal/daemon/eventbus.go` | New — event bus, subscribers, routing |
+| `internal/daemon/scanner.go` | New — PTY output regex scanner for events |
+| `internal/daemon/session.go` | Emit events on process exit, disconnect |
+| `internal/plugin/plugin.go` | Parse `[events]` section from TOML |
+| `internal/tui/toast.go` | New — toast notification overlay |
+| `internal/tui/model.go` | Handle event IPC messages, render toasts, tab badges |
+| `internal/ipc/messages.go` | New message types: `MsgPaneEvent`, `MsgToast` |
+
+## Success Criteria
+
+- [ ] Build failure in one pane shows toast in AI pane
+- [ ] Toast action key sends error context to AI pane
+- [ ] Tab badges show event counts
+- [ ] SSH panes auto-reconnect on disconnect
+- [ ] Plugin TOML `[events]` section is respected
+- [ ] Events are logged for debugging
+
+## Open Questions
+
+- Should events cross tab boundaries or only within same tab?
+- Event history / replay for debugging?
+- Should MCP server expose events as a tool? (`subscribe_to_events`)
+- Rate limiting on high-frequency events (e.g., test runner output)?
+- Security: can any pane send input to any other pane via events?

--- a/docs/roadmap/demo-gif.md
+++ b/docs/roadmap/demo-gif.md
@@ -1,0 +1,81 @@
+# The "Holy Shit" Demo GIF/Video
+
+| Field | Value |
+|-------|-------|
+| Priority | 2 |
+| Effort | Small |
+| Impact | Critical |
+| Status | Proposed |
+| Depends on | Pre-built binaries (for install step) |
+
+## Problem
+
+Adoption for developer tools is driven by a single viral moment. A 30-second visual that makes someone say "I need this" is worth more than 10 pages of documentation. Aethel currently has no visual demo — the README describes features but doesn't show them.
+
+## Proposed Solution
+
+Create a 30-second GIF/video that demonstrates Aethel's core value proposition in one continuous take:
+
+1. Show 5 panes: Claude Code mid-conversation, SSH tunnel, build watcher, webhook listener, terminal
+2. `sudo reboot`
+3. Login, type `aethel`
+4. **Everything snaps back** — Claude conversation resumed, build re-watching, SSH reconnected
+5. Total time: 3 seconds
+
+This GIF goes on the README, gets posted to Hacker News, r/programming, Twitter/X. It's the entire pitch in one visual.
+
+## User Experience
+
+The demo isn't a feature — it's marketing. But it should demonstrate real, reproducible behavior that any user can replicate after installing Aethel.
+
+## Technical Approach
+
+### Recording Setup
+
+- **Tool**: [VHS](https://github.com/charmbracelet/vhs) (terminal GIF recorder by Charm, integrates well with Bubble Tea) or asciinema + gif conversion
+- **Resolution**: 120x40 terminal, large font for readability on social media
+- **Duration**: 25-30 seconds max
+
+### Script
+
+```
+# Scene 1: The productive workspace (5s)
+[Show Aethel with 5 panes in 2 tabs]
+[Claude Code pane shows active conversation]
+[Build watcher shows "watching..."]
+[Webhook listener shows "Ready"]
+
+# Scene 2: The disaster (3s)
+[Type in terminal pane: sudo reboot]
+[Screen goes black]
+
+# Scene 3: The recovery (5s)
+[Login screen → type aethel]
+[Ghost buffers render instantly]
+[Claude Code resumes conversation]
+[Build watcher re-starts]
+[SSH reconnects]
+
+# Scene 4: The punchline (2s)
+[Hold on fully restored workspace]
+[Text overlay: "aethel — reboot-proof terminal sessions"]
+```
+
+### Optimization
+
+- Compress GIF to < 5MB for GitHub README inline display
+- Also produce MP4 for Twitter/social media
+- Host high-quality version externally (YouTube, project website)
+
+## Success Criteria
+
+- [ ] GIF is < 5MB and renders inline on GitHub README
+- [ ] Demo shows real reboot → full restore in under 5 seconds
+- [ ] README updated with embedded GIF above the fold
+- [ ] Social media posts drafted for HN, Reddit, Twitter/X
+
+## Open Questions
+
+- VHS vs asciinema vs screen recording?
+- Should the GIF show the install step too? (adds length but shows ease)
+- Real reboot vs simulated (daemon restart)?

--- a/docs/roadmap/mcp-server.md
+++ b/docs/roadmap/mcp-server.md
@@ -1,0 +1,126 @@
+# MCP Server — Make Aethel the AI's Eyes and Hands
+
+| Field | Value |
+|-------|-------|
+| Priority | 5 |
+| Effort | Medium |
+| Impact | Very High (differentiation) |
+| Status | Proposed |
+| Depends on | — |
+
+## Problem
+
+**Layer 5: Cross-tool blindness** — AI assistants can't see the build error in the next pane. Claude Code, VS Code Copilot, Cursor — they're all blind to what's happening in other terminal sessions. The AI fixes code but can't see that the build is still failing in another pane. The developer becomes a copy-paste bridge between tools.
+
+**No other terminal multiplexer offers this.** Aethel becomes the **bridge between AI and the dev environment** — not just a container for AI sessions but an active collaborator.
+
+## Proposed Solution
+
+Expose Aethel as a [Model Context Protocol](https://modelcontextprotocol.io/) server so AI assistants can interact with the terminal environment:
+
+```
+AI: "Check the test output in the build pane and fix the failing test"
+→ MCP call: aethel.read_pane_output(pane="build", last_lines=50)
+→ AI sees: "FAIL src/auth.test.ts - Expected 200, got 401"
+→ AI fixes the code
+→ MCP call: aethel.send_to_pane(pane="build", input="npm test")
+```
+
+### MCP Tools
+
+| Tool | Description |
+|------|-------------|
+| `list_panes` | Enumerate all panes with types, names, CWDs |
+| `read_pane_output` | Read the last N lines from any pane's ring buffer |
+| `send_to_pane` | Send keystrokes/commands to a pane |
+| `get_pane_status` | Process running, exit code, error state |
+| `create_pane` | Spin up a new pane with a plugin type |
+
+## Architecture: `aethel mcp` Subcommand (Not a Separate Process)
+
+The MCP server should be a **new subcommand** (`aethel mcp`) that acts as a thin bridge — exactly like the TUI client is a bridge between Bubble Tea and the daemon:
+
+```
+┌──────────────┐    ┌───────────────┐    ┌──────────────┐
+│ AI Tool       │    │ aethel mcp    │    │ aetheld      │
+│ (Claude, etc) │←──→│ (MCP↔IPC      │←──→│ (daemon)     │
+│               │stdio│  bridge)     │sock │              │
+│ JSON-RPC      │    │ Translates    │    │ Ring buffers  │
+│               │    │ MCP ↔ IPC msgs│    │ PTY sessions  │
+│               │    │               │    │ Plugins       │
+└──────────────┘    └───────────────┘    └──────────────┘
+```
+
+### Why not directly in the daemon?
+
+MCP servers are invoked by the AI tool as a child process via stdio. Claude Desktop, VS Code, Cursor — they all spawn `aethel mcp` and talk JSON-RPC over stdin/stdout. The daemon is a long-running background service over sockets — fundamentally different lifecycle.
+
+### Why not a separate binary?
+
+All data lives in the daemon — ring buffers, session state, PTY handles, plugin registry. A separate binary would need its own IPC connection, which is exactly what `aethel mcp` already is. A third binary fragments the project for no gain.
+
+### Why `aethel mcp` is the right design
+
+| Concern | How it's handled |
+|---------|-----------------|
+| Data access | Connects to daemon via existing IPC socket — same as TUI client |
+| Lifecycle | AI tool spawns/kills it — no new daemon management needed |
+| Protocol | Translates MCP JSON-RPC (stdio) ↔ length-prefixed JSON (IPC) |
+| New daemon messages | 2-3 new IPC message types: `ReadPaneOutput`, `ListPanesDetailed`, `PaneStatus` |
+| Deployment | Already in the `aethel` binary — zero extra install steps |
+| Existing state | Ring buffers already have `Bytes()` for output replay — MCP just reads them |
+
+## Technical Approach
+
+### 1. New Daemon Messages (small additions)
+
+| Message | Purpose |
+|---------|---------|
+| `MsgReadPaneOutput` | Request last N lines from a pane's ring buffer (data already exists from ghost buffer support) |
+| `MsgListPanesDetailed` | Return pane names, types, CWDs, process status |
+| `MsgPaneExitStatus` | Field on the existing pane struct |
+
+The core daemon logic stays untouched. The MCP subcommand is ~300-500 lines — a thin translation layer.
+
+### 2. AI Tool Configuration
+
+```json
+// claude_desktop_config.json or VS Code MCP settings
+{
+  "mcpServers": {
+    "aethel": {
+      "command": "aethel",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+The daemon doesn't even need to know MCP exists — it just sees another client connecting to the socket.
+
+### 3. Files
+
+| File | Change |
+|------|--------|
+| `cmd/aethel/mcp.go` | New — MCP server main loop, JSON-RPC handling |
+| `cmd/aethel/mcp_tools.go` | New — tool implementations (list, read, send, status, create) |
+| `internal/ipc/messages.go` | Add 2-3 new message types |
+| `internal/daemon/handler.go` | Handle new message types |
+| `cmd/aethel/main.go` | Add `mcp` subcommand routing |
+
+## Success Criteria
+
+- [ ] `aethel mcp` starts and speaks MCP JSON-RPC over stdio
+- [ ] Claude Desktop can connect with the config above
+- [ ] `list_panes` returns all panes with metadata
+- [ ] `read_pane_output` returns last N lines from any pane
+- [ ] `send_to_pane` sends input to a pane's PTY
+- [ ] `get_pane_status` returns process state
+- [ ] AI can autonomously read build output and act on it
+
+## Open Questions
+
+- Should `read_pane_output` return raw terminal output or stripped ANSI?
+- Rate limiting on `send_to_pane` to prevent AI from flooding a terminal?
+- Should `create_pane` support workspace-file-style definitions?
+- Resource endpoints (MCP resources) for continuous pane monitoring?

--- a/docs/roadmap/notification-center.md
+++ b/docs/roadmap/notification-center.md
@@ -1,0 +1,270 @@
+# Notification Center
+
+| Field | Value |
+|-------|-------|
+| Priority | 4 |
+| Effort | Medium |
+| Impact | High |
+| Status | Proposed |
+| Depends on | — (Phase 3 integrates with Process Health + Cross-Pane Events) |
+
+## Problem
+
+Users run long-running processes in panes — AI assistants asking for confirmation, builds compiling, tests executing, webhooks waiting. Today the user must **manually poll** each pane to check if it needs attention. This forces a choice: either watch a pane (wasting time) or risk missing an important event (wasting the result).
+
+This is the **context-switching tax** — the same class of problem Aethel solves for reboots, but for real-time multitasking within a session.
+
+**Example workflow without notification center:**
+1. Ask Claude Code to refactor auth module (pane 1)
+2. Switch to terminal to work on something else (pane 2)
+3. Periodically switch back to pane 1: "Is it done? Does it need confirmation?"
+4. Repeat 5-10 times before Claude finishes
+5. Miss the confirmation prompt, Claude sits idle for 10 minutes
+
+**Example workflow with notification center:**
+1. Ask Claude Code to refactor auth module (pane 1)
+2. Switch to terminal to work on something else (pane 2)
+3. Notification appears: "claude-code: Waiting for confirmation"
+4. Press Enter → jump to pane 1, confirm
+5. Press Alt+Backspace → jump back to pane 2, continue working
+
+## Proposed Solution
+
+Three components that ship incrementally:
+
+### 1. Daemon: Event Emission
+
+The daemon detects events and broadcasts them to connected TUI clients:
+
+- **Process exit detection** — when a PTY process exits, emit an event with the exit code
+- **Output pattern matching** — plugin TOML `[[notification_handlers]]` (parallel to existing `[[error_handlers]]`)
+- **Event queue** — bounded (50 items), survives TUI disconnect/reconnect, replayed on attach
+
+### 2. TUI: Notification Sidebar
+
+A non-modal sidebar on the right edge (~30 columns) that coexists with normal pane rendering:
+
+```
+┌─ 1:AI + Code ─┬─ 2:Backend ─┬─ 3:Infra ────────┐
+│                              │ ┌─ Notifications ─┐│
+│  $ npm run dev               │ │                  ││
+│  Server listening on :3000   │ │ ✖ claude-code  2m││
+│                              │ │   Process failed ││
+│                              │ │                  ││
+│                              │ │ ⚠ backend     5m ││
+│                              │ │   Needs input    ││
+│                              │ │                  ││
+│                              │ │ ℹ tests       8m ││
+│                              │ │   All passed     ││
+│                              │ │                  ││
+│                              │ │ ↑↓ Nav  ⏎ Go     ││
+│                              │ │ d Dismiss  D All ││
+│                              │ └──────────────────┘│
+├─ terminal · ~/project ───────┴─────────────────────┤
+│ [3 events]  1:AI + Code | 2:Backend | 3:Infra      │
+└─────────────────────────────────────────────────────┘
+```
+
+- **Auto-shows** when events arrive, toggleable via `Alt+N`
+- **Not modal** — panes remain interactive; sidebar is just a visual panel
+- **Focusable** — `Alt+N` or `Tab` moves focus to sidebar for navigation
+- **Event items**: severity icon + pane name + title + relative timestamp
+- **Status bar badge**: `[3 events]` when sidebar is hidden but events are pending
+
+### 3. TUI: Pane History Stack ("Go Back")
+
+A navigation history that enables the "work → jump → handle → return" loop:
+
+- `Alt+Backspace` pops the history and navigates back (like browser back / `cd -`)
+- History is pushed when navigating from a notification
+- Bounded stack (20 entries), gracefully skips stale references (closed panes)
+- **Works globally** — useful anytime the user jumps between panes, not just from notifications
+
+## User Experience
+
+### Keybindings
+
+| Key | Context | Action |
+|-----|---------|--------|
+| `Alt+N` | Global | Toggle notification sidebar |
+| `Alt+Backspace` | Global | Navigate back to previous pane |
+| `Up/Down` | Sidebar focused | Navigate events |
+| `Enter` | Sidebar focused | Go to linked pane (pushes current to history) |
+| `d` | Sidebar focused | Dismiss selected event |
+| `D` | Sidebar focused | Dismiss all events |
+| `Esc` | Sidebar focused | Close/unfocus sidebar |
+
+### Event Severity Icons
+
+| Severity | Icon | Color | When |
+|----------|------|-------|------|
+| Error | `✖` | Red | Process exit code != 0 |
+| Warning | `⚠` | Yellow | Output pattern: "waiting for confirmation/input" |
+| Info | `ℹ` | Blue | Process exit code 0, build complete |
+
+### Interaction with Other Features
+
+- **Focus mode** (`Ctrl+E`): sidebar hidden in focus mode — events still accumulate, shown on exit
+- **Dialogs**: sidebar hidden when a dialog is open (dialogs are modal)
+- **Tab switching**: events are cross-tab — clicking an event may switch tabs
+
+## Technical Approach
+
+### 1. Process Exit Detection (Daemon)
+
+Extend PTY `Session` interface with `Wait() (int, error)`:
+- Unix (`session_unix.go`): `cmd.Wait()` → `ProcessState.ExitCode()`
+- Windows (`session_windows.go`): `WaitForSingleObject` + `GetExitCodeProcess`
+
+Wrap `streamPTYOutput` completion in `spawnPane`:
+```go
+go func() {
+    d.streamPTYOutput(pane.ID, ptySession)
+    d.handleProcessExit(pane.ID)  // emits PaneEvent
+}()
+```
+
+### 2. IPC Messages
+
+```go
+// Daemon → Client
+MsgPaneEvent = "pane_event"
+type PaneEventPayload struct {
+    ID        string            `json:"id"`
+    PaneID    string            `json:"pane_id"`
+    TabID     string            `json:"tab_id"`
+    PaneName  string            `json:"pane_name"`
+    Type      string            `json:"type"`      // "process_exit", "output_match"
+    Title     string            `json:"title"`
+    Message   string            `json:"message"`
+    Severity  string            `json:"severity"`  // "info", "warning", "error"
+    Timestamp int64             `json:"timestamp"`
+    Data      map[string]string `json:"data"`
+}
+
+// Client → Daemon
+MsgDismissEvent = "dismiss_event"
+type DismissEventPayload struct {
+    EventID string `json:"event_id"`  // empty = dismiss all
+}
+```
+
+### 3. Daemon Event Queue
+
+```go
+// internal/daemon/event.go
+type eventQueue struct {
+    events []PaneEvent
+    max    int        // 50
+    mu     sync.Mutex
+}
+```
+
+- `Push()` prepends (newest first), trims to max
+- `Dismiss(eventID)` / `DismissAll()` for client requests
+- Replayed on `handleAttach` after workspace state (like ghost buffers)
+- `emitEvent()` pushes + broadcasts to all connected clients
+
+### 4. Plugin Notification Handlers
+
+```toml
+# Parallel to existing [[error_handlers]]
+[[notification_handlers]]
+pattern = "(?i)waiting for (confirmation|input|approval)"
+title = "Needs attention"
+severity = "warning"
+
+[[notification_handlers]]
+pattern = "Build succeeded|All tests passed"
+title = "Build complete"
+severity = "info"
+```
+
+Follows exact same pattern as `ErrorHandler` — compiled regex, checked in `flushPaneOutput()`.
+
+### 5. TUI Sidebar Rendering
+
+`View()` integration — when sidebar is visible, pane area shrinks:
+
+```go
+tabContent := tab.View()  // rendered at (width - sidebarW)
+if sidebarW > 0 {
+    sidebar := m.notifications.View(sidebarW, tabH)
+    tabContent = lipgloss.JoinHorizontal(lipgloss.Top, tabContent, sidebar)
+}
+```
+
+`sidebarFocused` state routes keys to `handleNotificationKey()` instead of PTY.
+
+### 6. Pane History Stack
+
+```go
+type PaneRef struct {
+    TabIndex int
+    PaneID   string
+}
+// Model.paneHistory []PaneRef — bounded stack (20)
+```
+
+`pushPaneHistory()` before notification navigation. `popPaneHistory()` on `Alt+Backspace`.
+
+## Implementation Phases
+
+### Phase 1: Foundation (standalone, no dependencies)
+- Process exit detection (`Session.Wait()` on both platforms)
+- `PaneEvent` struct + `eventQueue` in daemon
+- `MsgPaneEvent` IPC message + TUI handler
+- Basic `NotificationCenter` struct + sidebar rendering
+- `Alt+N` toggle keybinding
+- Pane history stack + `Alt+Backspace`
+- Status bar badge
+
+### Phase 2: Plugin Patterns
+- `NotificationHandler` struct in plugin system
+- `[[notification_handlers]]` TOML parsing
+- `MatchNotification()` in `flushPaneOutput`
+- Default patterns for claude-code plugin
+
+### Phase 3: Integration (when related features ship)
+- Consume events from cross-pane event bus
+- Consume health state changes from process health system
+- Tab bar event indicators
+- Auto-show/hide behavior configuration
+
+## Files to Change
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `internal/daemon/event.go` | **New** | PaneEvent, eventQueue, emitEvent |
+| `internal/tui/notification.go` | **New** | NotificationCenter, View(), handleNotificationKey() |
+| `internal/ipc/protocol.go` | Modify | MsgPaneEvent, MsgDismissEvent types + payloads |
+| `internal/daemon/daemon.go` | Modify | Process exit detection, event emission, replay on attach |
+| `internal/tui/model.go` | Modify | Sidebar in View(), pane history, keybindings, status bar badge |
+| `internal/tui/styles.go` | Modify | Notification sidebar styles |
+| `internal/config/config.go` | Modify | Keybindings (notification_toggle, go_back) + UI config |
+| `internal/plugin/plugin.go` | Modify | NotificationHandler struct |
+| `internal/plugin/scraper.go` | Modify | MatchNotification function |
+| `internal/pty/session.go` | Modify | Add Wait/ExitCode to Session interface |
+| `internal/pty/session_unix.go` | Modify | Implement Wait |
+| `internal/pty/session_windows.go` | Modify | Implement Wait |
+| `internal/plugin/defaults/claude-code.toml` | Modify | Add notification patterns |
+
+## Success Criteria
+
+- [ ] Process exit in any pane creates a notification
+- [ ] `Alt+N` toggles the notification sidebar
+- [ ] Selecting an event navigates to the linked pane (cross-tab if needed)
+- [ ] `Alt+Backspace` returns to the previous pane
+- [ ] Events survive TUI disconnect/reconnect (daemon queue)
+- [ ] Plugin `[[notification_handlers]]` regex triggers notifications on output match
+- [ ] Status bar shows event count when sidebar is hidden
+- [ ] Sidebar is non-modal — panes remain interactive
+- [ ] Focus mode hides sidebar; events accumulate
+
+## Open Questions
+
+- Should notifications have an audible bell (terminal bell character)?
+- Should the sidebar width be configurable?
+- Should events auto-expire after a timeout (e.g., 30 minutes)?
+- Should "go back" (`Alt+Backspace`) work for all pane switches (not just notification navigation)?
+- Should dismissed events go to a history view or disappear permanently?

--- a/docs/roadmap/pre-built-binaries.md
+++ b/docs/roadmap/pre-built-binaries.md
@@ -1,0 +1,73 @@
+# Pre-Built Binaries & One-Line Install
+
+| Field | Value |
+|-------|-------|
+| Priority | 1 |
+| Effort | Small |
+| Impact | Critical |
+| Status | Proposed |
+| Depends on | — |
+
+## Problem
+
+The current install path requires Docker or Go 1.25 — a significant adoption barrier. Most developer tools can be installed in under 10 seconds. Every extra step between "I want to try this" and "it's running" loses potential users. Zero friction = higher conversion from README visitor to actual user.
+
+## Proposed Solution
+
+Use **goreleaser** to produce pre-built binaries for every major platform, published as GitHub Releases. Provide multiple install paths so users can pick what's familiar:
+
+| Method | Platform | Command |
+|--------|----------|---------|
+| Install script | Linux / macOS | `curl -sSfL https://get.aethel.dev \| sh` |
+| Homebrew | macOS / Linux | `brew install artyomsv/tap/aethel` |
+| Winget | Windows | `winget install aethel` |
+| Scoop | Windows | `scoop install aethel` |
+| Go install | Any | `go install github.com/artyomsv/aethel/cmd/aethel@latest` |
+| GitHub Release | Any | Download from Releases page |
+
+## User Experience
+
+```bash
+# macOS / Linux
+curl -sSfL https://get.aethel.dev | sh
+aethel
+
+# Windows
+winget install aethel
+aethel
+
+# Go users
+go install github.com/artyomsv/aethel/cmd/aethel@latest
+```
+
+First-run experience should feel instant. The binary self-bootstraps: creates `~/.aethel/`, writes default plugins, starts daemon on first launch.
+
+## Technical Approach
+
+1. **goreleaser config** (`.goreleaser.yml`) — build matrix for:
+   - `linux/amd64`, `linux/arm64`
+   - `darwin/amd64` (Intel), `darwin/arm64` (Apple Silicon)
+   - `windows/amd64`
+   - Two binaries per platform: `aethel` (TUI) and `aetheld` (daemon)
+
+2. **GitHub Actions CI** — trigger on tag push (`v*`), run goreleaser, publish release
+
+3. **Install script** (`get.aethel.dev`) — detect OS/arch, download correct binary, place in PATH
+
+4. **Homebrew tap** — `artyomsv/homebrew-tap` repo with formula
+
+5. **Scoop/Winget manifests** — JSON manifests pointing to GitHub Releases
+
+## Success Criteria
+
+- [ ] `curl -sSfL https://get.aethel.dev | sh && aethel` works on fresh Linux/macOS
+- [ ] `winget install aethel && aethel` works on Windows
+- [ ] `brew install artyomsv/tap/aethel` works
+- [ ] GitHub Release page shows all platform binaries
+- [ ] README "Quick Start" section updated with one-line install
+
+## Open Questions
+
+- Domain for install script: `get.aethel.dev` vs GitHub Pages?
+- Should the install script also install shell completions?
+- Include `aetheld` in same package or auto-extract from `aethel` binary?

--- a/docs/roadmap/process-health.md
+++ b/docs/roadmap/process-health.md
@@ -1,0 +1,142 @@
+# Smart Process Health & Auto-Restart
+
+| Field | Value |
+|-------|-------|
+| Priority | 7 |
+| Effort | Medium |
+| Impact | High |
+| Status | Proposed |
+| Depends on | — |
+
+## Problem
+
+Aethel currently restores sessions after reboot, but processes can crash or hang during normal operation too. Developers babysit long-running processes (build watchers, webhook listeners, SSH tunnels) — manually checking if they're still alive, restarting them when they die. This is the gap between "terminal organizer" and "workflow orchestrator."
+
+## Proposed Solution
+
+Elevate what's already partially in `error_handlers` to a first-class health monitoring system:
+
+| Feature | Behavior |
+|---------|----------|
+| **Process health indicator** | Green/yellow/red dot on pane border based on process state |
+| **Auto-restart with backoff** | Crashed panes restart after 1s → 2s → 4s → ... → max 60s |
+| **Stale detection** | "No output for 5 minutes" warning for webhook/watcher panes |
+| **Desktop notifications** | OS-native notification when a watched pane errors |
+| **Cross-pane event bus** | "Build failed" event → available to other plugins |
+
+Plugin authors would declare health rules in TOML:
+
+```toml
+[health]
+auto_restart = true
+max_restarts = 5
+restart_backoff = "exponential"    # linear | exponential | fixed
+stale_timeout = "5m"
+notify_on_error = true
+```
+
+**Why this matters:** Moves Aethel from "terminal organizer" to "workflow orchestrator." Developers stop babysitting processes.
+
+## User Experience
+
+### Visual Indicators
+
+```
+┌─ terminal (backend) ● ──────────────────┐   ← green dot = healthy
+│ $ npm run dev                            │
+│ Server listening on :3000                │
+└──────────────────────────────────────────┘
+
+┌─ terminal (tests) ○ ────────────────────┐   ← yellow dot = stale
+│ $ npm test -- --watch                    │
+│ (no output for 5 minutes)               │
+└──────────────────────────────────────────┘
+
+┌─ stripe ✖ ──────────────────────────────┐   ← red dot = crashed
+│ Process exited with code 1              │
+│ Restarting in 4s... (attempt 3/5)       │
+└──────────────────────────────────────────┘
+```
+
+### Notifications
+
+- Desktop notification: "Stripe webhook listener crashed (exit code 1). Auto-restarting..."
+- Tab badge: red dot on tab header when any pane has errors
+- Status bar: "2 healthy, 1 restarting" summary
+
+## Technical Approach
+
+### 1. Health State Machine
+
+```
+         spawn
+    ┌────────────────┐
+    │                │
+    ▼                │
+ STARTING ──────► HEALTHY ──────► STALE
+    │                │               │
+    │                ▼               │
+    │            CRASHED ◄───────────┘
+    │                │
+    │                ▼
+    │          RESTARTING ──► (back to STARTING)
+    │                │
+    │                ▼
+    └──────────► DEAD (max restarts exceeded)
+```
+
+### 2. Daemon Changes
+
+- `Pane.HealthState` field tracking current state
+- Background goroutine per pane monitoring process exit
+- Stale timer resets on every PTY output byte
+- Restart logic with configurable backoff
+- Notification dispatch (OS-native via `beeep` or similar Go library)
+
+### 3. TUI Changes
+
+- Health dot rendered in pane top border (colored Unicode circle)
+- Tab badge when pane has error state
+- Status bar health summary
+- Restart countdown visible in crashed panes
+
+### 4. Plugin TOML Extension
+
+```toml
+[health]
+auto_restart = true           # restart on crash
+max_restarts = 5              # give up after N restarts
+restart_backoff = "exponential" # 1s, 2s, 4s, 8s...
+max_backoff = "60s"           # cap backoff at 60s
+stale_timeout = "5m"          # warn if no output for 5m
+notify_on_error = true        # OS desktop notification
+watched = true                # include in health summary
+```
+
+### 5. Files
+
+| File | Change |
+|------|--------|
+| `internal/daemon/health.go` | New — health state machine, restart logic, stale detection |
+| `internal/daemon/notify.go` | New — OS notification dispatch |
+| `internal/daemon/session.go` | Integrate health monitoring into pane lifecycle |
+| `internal/plugin/plugin.go` | Parse `[health]` section from TOML |
+| `internal/tui/pane.go` | Render health indicators |
+| `internal/tui/model.go` | Status bar health summary |
+
+## Success Criteria
+
+- [ ] Pane border shows green/yellow/red health indicator
+- [ ] Crashed panes auto-restart with exponential backoff
+- [ ] "No output for 5m" stale detection works
+- [ ] Desktop notification fires on pane crash
+- [ ] Plugin TOML `[health]` section is respected
+- [ ] `max_restarts` prevents infinite restart loops
+- [ ] Tab shows error badge when pane is unhealthy
+
+## Open Questions
+
+- Should health state persist across daemon restarts?
+- How to handle processes that exit cleanly with code 0 — restart or not?
+- Cross-pane event bus: separate feature or bundled here?
+- OS notification library choice: `beeep`, `notify-send`, Win32 toast?

--- a/docs/roadmap/session-sharing.md
+++ b/docs/roadmap/session-sharing.md
@@ -1,0 +1,131 @@
+# Session Sharing for Pair Programming
+
+| Field | Value |
+|-------|-------|
+| Priority | 10 |
+| Effort | Large |
+| Impact | Medium |
+| Status | Proposed |
+| Depends on | — |
+
+## Problem
+
+Remote pair programming with terminal tools is painful. Screen sharing is laggy and one-directional. tmux session sharing requires SSH access to the same machine. No existing tool combines terminal sharing with project context, typed panes, and AI session awareness.
+
+## Proposed Solution
+
+```bash
+# Developer A (host)
+aethel serve --share --token abc123
+
+# Developer B (remote)
+aethel attach --host dev-server:8080 --token abc123
+```
+
+Both developers see the same workspace. Read-only by default, collaborative mode optional. This is tmux session sharing but with project context, typed panes, and AI session awareness.
+
+## User Experience
+
+### Host Side
+
+```bash
+# Start sharing current workspace
+$ aethel serve --share --token mysecret
+Sharing workspace on :8080
+Token: mysecret
+Waiting for connections...
+
+# Or generate a random token
+$ aethel serve --share
+Sharing workspace on :8080
+Token: a7f3b2c1 (share this with your pair)
+
+# With specific port
+$ aethel serve --share --port 9090 --token mysecret
+```
+
+Status bar shows: `[sharing: 1 viewer]`
+
+### Remote Side
+
+```bash
+$ aethel attach --host 192.168.1.50:8080 --token mysecret
+Connected to workspace "my-saas-app" (read-only)
+Press Ctrl+Q to disconnect
+```
+
+### Modes
+
+| Mode | Behavior |
+|------|----------|
+| **Read-only** (default) | Remote sees all panes, can scroll, but cannot type or interact |
+| **Collaborative** | Both can type, navigate tabs, split panes. Cursor shows who's where |
+| **Follow** | Remote's view follows host's active pane/tab automatically |
+
+```bash
+# Enable collaborative mode
+aethel serve --share --token abc123 --mode collaborative
+```
+
+## Technical Approach
+
+### 1. Network Protocol
+
+Reuse the existing IPC protocol (length-prefixed JSON) over TCP instead of Unix sockets:
+
+```
+┌──────────┐     TCP + TLS      ┌──────────────┐
+│  Remote   │ ◄──────────────► │  Host daemon  │
+│  TUI      │  IPC messages     │  (aetheld)    │
+└──────────┘  + auth layer      └──────────────┘
+```
+
+### 2. Authentication
+
+- Token-based authentication (shared secret)
+- TLS encryption for all traffic (self-signed cert auto-generated)
+- Optional: OAuth/GitHub integration for team settings
+
+### 3. State Synchronization
+
+The host daemon already broadcasts state to connected TUI clients. Remote clients are just TUI clients connected over TCP instead of Unix socket:
+
+- Same `MsgSync` workspace state messages
+- Same `MsgPaneOutput` PTY output streaming
+- Input messages (`MsgInput`) gated by mode (blocked in read-only)
+
+### 4. Cursor Presence
+
+In collaborative mode, show remote cursor position:
+- Different cursor color per connected user
+- "User B is viewing Tab 2, Pane: backend" indicator
+- Active pane highlight shows who's focused where
+
+### 5. Files
+
+| File | Change |
+|------|--------|
+| `internal/daemon/share.go` | New — TCP listener, auth, remote client management |
+| `internal/daemon/tls.go` | New — self-signed TLS cert generation |
+| `internal/ipc/tcp.go` | New — TCP transport (reusing existing IPC protocol) |
+| `cmd/aethel/serve.go` | New — `serve --share` subcommand |
+| `cmd/aethel/attach.go` | New — `attach --host` subcommand |
+| `internal/tui/model.go` | Presence indicators, mode restrictions |
+
+## Success Criteria
+
+- [ ] `aethel serve --share` starts TCP listener with auth
+- [ ] `aethel attach --host` connects and shows remote workspace
+- [ ] Read-only mode prevents remote input
+- [ ] Collaborative mode allows both users to interact
+- [ ] PTY output streams with acceptable latency (< 100ms LAN)
+- [ ] TLS encryption on all traffic
+- [ ] Status bar shows connection status and viewer count
+
+## Open Questions
+
+- NAT traversal: should Aethel provide a relay server for WAN connections?
+- Maximum number of concurrent viewers?
+- Should shared sessions persist after host disconnects?
+- Recording: save shared sessions as replayable recordings?
+- Integration with VS Code Live Share or similar?

--- a/docs/roadmap/tmux-migration.md
+++ b/docs/roadmap/tmux-migration.md
@@ -1,0 +1,124 @@
+# tmux Migration Path
+
+| Field | Value |
+|-------|-------|
+| Priority | 8 |
+| Effort | Small |
+| Impact | Medium |
+| Status | Proposed |
+| Depends on | — |
+
+## Problem
+
+tmux has millions of users with years of muscle memory. Switching to Aethel means re-learning keybindings and manually recreating session layouts. The switching cost is high enough that many users won't bother trying Aethel, even if they find the feature set compelling.
+
+Making switching painless is the fastest acquisition channel.
+
+## Proposed Solution
+
+Two import commands that lower the barrier to adoption:
+
+```bash
+aethel import-keybindings tmux    # reads ~/.tmux.conf, maps to config.toml
+aethel import-session             # snapshot running tmux session → Aethel workspace
+```
+
+## User Experience
+
+### Keybinding Import
+
+```bash
+$ aethel import-keybindings tmux
+Reading ~/.tmux.conf...
+Mapped 12 keybindings:
+  prefix + "    → split_horizontal (Alt+H)
+  prefix + %    → split_vertical (Alt+V)
+  prefix + c    → new_tab (Ctrl+T)
+  prefix + x    → close_pane (Ctrl+W)
+  prefix + z    → focus_pane (Ctrl+E)
+  prefix + n    → next_tab
+  prefix + p    → prev_tab
+  ...
+Written to ~/.aethel/config.toml
+Note: Aethel doesn't use a prefix key — bindings are mapped to direct shortcuts.
+```
+
+### Session Import
+
+```bash
+$ aethel import-session
+Detected tmux session: "dev" (3 windows, 7 panes)
+Importing:
+  Window 1: "code" → Tab 1 (2 panes, vertical split)
+  Window 2: "servers" → Tab 2 (3 panes, mixed splits)
+  Window 3: "logs" → Tab 3 (2 panes, horizontal split)
+Workspace created. Run 'aethel' to open.
+Note: Running processes are not migrated — only layout and directories.
+```
+
+## Technical Approach
+
+### 1. Keybinding Parser
+
+Parse `~/.tmux.conf` for `bind-key` / `bind` directives:
+
+```
+bind-key -T prefix '"' split-window -v
+bind-key -T prefix '%' split-window -h
+bind-key -T prefix 'c' new-window
+bind-key -T prefix 'z' resize-pane -Z
+```
+
+Map tmux actions to Aethel config keys:
+
+| tmux Action | Aethel Keybinding |
+|-------------|-------------------|
+| `split-window -v` | `split_horizontal` |
+| `split-window -h` | `split_vertical` |
+| `new-window` | `new_tab` |
+| `kill-pane` | `close_pane` |
+| `resize-pane -Z` | `focus_pane` |
+| `next-window` | Next tab |
+| `previous-window` | Previous tab |
+| `select-pane -t +1` | `next_pane` |
+
+Note: Aethel doesn't use a prefix key — tmux `prefix + x` becomes a direct shortcut.
+
+### 2. Session Snapshot
+
+Use `tmux list-windows` and `tmux list-panes` to capture:
+- Window names → tab names
+- Pane layout (tmux layout string) → split tree
+- Pane CWDs → pane working directories
+- Pane dimensions → split ratios
+
+```bash
+tmux list-windows -t dev -F "#{window_index}:#{window_name}:#{window_layout}"
+tmux list-panes -t dev -F "#{pane_index}:#{pane_current_path}:#{pane_width}:#{pane_height}"
+```
+
+Output as workspace JSON or `.aethel.toml` (if workspace files feature is implemented).
+
+### 3. Files
+
+| File | Change |
+|------|--------|
+| `cmd/aethel/import.go` | New — `import-keybindings` and `import-session` subcommands |
+| `internal/tmux/parser.go` | New — tmux.conf parser and keybinding mapper |
+| `internal/tmux/session.go` | New — tmux session snapshot via CLI commands |
+
+## Success Criteria
+
+- [ ] `aethel import-keybindings tmux` reads `.tmux.conf` and updates `config.toml`
+- [ ] Mapped keybindings work correctly in Aethel
+- [ ] `aethel import-session` captures running tmux layout
+- [ ] Imported session preserves window names, pane CWDs, split structure
+- [ ] Clear output showing what was mapped/imported
+- [ ] Unmappable bindings are listed with explanations
+
+## Open Questions
+
+- Support for tmux plugins (tpm) keybindings?
+- Handle custom prefix keys beyond `Ctrl+B`?
+- Should session import also capture environment variables?
+- Support importing from screen as well?

--- a/docs/roadmap/workspace-files.md
+++ b/docs/roadmap/workspace-files.md
@@ -1,0 +1,159 @@
+# Project Workspace Files (`.aethel.toml`)
+
+| Field | Value |
+|-------|-------|
+| Priority | 3 |
+| Effort | Medium |
+| Impact | Very High |
+| Status | Proposed |
+| Depends on | — |
+
+## Problem
+
+**Layer 3: Project fragmentation** — 5 terminals + 3 tools + 2 SSH sessions = no single "project view." New team members face onboarding friction: "How do I run this project?" → README with 8 terminal commands. Every developer sets up their own ad-hoc arrangement.
+
+This is the single highest-impact feature for adoption. It transforms Aethel from a personal tool into a team infrastructure tool.
+
+## Proposed Solution
+
+Define a workspace blueprint as a `.aethel.toml` file checked into the repository. When a developer runs `aethel` in a directory containing this file, the entire workspace materializes automatically.
+
+```toml
+# .aethel.toml — checked into the repo
+[workspace]
+name = "my-saas-app"
+
+[[tabs]]
+name = "AI + Code"
+[[tabs.panes]]
+plugin = "claude-code"
+cwd = "."
+[[tabs.panes]]
+plugin = "terminal"
+cwd = "."
+split = "vertical"
+
+[[tabs]]
+name = "Backend"
+[[tabs.panes]]
+plugin = "terminal"
+cmd = "npm run dev"
+[[tabs.panes]]
+plugin = "terminal"
+cmd = "npm test -- --watch"
+split = "horizontal"
+
+[[tabs]]
+name = "Infra"
+[[tabs.panes]]
+plugin = "stripe"
+args = ["listen", "--forward-to", "localhost:3000/webhooks"]
+```
+
+Then: `cd my-project && aethel` → entire workspace materializes.
+
+**Why this drives adoption:** Every team member who clones a repo gets the *exact same* dev environment. It becomes like `docker-compose.yml` — once one person adds it, everyone uses it. **Network effect within teams.**
+
+## User Experience
+
+### Creating a Workspace File
+
+```bash
+# Option 1: Manual — create .aethel.toml in project root
+# Option 2: Snapshot current workspace
+aethel workspace export > .aethel.toml
+
+# Option 3: Interactive
+aethel workspace init
+```
+
+### Using a Workspace File
+
+```bash
+cd my-project
+aethel                    # auto-detects .aethel.toml, materializes workspace
+aethel --workspace alt.toml  # use a different workspace file
+```
+
+### Behavior
+
+- If daemon is running with existing workspace, detect `.aethel.toml` and offer to load it
+- If starting fresh, create tabs/panes/splits from the file
+- CWD paths are relative to the `.aethel.toml` location
+- `cmd` fields are executed in the pane after creation
+- Plugin references must exist (built-in or installed in `~/.aethel/plugins/`)
+
+## Technical Approach
+
+### 1. TOML Schema
+
+```go
+type WorkspaceFile struct {
+    Workspace WorkspaceMeta `toml:"workspace"`
+    Tabs      []TabDef      `toml:"tabs"`
+}
+
+type WorkspaceMeta struct {
+    Name    string `toml:"name"`
+    Version string `toml:"version,omitempty"` // schema version
+}
+
+type TabDef struct {
+    Name  string    `toml:"name"`
+    Color string    `toml:"color,omitempty"`
+    Panes []PaneDef `toml:"panes"`
+}
+
+type PaneDef struct {
+    Plugin string   `toml:"plugin"`           // plugin name
+    CWD    string   `toml:"cwd,omitempty"`    // relative to .aethel.toml
+    CMD    string   `toml:"cmd,omitempty"`    // command to run after spawn
+    Args   []string `toml:"args,omitempty"`   // plugin args
+    Split  string   `toml:"split,omitempty"`  // "horizontal" or "vertical"
+    Name   string   `toml:"name,omitempty"`   // pane display name
+}
+```
+
+### 2. Loading Flow
+
+```
+aethel starts
+  → check CWD for .aethel.toml
+  → parse workspace file
+  → connect to daemon (auto-start if needed)
+  → for each tab:
+      → create tab via IPC
+      → for each pane:
+          → resolve plugin
+          → resolve CWD (relative → absolute)
+          → create pane via IPC (with plugin type, args)
+          → if split specified, send split command
+          → if cmd specified, send input to PTY
+```
+
+### 3. Export Command
+
+Snapshot current daemon state into `.aethel.toml` format:
+- Walk tabs/panes, extract plugin type, CWD, instance args
+- Relativize CWD paths to project root
+- Output valid TOML
+
+### 4. File Location
+
+- `internal/workspace/` — new package for workspace file parsing and materialization
+- `cmd/aethel/workspace.go` — CLI subcommands (`export`, `init`)
+
+## Success Criteria
+
+- [ ] `aethel` in a directory with `.aethel.toml` creates the described workspace
+- [ ] `aethel workspace export` snapshots current workspace to valid TOML
+- [ ] Relative CWD paths resolve correctly
+- [ ] Missing plugins produce clear error messages
+- [ ] `.aethel.toml` works across team members (no machine-specific paths)
+
+## Open Questions
+
+- Should workspace files support environment variables / templating?
+- Merge vs replace behavior when daemon already has an active workspace?
+- Should `cmd` support shell operators (pipes, &&)?
+- Version field for schema evolution?


### PR DESCRIPTION
Create docs/roadmap/ with 11 detailed PRDs for planned features:
- Core: workspace files, MCP server, command palette, notification center
- Growth: pre-built binaries, demo GIF, community plugins, tmux migration
- Advanced: process health, cross-pane events, session sharing

Restructure ROADMAP.md with Core/Growth/Advanced categories, priority matrix, strategic pain-layer analysis, and feature synergies.