### PR TITLE
feat(notification): add notification center with smart idle analysis …

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -65,11 +65,11 @@ Architecture: thin bridge between MCP JSON-RPC (stdio) and daemon IPC (socket). 
 
 MCP SDK: `github.com/modelcontextprotocol/go-sdk` (official SDK, v1.4+). Typed tool handlers with struct-based input schemas.
 
-13 MCP tools: `list_panes`, `read_pane_output` (ANSI-stripped), `send_to_pane`, `get_pane_status`, `create_pane`, `send_keys` (named key sequences), `restart_pane`, `screenshot_pane` (VT-emulated text screenshot), `switch_tab`, `list_tabs`, `destroy_pane`, `set_active_pane` (TUI cooperation), `close_tui` (TUI cooperation).
+15 MCP tools: `list_panes`, `read_pane_output` (ANSI-stripped), `send_to_pane`, `get_pane_status`, `create_pane`, `send_keys` (named key sequences), `restart_pane`, `screenshot_pane` (VT-emulated text screenshot), `switch_tab`, `list_tabs`, `destroy_pane`, `set_active_pane` (TUI cooperation), `close_tui` (TUI cooperation), `get_notifications` (non-blocking), `watch_notifications` (blocking, replaces polling).
 
 IPC request-response: `Message.ID` field (omitempty, backward compatible) correlates requests with responses. Daemon responds to the requesting connection when `ID` is set, broadcasts when empty.
 
-Key files: `cmd/aethel/mcp.go` (bridge + daemon connection), `cmd/aethel/mcp_tools.go` (13 tool implementations), `cmd/aethel/mcp_keys.go` (key name → escape sequence map), `cmd/aethel/mcp_log.go` (per-pane interaction logging + two-layer redaction).
+Key files: `cmd/aethel/mcp.go` (bridge + daemon connection), `cmd/aethel/mcp_tools.go` (15 tool implementations), `cmd/aethel/mcp_keys.go` (key name → escape sequence map), `cmd/aethel/mcp_log.go` (per-pane interaction logging + two-layer redaction).
 
 AI tool configuration:
 ```json
@@ -152,4 +152,5 @@ AETHEL_HOME=/custom/path ./aethel  # Arbitrary data directory
 - **M6 (Done):** Pane Focus — Ctrl+E toggles active pane full-screen (`TabModel.focusMode`). Layout tree stays intact; `Resize()`/`View()` skip non-active panes. `* FOCUS *` in pane top border, `[focus]` in status bar. Pane nav disabled in focus. Split/close auto-exit focus. Not persisted
 - **M7:** Pane Notes — side-by-side note-taking linked to panes
 - **M8 (Done):** Bubble Tea v2 + Lipgloss v2 migration — declarative View, typed mouse events, platform-native clipboard (Win32/pbcopy/xclip), text selection (keyboard + mouse), bracketed paste
-- **M10 (Done):** MCP Server — `aethel mcp` exposes 13 tools via Model Context Protocol. Phase A: list_panes, read_pane_output, send_to_pane, get_pane_status, create_pane. Phase B: send_keys, restart_pane, screenshot_pane (VT-emulated), switch_tab, list_tabs, destroy_pane, set_active_pane, close_tui. Official Go SDK (`modelcontextprotocol/go-sdk`). Request-response IPC via `Message.ID` field. TUI cooperation via broadcast messages for set_active_pane and close_tui
+- **M10 (Done):** MCP Server — `aethel mcp` exposes 15 tools via Model Context Protocol. Phase A: list_panes, read_pane_output, send_to_pane, get_pane_status, create_pane. Phase B: send_keys, restart_pane, screenshot_pane (VT-emulated), switch_tab, list_tabs, destroy_pane, set_active_pane, close_tui. Official Go SDK (`modelcontextprotocol/go-sdk`). Request-response IPC via `Message.ID` field. TUI cooperation via broadcast messages for set_active_pane and close_tui
+- **M12 (Done):** Notification Center — daemon event queue (`internal/daemon/event.go`) with process exit detection and output pattern matching via `[[notification_handlers]]` TOML. TUI sidebar (`internal/tui/notification.go`) toggled via Alt+N, non-modal, coexists with panes. Pane history stack with Alt+Backspace navigation. Status bar badge `[N events]`. MCP tools: `get_notifications` (non-blocking) and `watch_notifications` (blocking, replaces polling). `requestWithTimeout` for long waits up to 5 min

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Notification Center (M12)** — daemon event queue with process exit detection, output pattern matching via `[[idle_handlers]]` TOML, and bell character detection with 30s cooldown. TUI sidebar toggled via Alt+N (visibility) / F3 (focus+navigate). Pane history stack with Alt+Backspace navigation. Status bar `[N events]` badge
+- **Smart idle analysis** — when a pane goes idle (5s no output), last lines are analyzed against plugin `[[idle_handlers]]` patterns. SSH `[Y/n]` → "Waiting for confirmation", Claude Code prompt → "Waiting for input", password prompts detected. AI panes default to "warning" severity
+- **OSC 133 command markers** — shell integration hooks extended for bash, zsh, PowerShell to emit command start/end sequences. Daemon parses `OSC 133;D` for precise command completion with exit code
+- **MCP notification tools** — `get_notifications` (non-blocking) and `watch_notifications` (blocking up to 5 min, replaces polling). `requestWithTimeout` for long MCP waits
+- **Plugin `path` field** — optional `path = "/full/path/to/binary"` in plugin TOML overrides PATH lookup. Fallback search in `~/.local/bin/` for Explorer-launched apps on Windows
+- **Plugin `[[idle_handlers]]`** — new TOML section for context-aware idle notifications, parallel to existing `[[error_handlers]]`. Default patterns for terminal, claude-code, and ssh plugins
+
+### Fixed
+
+- **Focus mode mouse selection** — bypasses layout tree traversal when Ctrl+E focus mode is active, uses active pane directly
+- **SSH cursor visibility** — added `"ssh"` to terminal-type check so cursor renders in SSH panes
+- **Paste cursor position** — delayed re-render (100ms) after paste so cursor updates to end of pasted text
+- **DecodePayload error checking** — all 11 pre-existing IPC handlers now check decode errors (was silently ignored)
+- **Shutdown double-close panic** — `sync.Once` guards `close(d.shutdown)` against multiple shutdown messages
+- **Watcher timer leak** — `time.NewTimer` + `defer timer.Stop()` replaces `time.After` in watch goroutine and MCP bridge
+- **Idle detection race** — single `PluginMu` lock span for read+write in `checkIdlePanes` prevents race with `flushPaneOutput`
+- **PowerShell 5.1 compat** — shell init uses `[char]0x1b` for escape instead of `` `e `` which only works in PowerShell 7+
+- **Zsh exit code capture** — `precmd` saves `$?` to local immediately, inserted first in `precmd_functions` before OSC 7
+
+### Changed
+
+- **IPC server** — `onDisconnect` callback now receives `*Conn` for watcher cleanup on disconnect
+- **`flushPaneOutput` refactored** — extracted `detectBellEvent`, `detectOSC133Exit`, `applyPluginHandlers` helpers
+- **Notification matching moved to idle time** — patterns run against last 5 lines at idle, not on every output chunk (eliminates false positives from arrow keys, command history)
+
 ## [0.11.0] - 2026-03-25
 
 ### Added

--- a/cmd/aethel/mcp.go
+++ b/cmd/aethel/mcp.go
@@ -77,8 +77,14 @@ func (b *mcpBridge) sendRaw(msg *ipc.Message) error {
 	return b.client.Send(msg)
 }
 
-// request sends an IPC message and waits for the response with matching ID.
+// request sends an IPC message and waits for the response with the default timeout.
 func (b *mcpBridge) request(msgType string, payload any) (*ipc.Message, error) {
+	return b.requestWithTimeout(msgType, payload, mcpRequestTimeout)
+}
+
+// requestWithTimeout is like request but with a custom timeout.
+// Used by watch_notifications which may block for minutes.
+func (b *mcpBridge) requestWithTimeout(msgType string, payload any, timeout time.Duration) (*ipc.Message, error) {
 	id := uuid.New().String()
 	ch := make(chan *ipc.Message, 1)
 
@@ -102,13 +108,16 @@ func (b *mcpBridge) request(msgType string, payload any) (*ipc.Message, error) {
 		return nil, fmt.Errorf("send %s: %w", msgType, err)
 	}
 
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
 	select {
 	case resp, ok := <-ch:
 		if !ok {
 			return nil, fmt.Errorf("connection lost while waiting for %s response", msgType)
 		}
 		return resp, nil
-	case <-time.After(mcpRequestTimeout):
+	case <-timer.C:
 		b.mu.Lock()
 		delete(b.pending, id)
 		b.mu.Unlock()
@@ -153,7 +162,9 @@ func runMCP() {
 				"- send_keys: for navigating interactive menus, send arrow keys ONE AT A TIME with separate calls. " +
 				"Do NOT batch escape-sequence keys in a single call — TUI apps may only process the first one.\n" +
 				"- send_to_pane: for typing text commands — appends newline by default to execute.\n" +
-				"- Destructive tools (restart_pane, destroy_pane, close_tui): always confirm with the user before using.\n\n" +
+				"- Destructive tools (restart_pane, destroy_pane, close_tui): always confirm with the user before using.\n" +
+				"- watch_notifications: blocks until an event fires on specified panes (replaces polling). Use after starting long-running tasks.\n" +
+				"- get_notifications: returns all pending notification events without blocking.\n\n" +
 				"Sensitive data handling:\n" +
 				"When sending sensitive data (passwords, API keys, tokens, seeds) via send_to_pane or send_keys, " +
 				"wrap the value with <<REDACT>>...<</REDACT>> markers.\n" +

--- a/cmd/aethel/mcp_tools.go
+++ b/cmd/aethel/mcp_tools.go
@@ -27,6 +27,9 @@ func registerMCPTools(s *mcp.Server, bridge *mcpBridge, mcpLog *mcpLogger) {
 	registerDestroyPaneTool(s, bridge, mcpLog)
 	registerSetActivePaneTool(s, bridge, mcpLog)
 	registerCloseTUITool(s, bridge, mcpLog)
+	// Notification tools
+	registerGetNotificationsTool(s, bridge, mcpLog)
+	registerWatchNotificationsTool(s, bridge, mcpLog)
 }
 
 func registerListPanesTool(s *mcp.Server, bridge *mcpBridge, mcpLog *mcpLogger) {
@@ -434,6 +437,76 @@ func registerCloseTUITool(s *mcp.Server, bridge *mcpBridge, mcpLog *mcpLogger) {
 		}
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{&mcp.TextContent{Text: "TUI close signal sent. Daemon continues running."}},
+		}, nil, nil
+	})
+}
+
+// Notification tools
+
+func registerGetNotificationsTool(s *mcp.Server, bridge *mcpBridge, mcpLog *mcpLogger) {
+	type Input struct{}
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "get_notifications",
+		Description: "Get all pending notification events from the Notification Center without blocking. Returns process exits, output pattern matches, and other pane events.",
+	}, func(_ context.Context, _ *mcp.CallToolRequest, _ Input) (*mcp.CallToolResult, any, error) {
+		resp, err := bridge.request(ipc.MsgGetNotificationsReq, nil)
+		if err != nil {
+			return nil, nil, fmt.Errorf("get_notifications: %w", err)
+		}
+		var payload ipc.GetNotificationsRespPayload
+		if err := resp.DecodePayload(&payload); err != nil {
+			return nil, nil, fmt.Errorf("get_notifications decode: %w", err)
+		}
+		mcpLog.Log("", "get_notifications", fmt.Sprintf("events=%d", len(payload.Events)))
+		// GetNotificationsRespPayload has primitive fields — json.MarshalIndent cannot fail
+		text, _ := json.MarshalIndent(payload.Events, "", "  ")
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: string(text)}},
+		}, nil, nil
+	})
+}
+
+func registerWatchNotificationsTool(s *mcp.Server, bridge *mcpBridge, mcpLog *mcpLogger) {
+	type Input struct {
+		PaneIDs []string `json:"pane_ids,omitempty" jsonschema:"pane IDs to watch (empty = all panes)"`
+		Timeout int      `json:"timeout,omitempty" jsonschema:"timeout in seconds (default 60, max 300)"`
+	}
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name: "watch_notifications",
+		Description: "Block until a notification event fires for the specified panes. Returns event details when a process exits, " +
+			"output matches a notification pattern, or timeout. Use this instead of polling with sleep + screenshot.",
+	}, func(_ context.Context, _ *mcp.CallToolRequest, input Input) (*mcp.CallToolResult, any, error) {
+		timeout := input.Timeout
+		if timeout <= 0 {
+			timeout = 60
+		}
+		if timeout > 300 {
+			timeout = 300
+		}
+
+		mcpLog.Log("", "watch_notifications", fmt.Sprintf("panes=%d timeout=%ds", len(input.PaneIDs), timeout))
+
+		resp, err := bridge.requestWithTimeout(
+			ipc.MsgWatchNotificationsReq,
+			ipc.WatchNotificationsReqPayload{
+				PaneIDs:   input.PaneIDs,
+				TimeoutMs: timeout * 1000,
+			},
+			time.Duration(timeout+5)*time.Second,
+		)
+		if err != nil {
+			return nil, nil, fmt.Errorf("watch_notifications: %w", err)
+		}
+		var payload ipc.WatchNotificationsRespPayload
+		if err := resp.DecodePayload(&payload); err != nil {
+			return nil, nil, fmt.Errorf("watch_notifications decode: %w", err)
+		}
+		// WatchNotificationsRespPayload has primitive fields — json.MarshalIndent cannot fail
+		text, _ := json.MarshalIndent(payload, "", "  ")
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: string(text)}},
 		}, nil, nil
 	})
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,8 +15,14 @@ type Config struct {
 	Logging     LoggingConfig     `toml:"logging"`
 	Security    SecurityConfig    `toml:"security"`
 	UI          UIConfig          `toml:"ui"`
-	Keybindings KeybindingsConfig `toml:"keybindings"`
-	MCP         MCPConfig         `toml:"mcp"`
+	Keybindings  KeybindingsConfig  `toml:"keybindings"`
+	MCP          MCPConfig          `toml:"mcp"`
+	Notification NotificationConfig `toml:"notification"`
+}
+
+type NotificationConfig struct {
+	SidebarWidth int `toml:"sidebar_width"` // default 30
+	MaxEvents    int `toml:"max_events"`    // default 50
 }
 
 type MCPConfig struct {
@@ -70,7 +76,10 @@ type KeybindingsConfig struct {
 	Paste           string `toml:"paste"`
 	JSONTransform   string `toml:"json_transform"`
 	QuickActions    string `toml:"quick_actions"`
-	FocusPane       string `toml:"focus_pane"`
+	FocusPane          string `toml:"focus_pane"`
+	NotificationToggle string `toml:"notification_toggle"`
+	NotificationFocus  string `toml:"notification_focus"`
+	GoBack             string `toml:"go_back"`
 }
 
 func Default() Config {
@@ -102,6 +111,10 @@ func Default() Config {
 		MCP: MCPConfig{
 			HighlightDuration: "10s",
 		},
+		Notification: NotificationConfig{
+			SidebarWidth: 30,
+			MaxEvents:    50,
+		},
 		Keybindings: KeybindingsConfig{
 			Quit:            "ctrl+q",
 			NewTab:          "ctrl+t",
@@ -119,7 +132,10 @@ func Default() Config {
 			Paste:           "ctrl+v",
 			JSONTransform:   "ctrl+j",
 			QuickActions:    "ctrl+a",
-			FocusPane:       "ctrl+e",
+			FocusPane:          "ctrl+e",
+			NotificationToggle: "alt+n",
+			NotificationFocus:  "f3",
+			GoBack:             "alt+backspace",
 		},
 	}
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1,15 +1,20 @@
 package daemon
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"log"
 	"os"
 	"os/exec"
 	"os/signal"
+	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
+
+	"regexp"
 
 	"github.com/charmbracelet/x/ansi"
 	"github.com/charmbracelet/x/vt"
@@ -23,14 +28,20 @@ import (
 	"github.com/artyomsv/aethel/internal/shellinit"
 )
 
+// oscBellRe matches OSC sequences terminated by BEL (\x07), e.g., \x1b]0;title\x07.
+// Used to strip these before bell detection so OSC terminators aren't treated as bells.
+var oscBellRe = regexp.MustCompile(`\x1b\][^\x07]*\x07`)
+
 type Daemon struct {
 	cfg        config.Config
 	server     *ipc.Server
 	session    *SessionManager
 	registry   *plugin.Registry
-	shutdown   chan struct{}
-	snapshotCh chan struct{} // buffered channel for snapshot requests
-	restored   bool         // true if workspace was loaded from disk
+	shutdown     chan struct{}
+	shutdownOnce sync.Once
+	snapshotCh   chan struct{} // buffered channel for snapshot requests
+	restored     bool         // true if workspace was loaded from disk
+	events       *eventQueue  // notification center event queue
 }
 
 func New(cfg config.Config) *Daemon {
@@ -42,12 +53,18 @@ func New(cfg config.Config) *Daemon {
 
 	reg := plugin.NewRegistry()
 
+	maxEvents := cfg.Notification.MaxEvents
+	if maxEvents <= 0 {
+		maxEvents = 50
+	}
+
 	return &Daemon{
 		cfg:        cfg,
 		session:    NewSessionManager(bufSize),
 		registry:   reg,
 		shutdown:   make(chan struct{}),
 		snapshotCh: make(chan struct{}, 1),
+		events:     newEventQueue(maxEvents),
 	}
 }
 
@@ -76,7 +93,10 @@ func (d *Daemon) Start() error {
 	}
 
 	sockPath := config.SocketPath()
-	d.server = ipc.NewServer(sockPath, d.handleMessage, func() { d.requestSnapshot() })
+	d.server = ipc.NewServer(sockPath, d.handleMessage, func(conn *ipc.Conn) {
+		d.requestSnapshot()
+		d.events.RemoveWatchersByConn(conn)
+	})
 
 	if err := d.server.Start(); err != nil {
 		return fmt.Errorf("start IPC server: %w", err)
@@ -86,6 +106,8 @@ func (d *Daemon) Start() error {
 	if d.restored {
 		d.respawnPanes()
 	}
+
+	go d.idleChecker()
 
 	log.Printf("aetheld started, listening on %s", sockPath)
 	return nil
@@ -441,7 +463,7 @@ func (d *Daemon) handleMessage(conn *ipc.Conn, msg *ipc.Message) {
 	case ipc.MsgReloadPlugins:
 		d.handleReloadPlugins()
 	case ipc.MsgShutdown:
-		close(d.shutdown)
+		d.shutdownOnce.Do(func() { close(d.shutdown) })
 
 	// MCP request-response
 	case ipc.MsgListPanesReq:
@@ -466,12 +488,23 @@ func (d *Daemon) handleMessage(conn *ipc.Conn, msg *ipc.Message) {
 		d.handleSetActivePane(conn, msg)
 	case ipc.MsgCloseTUI:
 		d.server.Broadcast(msg)
+
+	// Notification center
+	case ipc.MsgDismissEvent:
+		d.handleDismissEvent(msg)
+	case ipc.MsgGetNotificationsReq:
+		d.handleGetNotificationsReq(conn, msg)
+	case ipc.MsgWatchNotificationsReq:
+		d.handleWatchNotificationsReq(conn, msg)
 	}
 }
 
 func (d *Daemon) handleAttach(conn *ipc.Conn, msg *ipc.Message) {
 	var attach ipc.AttachPayload
-	msg.DecodePayload(&attach)
+	if err := msg.DecodePayload(&attach); err != nil {
+		log.Printf("handleAttach: decode: %v", err)
+		return
+	}
 
 	cols, rows := attach.Cols, attach.Rows
 	if cols <= 0 {
@@ -535,11 +568,20 @@ func (d *Daemon) handleAttach(conn *ipc.Conn, msg *ipc.Message) {
 			pane.GhostSnap = nil // clear after first replay
 		}
 	}
+
+	// Replay pending notification events
+	for _, e := range d.events.Events() {
+		payload := toPaneEventPayload(e)
+		evtMsg, _ := ipc.NewMessage(ipc.MsgPaneEvent, payload)
+		conn.Send(evtMsg)
+	}
 }
 
 func (d *Daemon) handleCreateTab(conn *ipc.Conn, msg *ipc.Message) {
 	var payload ipc.CreateTabPayload
-	msg.DecodePayload(&payload)
+	if err := msg.DecodePayload(&payload); err != nil {
+		return
+	}
 
 	tab := d.session.CreateTab(payload.Name)
 	d.session.SwitchTab(tab.ID)
@@ -561,7 +603,9 @@ func (d *Daemon) handleCreateTab(conn *ipc.Conn, msg *ipc.Message) {
 
 func (d *Daemon) handleDestroyTab(msg *ipc.Message) {
 	var payload ipc.DestroyTabPayload
-	msg.DecodePayload(&payload)
+	if err := msg.DecodePayload(&payload); err != nil {
+		return
+	}
 	log.Printf("tab destroy: %s", payload.TabID)
 	d.session.DestroyTab(payload.TabID)
 
@@ -583,7 +627,9 @@ func (d *Daemon) handleDestroyTab(msg *ipc.Message) {
 
 func (d *Daemon) handleSwitchTab(msg *ipc.Message) {
 	var payload ipc.SwitchTabPayload
-	msg.DecodePayload(&payload)
+	if err := msg.DecodePayload(&payload); err != nil {
+		return
+	}
 	log.Printf("tab switch: %s", payload.TabID)
 	d.session.SwitchTab(payload.TabID)
 	d.broadcastState()
@@ -592,7 +638,9 @@ func (d *Daemon) handleSwitchTab(msg *ipc.Message) {
 
 func (d *Daemon) handleUpdateTab(msg *ipc.Message) {
 	var payload ipc.UpdateTabPayload
-	msg.DecodePayload(&payload)
+	if err := msg.DecodePayload(&payload); err != nil {
+		return
+	}
 
 	tab := d.session.Tab(payload.TabID)
 	if tab == nil {
@@ -613,7 +661,9 @@ func (d *Daemon) handleUpdateTab(msg *ipc.Message) {
 
 func (d *Daemon) handleCreatePane(msg *ipc.Message) {
 	var payload ipc.CreatePanePayload
-	msg.DecodePayload(&payload)
+	if err := msg.DecodePayload(&payload); err != nil {
+		return
+	}
 
 	cwd := payload.CWD
 	if cwd == "" {
@@ -679,7 +729,9 @@ func (d *Daemon) handleReplacePane(payload ipc.CreatePanePayload, cwd, paneType 
 
 func (d *Daemon) handleDestroyPane(msg *ipc.Message) {
 	var payload ipc.DestroyPanePayload
-	msg.DecodePayload(&payload)
+	if err := msg.DecodePayload(&payload); err != nil {
+		return
+	}
 
 	// Capture tab ID before destroying the pane
 	var tabID string
@@ -710,7 +762,9 @@ func (d *Daemon) handleDestroyPane(msg *ipc.Message) {
 
 func (d *Daemon) handlePaneInput(msg *ipc.Message) {
 	var payload ipc.PaneInputPayload
-	msg.DecodePayload(&payload)
+	if err := msg.DecodePayload(&payload); err != nil {
+		return
+	}
 
 	pane := d.session.Pane(payload.PaneID)
 	if pane == nil || pane.PTY == nil {
@@ -721,7 +775,9 @@ func (d *Daemon) handlePaneInput(msg *ipc.Message) {
 
 func (d *Daemon) handleResizePane(msg *ipc.Message) {
 	var payload ipc.ResizePanePayload
-	msg.DecodePayload(&payload)
+	if err := msg.DecodePayload(&payload); err != nil {
+		return
+	}
 
 	pane := d.session.Pane(payload.PaneID)
 	if pane == nil || pane.PTY == nil {
@@ -734,7 +790,9 @@ func (d *Daemon) handleResizePane(msg *ipc.Message) {
 
 func (d *Daemon) handleUpdatePane(msg *ipc.Message) {
 	var payload ipc.UpdatePanePayload
-	msg.DecodePayload(&payload)
+	if err := msg.DecodePayload(&payload); err != nil {
+		return
+	}
 
 	pane := d.session.Pane(payload.PaneID)
 	if pane == nil {
@@ -762,7 +820,9 @@ func (d *Daemon) handleReloadPlugins() {
 
 func (d *Daemon) handleUpdateLayout(msg *ipc.Message) {
 	var payload ipc.UpdateLayoutPayload
-	msg.DecodePayload(&payload)
+	if err := msg.DecodePayload(&payload); err != nil {
+		return
+	}
 
 	tab := d.session.Tab(payload.TabID)
 	if tab == nil {
@@ -824,6 +884,24 @@ func (d *Daemon) streamPTYOutput(paneID string, pty apty.Session) {
 					pane.ExitedAt = time.Now()
 					pane.PluginMu.Unlock()
 					log.Printf("pane %s: process exited with code %d", paneID, code)
+
+					severity := "info"
+					title := "Process exited (code 0)"
+					if code != 0 {
+						severity = "error"
+						title = fmt.Sprintf("Process failed (code %d)", code)
+					}
+					d.emitEvent(PaneEvent{
+						ID:        uuid.New().String(),
+						PaneID:    paneID,
+						TabID:     pane.TabID,
+						PaneName:  pane.Name,
+						Type:      "process_exit",
+						Title:     title,
+						Severity:  severity,
+						Timestamp: time.Now(),
+						Data:      map[string]string{"exit_code": strconv.Itoa(code)},
+					})
 				}
 				return
 			}
@@ -851,38 +929,101 @@ func (d *Daemon) flushPaneOutput(paneID string, data []byte) {
 		pane.OutputBuf.Write(data)
 	}
 
-	// Scrape plugin state from output (e.g., session IDs)
-	if pane.Type != "" && pane.Type != "terminal" {
-		p := d.registry.Get(pane.Type)
-		if scraped := plugin.ScrapeOutput(p, data); scraped != nil {
-			pane.PluginMu.Lock()
-			if pane.PluginState == nil {
-				pane.PluginState = make(map[string]string)
-			}
-			for k, v := range scraped {
-				pane.PluginState[k] = v
-				log.Printf("pane %s: scraped %s=%.8s...", paneID, k, v)
-			}
-			pane.PluginMu.Unlock()
-		}
+	// Update idle tracking (guarded by PluginMu for goroutine safety)
+	pane.PluginMu.Lock()
+	pane.LastOutputAt = time.Now()
+	pane.IdleNotified = false
+	pane.PluginMu.Unlock()
 
-		// Check for error patterns
-		if eh := plugin.MatchError(p, data); eh != nil && eh.Action == "dialog" {
-			message := plugin.ExpandMessage(eh.Message, pane.InstanceArgs)
-			errMsg, _ := ipc.NewMessage(ipc.MsgPluginError, ipc.PluginErrorPayload{
-				PaneID:  paneID,
-				Title:   eh.Title,
-				Message: message,
-			})
-			d.server.Broadcast(errMsg)
-		}
-	}
+	d.detectBellEvent(pane, paneID, data)
+	d.detectOSC133Exit(pane, paneID, data)
+	d.applyPluginHandlers(pane, paneID, data)
 
 	msg, _ := ipc.NewMessage(ipc.MsgPaneOutput, ipc.PaneOutputPayload{
 		PaneID: paneID,
 		Data:   data,
 	})
 	d.server.Broadcast(msg)
+}
+
+// detectBellEvent checks for standalone bell characters (not OSC terminators).
+func (d *Daemon) detectBellEvent(pane *Pane, paneID string, data []byte) {
+	const bellCooldown = 30 * time.Second
+	if !bytes.Contains(data, []byte{0x07}) {
+		return
+	}
+	cleaned := oscBellRe.ReplaceAll(data, nil)
+	if !bytes.Contains(cleaned, []byte{0x07}) {
+		return
+	}
+	pane.PluginMu.Lock()
+	defer pane.PluginMu.Unlock()
+	if !pane.LastBellEventAt.IsZero() && time.Since(pane.LastBellEventAt) < bellCooldown {
+		return
+	}
+	pane.LastBellEventAt = time.Now()
+	d.emitEvent(PaneEvent{
+		ID: uuid.New().String(), PaneID: paneID, TabID: pane.TabID,
+		PaneName: pane.Name, Type: "bell",
+		Title: "Attention", Severity: "warning", Timestamp: time.Now(),
+	})
+}
+
+// detectOSC133Exit parses OSC 133;D (command complete) sequences from shell integration.
+func (d *Daemon) detectOSC133Exit(pane *Pane, paneID string, data []byte) {
+	idx := bytes.Index(data, []byte("\x1b]133;D;"))
+	if idx < 0 {
+		return
+	}
+	rest := data[idx+8:]
+	end := bytes.IndexAny(rest, "\x07\x1b")
+	if end <= 0 {
+		return
+	}
+	code, err := strconv.Atoi(string(rest[:end]))
+	if err != nil {
+		return
+	}
+	severity := "info"
+	title := "Command completed"
+	if code != 0 {
+		severity = "error"
+		title = fmt.Sprintf("Command failed (code %d)", code)
+	}
+	d.emitEvent(PaneEvent{
+		ID: uuid.New().String(), PaneID: paneID, TabID: pane.TabID,
+		PaneName: pane.Name, Type: "command_complete",
+		Title: title, Severity: severity, Timestamp: time.Now(),
+		Data: map[string]string{"exit_code": strconv.Itoa(code)},
+	})
+}
+
+// applyPluginHandlers runs scraping, error matching for non-terminal plugins.
+func (d *Daemon) applyPluginHandlers(pane *Pane, paneID string, data []byte) {
+	if pane.Type == "" || pane.Type == "terminal" {
+		return
+	}
+	p := d.registry.Get(pane.Type)
+	if scraped := plugin.ScrapeOutput(p, data); scraped != nil {
+		pane.PluginMu.Lock()
+		if pane.PluginState == nil {
+			pane.PluginState = make(map[string]string)
+		}
+		for k, v := range scraped {
+			pane.PluginState[k] = v
+			log.Printf("pane %s: scraped %s=%.8s...", paneID, k, v)
+		}
+		pane.PluginMu.Unlock()
+	}
+	if eh := plugin.MatchError(p, data); eh != nil && eh.Action == "dialog" {
+		message := plugin.ExpandMessage(eh.Message, pane.InstanceArgs)
+		errMsg, _ := ipc.NewMessage(ipc.MsgPluginError, ipc.PluginErrorPayload{
+			PaneID:  paneID,
+			Title:   eh.Title,
+			Message: message,
+		})
+		d.server.Broadcast(errMsg)
+	}
 }
 
 func (d *Daemon) broadcastState() {
@@ -1067,6 +1208,112 @@ func (d *Daemon) highlightPane(paneID string) {
 func (d *Daemon) respondToAndHighlight(conn *ipc.Conn, requestID, msgType string, payload any, paneID string) {
 	respondTo(conn, requestID, msgType, payload)
 	d.highlightPane(paneID)
+}
+
+// emitEvent pushes an event to the queue and broadcasts to all clients.
+func (d *Daemon) emitEvent(e PaneEvent) {
+	d.events.Push(e)
+	payload := toPaneEventPayload(e)
+	msg, _ := ipc.NewMessage(ipc.MsgPaneEvent, payload)
+	d.server.Broadcast(msg)
+}
+
+// idleChecker runs a periodic check for panes that have gone idle.
+func (d *Daemon) idleChecker() {
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-d.shutdown:
+			return
+		case <-ticker.C:
+			d.checkIdlePanes()
+		}
+	}
+}
+
+func (d *Daemon) checkIdlePanes() {
+	const threshold = 5 * time.Second
+	const cooldown = 30 * time.Second
+	now := time.Now()
+	for _, tab := range d.session.Tabs() {
+		for _, pane := range d.session.Panes(tab.ID) {
+			// Single lock span: read + conditionally write to avoid race with flushPaneOutput
+			pane.PluginMu.Lock()
+			shouldFire := !pane.IdleNotified &&
+				!pane.LastOutputAt.IsZero() &&
+				pane.ExitCode == nil &&
+				(pane.LastIdleEventAt.IsZero() || now.Sub(pane.LastIdleEventAt) >= cooldown) &&
+				now.Sub(pane.LastOutputAt) >= threshold
+			if shouldFire {
+				pane.IdleNotified = true
+				pane.LastIdleEventAt = now
+			}
+			pane.PluginMu.Unlock()
+
+			if !shouldFire {
+				continue
+			}
+
+			title, severity := d.analyzeIdleTitle(pane)
+			d.emitEvent(PaneEvent{
+				ID:        uuid.New().String(),
+				PaneID:    pane.ID,
+				TabID:     pane.TabID,
+				PaneName:  pane.Name,
+				Type:      "output_idle",
+				Title:     title,
+				Severity:  severity,
+				Timestamp: now,
+			})
+		}
+	}
+}
+
+// analyzeIdleTitle determines the notification title/severity by matching
+// the last few lines of pane output against plugin idle handlers.
+func (d *Daemon) analyzeIdleTitle(pane *Pane) (title, severity string) {
+	title = "Output idle"
+	severity = "info"
+
+	p := d.registry.Get(pane.Type)
+	if p == nil {
+		p = d.registry.Get("terminal")
+	}
+	if p == nil {
+		return
+	}
+	if p.Category == "ai" {
+		title = "Waiting for input"
+		severity = "warning"
+	}
+	if pane.OutputBuf != nil && len(p.IdleHandlers) > 0 {
+		raw := pane.OutputBuf.Bytes()
+		// Limit to last 4KB for performance
+		if len(raw) > 4096 {
+			raw = raw[len(raw)-4096:]
+		}
+		stripped := ansi.Strip(string(raw))
+		text := lastNLines(stripped, 5)
+		if ih := plugin.MatchIdle(p, text); ih != nil {
+			title = ih.Title
+			severity = ih.Severity
+		}
+	}
+	return
+}
+
+// lastNLines returns the last n non-empty lines from text.
+func lastNLines(text string, n int) string {
+	lines := strings.Split(text, "\n")
+	var result []string
+	for i := len(lines) - 1; i >= 0 && len(result) < n; i-- {
+		trimmed := strings.TrimSpace(lines[i])
+		if trimmed != "" {
+			result = append([]string{trimmed}, result...)
+		}
+	}
+	return strings.Join(result, "\n")
 }
 
 func (d *Daemon) handleListPanesReq(conn *ipc.Conn, msg *ipc.Message) {
@@ -1479,4 +1726,85 @@ func (d *Daemon) handleSetActivePane(conn *ipc.Conn, msg *ipc.Message) {
 
 	d.broadcastState()
 	d.requestSnapshot()
+}
+
+// Notification center handlers
+
+func (d *Daemon) handleDismissEvent(msg *ipc.Message) {
+	var payload ipc.DismissEventPayload
+	if err := msg.DecodePayload(&payload); err != nil {
+		return
+	}
+	if payload.EventID == "" {
+		d.events.DismissAll()
+	} else {
+		d.events.Dismiss(payload.EventID)
+	}
+}
+
+func (d *Daemon) handleGetNotificationsReq(conn *ipc.Conn, msg *ipc.Message) {
+	events := d.events.Events()
+	var payloads []ipc.PaneEventPayload
+	for _, e := range events {
+		payloads = append(payloads, toPaneEventPayload(e))
+	}
+	respondTo(conn, msg.ID, ipc.MsgGetNotificationsResp, ipc.GetNotificationsRespPayload{
+		Events: payloads,
+	})
+}
+
+func (d *Daemon) handleWatchNotificationsReq(conn *ipc.Conn, msg *ipc.Message) {
+	var req ipc.WatchNotificationsReqPayload
+	if err := msg.DecodePayload(&req); err != nil {
+		log.Printf("handleWatchNotificationsReq: decode: %v", err)
+		respondTo(conn, msg.ID, ipc.MsgWatchNotificationsResp, ipc.WatchNotificationsRespPayload{Timeout: true})
+		return
+	}
+
+	timeoutMs := req.TimeoutMs
+	if timeoutMs <= 0 {
+		timeoutMs = 60000 // 60s default
+	}
+	if timeoutMs > 300000 {
+		timeoutMs = 300000 // 5 min max
+	}
+
+	paneFilter := make(map[string]bool)
+	for _, id := range req.PaneIDs {
+		paneFilter[id] = true
+	}
+
+	// Remove any existing watcher for this connection (limit 1 per connection)
+	d.events.RemoveWatchersByConn(conn)
+
+	watcher := &connWatcher{
+		conn:    conn,
+		paneIDs: paneFilter,
+		ch:      make(chan *PaneEvent, 1),
+	}
+	d.events.AddWatcher(watcher)
+
+	// Block in goroutine — respond when event fires or timeout
+	go func() {
+		timer := time.NewTimer(time.Duration(timeoutMs) * time.Millisecond)
+		defer timer.Stop()
+
+		select {
+		case evt, ok := <-watcher.ch:
+			if !ok {
+				return // connection closed
+			}
+			payload := toPaneEventPayload(*evt)
+			respondTo(conn, msg.ID, ipc.MsgWatchNotificationsResp, ipc.WatchNotificationsRespPayload{
+				Event: &payload,
+			})
+		case <-timer.C:
+			d.events.RemoveWatcher(watcher)
+			respondTo(conn, msg.ID, ipc.MsgWatchNotificationsResp, ipc.WatchNotificationsRespPayload{
+				Timeout: true,
+			})
+		case <-d.shutdown:
+			d.events.RemoveWatcher(watcher)
+		}
+	}()
 }

--- a/internal/daemon/event.go
+++ b/internal/daemon/event.go
@@ -1,0 +1,163 @@
+package daemon
+
+import (
+	"sync"
+	"time"
+
+	"github.com/artyomsv/aethel/internal/ipc"
+)
+
+// PaneEvent represents a notification event from a pane.
+type PaneEvent struct {
+	ID        string
+	PaneID    string
+	TabID     string
+	PaneName  string
+	Type      string            // "process_exit", "output_match"
+	Title     string
+	Message   string
+	Severity  string            // "info", "warning", "error"
+	Timestamp time.Time
+	Data      map[string]string // e.g., {"exit_code": "1"}
+}
+
+// connWatcher blocks an MCP connection until a matching event fires.
+type connWatcher struct {
+	conn    *ipc.Conn
+	paneIDs map[string]bool // filter set (empty = all panes)
+	ch      chan *PaneEvent // buffered(1), woken on match
+}
+
+// eventQueue is a bounded, mutex-protected event store with watcher support.
+type eventQueue struct {
+	events   []PaneEvent
+	max      int
+	watchers []*connWatcher
+	mu       sync.Mutex
+}
+
+func newEventQueue(max int) *eventQueue {
+	if max <= 0 {
+		max = 50
+	}
+	return &eventQueue{
+		max:    max,
+		events: make([]PaneEvent, 0, max),
+	}
+}
+
+// Push adds an event (newest first) and wakes any matching watchers.
+func (q *eventQueue) Push(e PaneEvent) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	q.events = append([]PaneEvent{e}, q.events...)
+	if len(q.events) > q.max {
+		q.events = q.events[:q.max]
+	}
+
+	// Wake matching watchers (one-shot: remove after waking)
+	var remaining []*connWatcher
+	for _, w := range q.watchers {
+		if len(w.paneIDs) == 0 || w.paneIDs[e.PaneID] {
+			select {
+			case w.ch <- &e:
+			default:
+			}
+			// Don't add to remaining — watcher is consumed
+		} else {
+			remaining = append(remaining, w)
+		}
+	}
+	q.watchers = remaining
+}
+
+// Dismiss removes an event by ID.
+func (q *eventQueue) Dismiss(eventID string) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	for i, e := range q.events {
+		if e.ID == eventID {
+			q.events = append(q.events[:i], q.events[i+1:]...)
+			return
+		}
+	}
+}
+
+// DismissAll removes all events.
+func (q *eventQueue) DismissAll() {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.events = nil
+}
+
+// Events returns a snapshot copy of all events.
+func (q *eventQueue) Events() []PaneEvent {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	out := make([]PaneEvent, len(q.events))
+	copy(out, q.events)
+	return out
+}
+
+// Count returns the number of pending events.
+func (q *eventQueue) Count() int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return len(q.events)
+}
+
+// AddWatcher registers a connection to be woken when a matching event fires.
+func (q *eventQueue) AddWatcher(w *connWatcher) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.watchers = append(q.watchers, w)
+}
+
+// RemoveWatcher removes a specific watcher (used on timeout).
+func (q *eventQueue) RemoveWatcher(w *connWatcher) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	for i, existing := range q.watchers {
+		if existing == w {
+			q.watchers = append(q.watchers[:i], q.watchers[i+1:]...)
+			return
+		}
+	}
+}
+
+// RemoveWatchersByConn removes all watchers for a specific connection
+// and closes their channels to unblock any waiting goroutines.
+func (q *eventQueue) RemoveWatchersByConn(conn *ipc.Conn) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	var remaining []*connWatcher
+	for _, w := range q.watchers {
+		if w.conn == conn {
+			close(w.ch)
+		} else {
+			remaining = append(remaining, w)
+		}
+	}
+	q.watchers = remaining
+}
+
+// toPaneEventPayload converts a PaneEvent to an IPC payload.
+func toPaneEventPayload(e PaneEvent) ipc.PaneEventPayload {
+	return ipc.PaneEventPayload{
+		ID:        e.ID,
+		PaneID:    e.PaneID,
+		TabID:     e.TabID,
+		PaneName:  e.PaneName,
+		Type:      e.Type,
+		Title:     e.Title,
+		Message:   e.Message,
+		Severity:  e.Severity,
+		Timestamp: e.Timestamp.UnixMilli(),
+		Data:      e.Data,
+	}
+}

--- a/internal/daemon/event_test.go
+++ b/internal/daemon/event_test.go
@@ -1,0 +1,118 @@
+package daemon
+
+import (
+	"testing"
+	"time"
+)
+
+func TestEventQueue_Push_BoundsToMax(t *testing.T) {
+	q := newEventQueue(3)
+	for i := 0; i < 5; i++ {
+		q.Push(PaneEvent{ID: string(rune('a' + i)), Title: "event"})
+	}
+	if q.Count() != 3 {
+		t.Errorf("Count: got %d, want 3", q.Count())
+	}
+	events := q.Events()
+	// Newest first
+	if events[0].ID != "e" {
+		t.Errorf("events[0].ID: got %q, want %q", events[0].ID, "e")
+	}
+}
+
+func TestEventQueue_Push_NewestFirst(t *testing.T) {
+	q := newEventQueue(10)
+	q.Push(PaneEvent{ID: "first"})
+	q.Push(PaneEvent{ID: "second"})
+	events := q.Events()
+	if events[0].ID != "second" {
+		t.Errorf("events[0].ID: got %q, want %q", events[0].ID, "second")
+	}
+}
+
+func TestEventQueue_Dismiss(t *testing.T) {
+	q := newEventQueue(10)
+	q.Push(PaneEvent{ID: "a"})
+	q.Push(PaneEvent{ID: "b"})
+	q.Dismiss("a")
+	if q.Count() != 1 {
+		t.Errorf("Count after dismiss: got %d, want 1", q.Count())
+	}
+	if q.Events()[0].ID != "b" {
+		t.Errorf("remaining event: got %q, want %q", q.Events()[0].ID, "b")
+	}
+}
+
+func TestEventQueue_DismissAll(t *testing.T) {
+	q := newEventQueue(10)
+	q.Push(PaneEvent{ID: "a"})
+	q.Push(PaneEvent{ID: "b"})
+	q.DismissAll()
+	if q.Count() != 0 {
+		t.Errorf("Count after dismiss all: got %d, want 0", q.Count())
+	}
+}
+
+func TestEventQueue_WatcherWoken(t *testing.T) {
+	q := newEventQueue(10)
+	ch := make(chan *PaneEvent, 1)
+	w := &connWatcher{paneIDs: nil, ch: ch} // nil = all panes
+	q.AddWatcher(w)
+
+	q.Push(PaneEvent{ID: "evt1", PaneID: "pane-1"})
+
+	select {
+	case evt := <-ch:
+		if evt.ID != "evt1" {
+			t.Errorf("watcher got %q, want %q", evt.ID, "evt1")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("watcher not woken within 1s")
+	}
+}
+
+func TestEventQueue_WatcherFiltered(t *testing.T) {
+	q := newEventQueue(10)
+	ch := make(chan *PaneEvent, 1)
+	w := &connWatcher{
+		paneIDs: map[string]bool{"pane-2": true},
+		ch:      ch,
+	}
+	q.AddWatcher(w)
+
+	// Push event for pane-1 (should NOT wake watcher)
+	q.Push(PaneEvent{ID: "evt1", PaneID: "pane-1"})
+	select {
+	case <-ch:
+		t.Fatal("watcher should not be woken for pane-1")
+	case <-time.After(50 * time.Millisecond):
+		// expected
+	}
+
+	// Push event for pane-2 (should wake watcher)
+	q.Push(PaneEvent{ID: "evt2", PaneID: "pane-2"})
+	select {
+	case evt := <-ch:
+		if evt.ID != "evt2" {
+			t.Errorf("watcher got %q, want %q", evt.ID, "evt2")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("watcher not woken for pane-2")
+	}
+}
+
+func TestEventQueue_RemoveWatcher(t *testing.T) {
+	q := newEventQueue(10)
+	ch := make(chan *PaneEvent, 1)
+	w := &connWatcher{paneIDs: nil, ch: ch}
+	q.AddWatcher(w)
+	q.RemoveWatcher(w)
+
+	q.Push(PaneEvent{ID: "evt1"})
+	select {
+	case <-ch:
+		t.Fatal("removed watcher should not be woken")
+	case <-time.After(50 * time.Millisecond):
+		// expected
+	}
+}

--- a/internal/daemon/session.go
+++ b/internal/daemon/session.go
@@ -36,6 +36,10 @@ type Pane struct {
 	ExitedAt     time.Time           // When the process exited (zero if running)
 	Cols         int                 // Last known terminal width (0 = unknown)
 	Rows         int                 // Last known terminal height (0 = unknown)
+	LastOutputAt    time.Time        // Updated on every flushPaneOutput
+	IdleNotified    bool             // Prevents re-firing for same idle period
+	LastIdleEventAt time.Time        // Cooldown: last time an idle event was emitted
+	LastBellEventAt time.Time        // Cooldown: last time a bell event was emitted
 }
 
 type SessionManager struct {

--- a/internal/ipc/protocol.go
+++ b/internal/ipc/protocol.go
@@ -64,6 +64,14 @@ const (
 	MsgSetActivePane      = "set_active_pane"  // broadcast to TUI
 	MsgCloseTUI           = "close_tui"        // broadcast to TUI
 	MsgHighlightPane      = "highlight_pane"   // broadcast to TUI (MCP interaction indicator)
+
+	// Notification center (M12)
+	MsgPaneEvent              = "pane_event"               // broadcast to TUI
+	MsgDismissEvent           = "dismiss_event"            // client → daemon
+	MsgGetNotificationsReq    = "get_notifications_req"    // MCP request
+	MsgGetNotificationsResp   = "get_notifications_resp"   // MCP response
+	MsgWatchNotificationsReq  = "watch_notifications_req"  // MCP request (blocking)
+	MsgWatchNotificationsResp = "watch_notifications_resp" // MCP response
 )
 
 // Message is the wire format for IPC communication.
@@ -257,6 +265,39 @@ type SetActivePanePayload struct {
 
 type HighlightPanePayload struct {
 	PaneID string `json:"pane_id"`
+}
+
+// Notification center payloads (M12)
+
+type PaneEventPayload struct {
+	ID        string            `json:"id"`
+	PaneID    string            `json:"pane_id"`
+	TabID     string            `json:"tab_id"`
+	PaneName  string            `json:"pane_name"`
+	Type      string            `json:"type"`
+	Title     string            `json:"title"`
+	Message   string            `json:"message,omitempty"`
+	Severity  string            `json:"severity"`
+	Timestamp int64             `json:"timestamp"`
+	Data      map[string]string `json:"data,omitempty"`
+}
+
+type DismissEventPayload struct {
+	EventID string `json:"event_id"` // empty = dismiss all
+}
+
+type GetNotificationsRespPayload struct {
+	Events []PaneEventPayload `json:"events"`
+}
+
+type WatchNotificationsReqPayload struct {
+	PaneIDs   []string `json:"pane_ids,omitempty"`
+	TimeoutMs int      `json:"timeout_ms"`
+}
+
+type WatchNotificationsRespPayload struct {
+	Event   *PaneEventPayload `json:"event,omitempty"`
+	Timeout bool              `json:"timeout"`
 }
 
 // NewMessage creates a Message with a typed payload.

--- a/internal/ipc/protocol_test.go
+++ b/internal/ipc/protocol_test.go
@@ -95,6 +95,12 @@ func TestMessageTypes(t *testing.T) {
 		ipc.MsgSetActivePane,
 		ipc.MsgCloseTUI,
 		ipc.MsgHighlightPane,
+		ipc.MsgPaneEvent,
+		ipc.MsgDismissEvent,
+		ipc.MsgGetNotificationsReq,
+		ipc.MsgGetNotificationsResp,
+		ipc.MsgWatchNotificationsReq,
+		ipc.MsgWatchNotificationsResp,
 	}
 	for _, typ := range types {
 		if typ == "" {

--- a/internal/ipc/server.go
+++ b/internal/ipc/server.go
@@ -38,14 +38,14 @@ func (c *Conn) Close() error {
 type Server struct {
 	path         string
 	handler      MessageHandler
-	onDisconnect func() // called when a client disconnects
+	onDisconnect func(*Conn) // called when a client disconnects
 	listener     net.Listener
 	conns        []*Conn
 	mu           sync.Mutex
 	done         chan struct{}
 }
 
-func NewServer(socketPath string, handler MessageHandler, onDisconnect func()) *Server {
+func NewServer(socketPath string, handler MessageHandler, onDisconnect func(*Conn)) *Server {
 	return &Server{
 		path:         socketPath,
 		handler:      handler,
@@ -83,7 +83,9 @@ func (s *Server) Broadcast(msg *Message) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for _, c := range s.conns {
-		c.Send(msg)
+		if err := c.Send(msg); err != nil {
+			log.Printf("broadcast send: %v", err)
+		}
 	}
 }
 
@@ -120,7 +122,7 @@ func (s *Server) handleConn(conn *Conn) {
 		s.mu.Unlock()
 		log.Printf("ipc: client disconnected (remaining=%d)", count)
 		if s.onDisconnect != nil {
-			s.onDisconnect()
+			s.onDisconnect(conn)
 		}
 	}()
 

--- a/internal/plugin/builtin.go
+++ b/internal/plugin/builtin.go
@@ -23,6 +23,11 @@ func builtinTerminal() *PanePlugin {
 			GhostBuffer: true,
 		},
 		Instances: instances,
+		IdleHandlers: []IdleHandler{
+			{Pattern: `(?i)\[Y/n\]|\[y/N\]|\(yes/no\)|Continue\?|Proceed\?`, Title: "Waiting for confirmation", Severity: "warning"},
+			{Pattern: `(?i)password:|passphrase:`, Title: "Waiting for password", Severity: "warning"},
+			{Pattern: `(?i)(error|FAIL|fatal|panic|exception)`, Title: "Error detected", Severity: "error"},
+		},
 		Available: true, // always available
 	}
 }

--- a/internal/plugin/defaults/claude-code.toml
+++ b/internal/plugin/defaults/claude-code.toml
@@ -9,6 +9,7 @@ description = "AI coding assistant"
 
 [command]
 cmd = "claude"
+# path = "/path/to/claude"  # uncomment to override PATH lookup
 detect = "claude --version"
 
 [persistence]
@@ -22,3 +23,19 @@ pattern = '(?i)error.*API key not found|ANTHROPIC_API_KEY.*not set'
 title = "API Key Missing"
 message = "Set ANTHROPIC_API_KEY in your environment or run 'claude auth'."
 action = "dialog"
+
+# Idle handlers — checked when pane goes idle (last 5 lines analyzed)
+[[idle_handlers]]
+pattern = '(?i)waiting for (confirmation|input|approval|permission)'
+title = "Needs your approval"
+severity = "warning"
+
+[[idle_handlers]]
+pattern = '(?i)(plan|question|choose|select|pick)'
+title = "Waiting for your choice"
+severity = "warning"
+
+[[idle_handlers]]
+pattern = '❯|> $'
+title = "Waiting for input"
+severity = "info"

--- a/internal/plugin/defaults/ssh.toml
+++ b/internal/plugin/defaults/ssh.toml
@@ -9,6 +9,7 @@ description = "Remote SSH connection"
 
 [command]
 cmd = "ssh"
+# path = "/usr/bin/ssh"  # uncomment to override PATH lookup
 detect = "ssh -V"
 arg_template = ["-p", "{port}", "{user}@{host}"]
 
@@ -65,3 +66,19 @@ pattern = "Connection refused|No route to host"
 title = "Connection Failed"
 message = "Cannot reach host. Check that the server is running and the address is correct."
 action = "dialog"
+
+# Idle handlers — checked when pane goes idle (last 5 lines analyzed)
+[[idle_handlers]]
+pattern = '(?i)\[Y/n\]|\[y/N\]|\(yes/no\)|Continue\?|Proceed\?'
+title = "Waiting for confirmation"
+severity = "warning"
+
+[[idle_handlers]]
+pattern = '(?i)password:|passphrase:'
+title = "Waiting for password"
+severity = "warning"
+
+[[idle_handlers]]
+pattern = '(?i)(error|FAIL|fatal|panic)'
+title = "Error detected"
+severity = "error"

--- a/internal/plugin/defaults/stripe.toml
+++ b/internal/plugin/defaults/stripe.toml
@@ -9,6 +9,7 @@ description = "Stripe webhook listener"
 
 [command]
 cmd = "stripe"
+# path = "E:/Tools/stripe/stripe.exe"  # uncomment to override PATH lookup
 args = ["listen"]
 detect = "stripe --version"
 arg_template = ["listen", "--forward-to", "{url}"]

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -13,13 +13,16 @@ type PanePlugin struct {
 	Persistence   PersistenceConfig
 	Display       DisplayConfig
 	Instances     []InstanceConfig
-	ErrorHandlers []ErrorHandler
-	Available     bool // set at startup by running detect cmd
+	ErrorHandlers        []ErrorHandler
+	NotificationHandlers []NotificationHandler
+	IdleHandlers         []IdleHandler
+	Available            bool // set at startup by running detect cmd
 }
 
 // CommandConfig describes how to launch the plugin's process.
 type CommandConfig struct {
 	Cmd              string
+	Path             string      // optional: full path to binary (overrides PATH lookup)
 	Args             []string
 	Env              []string
 	DetectCmd        string
@@ -105,4 +108,52 @@ func (eh *ErrorHandler) Compile() error {
 // Compiled returns the compiled regex, or nil if compilation failed.
 func (eh *ErrorHandler) Compiled() *regexp.Regexp {
 	return eh.compiled
+}
+
+// NotificationHandler matches PTY output patterns and triggers notification events.
+type NotificationHandler struct {
+	Pattern  string
+	Title    string
+	Severity string // "info", "warning", "error"
+	compiled *regexp.Regexp
+}
+
+// Compile pre-compiles the regex pattern.
+func (nh *NotificationHandler) Compile() error {
+	re, err := regexp.Compile(nh.Pattern)
+	if err != nil {
+		return err
+	}
+	nh.compiled = re
+	return nil
+}
+
+// Compiled returns the compiled regex, or nil if compilation failed.
+func (nh *NotificationHandler) Compiled() *regexp.Regexp {
+	return nh.compiled
+}
+
+// IdleHandler matches patterns against pane content when the pane goes idle.
+// Unlike NotificationHandler (checked on every output chunk), IdleHandler runs
+// only at idle time against the last few lines — much less noisy.
+type IdleHandler struct {
+	Pattern  string
+	Title    string
+	Severity string // "info", "warning", "error"
+	compiled *regexp.Regexp
+}
+
+// Compile pre-compiles the regex pattern.
+func (ih *IdleHandler) Compile() error {
+	re, err := regexp.Compile(ih.Pattern)
+	if err != nil {
+		return err
+	}
+	ih.compiled = re
+	return nil
+}
+
+// Compiled returns the compiled regex, or nil if compilation failed.
+func (ih *IdleHandler) Compiled() *regexp.Regexp {
+	return ih.compiled
 }

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -498,3 +498,97 @@ func TestErrorHandlerCompile(t *testing.T) {
 		t.Fatal("compiled regex should not be nil")
 	}
 }
+
+func TestMatchNotification(t *testing.T) {
+	p := &PanePlugin{
+		NotificationHandlers: []NotificationHandler{
+			{Pattern: `(?i)waiting for confirmation`, Title: "Needs attention", Severity: "warning"},
+			{Pattern: `(?i)task completed`, Title: "Done", Severity: "info"},
+		},
+	}
+	for i := range p.NotificationHandlers {
+		if err := p.NotificationHandlers[i].Compile(); err != nil {
+			t.Fatalf("compile: %v", err)
+		}
+	}
+
+	nh := MatchNotification(p, []byte("Waiting for confirmation from user"))
+	if nh == nil {
+		t.Fatal("expected match for 'waiting for confirmation'")
+	}
+	if nh.Title != "Needs attention" {
+		t.Errorf("Title: got %q, want %q", nh.Title, "Needs attention")
+	}
+	if nh.Severity != "warning" {
+		t.Errorf("Severity: got %q, want %q", nh.Severity, "warning")
+	}
+}
+
+func TestMatchNotificationNoMatch(t *testing.T) {
+	p := &PanePlugin{
+		NotificationHandlers: []NotificationHandler{
+			{Pattern: `(?i)waiting for confirmation`, Title: "Needs attention", Severity: "warning"},
+		},
+	}
+	for i := range p.NotificationHandlers {
+		p.NotificationHandlers[i].Compile()
+	}
+
+	nh := MatchNotification(p, []byte("normal output with no match"))
+	if nh != nil {
+		t.Fatal("expected no match for normal output")
+	}
+}
+
+func TestNotificationHandlerCompile(t *testing.T) {
+	nh := NotificationHandler{Pattern: `[invalid`}
+	if err := nh.Compile(); err == nil {
+		t.Fatal("expected error for invalid regex")
+	}
+
+	nh2 := NotificationHandler{Pattern: `valid.*pattern`}
+	if err := nh2.Compile(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if nh2.Compiled() == nil {
+		t.Fatal("compiled regex should not be nil")
+	}
+}
+
+func TestMatchIdle_Match_ReturnsHandler(t *testing.T) {
+	p := &PanePlugin{
+		IdleHandlers: []IdleHandler{
+			{Pattern: `(?i)\[Y/n\]`, Title: "Waiting for confirmation", Severity: "warning"},
+			{Pattern: `(?i)password:`, Title: "Waiting for password", Severity: "warning"},
+		},
+	}
+	for i := range p.IdleHandlers {
+		if err := p.IdleHandlers[i].Compile(); err != nil {
+			t.Fatalf("compile: %v", err)
+		}
+	}
+
+	ih := MatchIdle(p, "Do you want to continue? [Y/n]")
+	if ih == nil {
+		t.Fatal("expected match for [Y/n]")
+	}
+	if ih.Title != "Waiting for confirmation" {
+		t.Errorf("Title: got %q, want %q", ih.Title, "Waiting for confirmation")
+	}
+}
+
+func TestMatchIdle_NoMatch_ReturnsNil(t *testing.T) {
+	p := &PanePlugin{
+		IdleHandlers: []IdleHandler{
+			{Pattern: `(?i)\[Y/n\]`, Title: "Waiting for confirmation", Severity: "warning"},
+		},
+	}
+	for i := range p.IdleHandlers {
+		p.IdleHandlers[i].Compile()
+	}
+
+	ih := MatchIdle(p, "artyom@server:~$")
+	if ih != nil {
+		t.Fatal("expected no match for shell prompt")
+	}
+}

--- a/internal/plugin/registry.go
+++ b/internal/plugin/registry.go
@@ -43,6 +43,16 @@ func compilePatterns(p *PanePlugin) {
 			log.Printf("plugin %s: invalid error pattern %q: %v", p.Name, p.ErrorHandlers[i].Pattern, err)
 		}
 	}
+	for i := range p.NotificationHandlers {
+		if err := p.NotificationHandlers[i].Compile(); err != nil {
+			log.Printf("plugin %s: invalid notification pattern %q: %v", p.Name, p.NotificationHandlers[i].Pattern, err)
+		}
+	}
+	for i := range p.IdleHandlers {
+		if err := p.IdleHandlers[i].Compile(); err != nil {
+			log.Printf("plugin %s: invalid idle pattern %q: %v", p.Name, p.IdleHandlers[i].Pattern, err)
+		}
+	}
 }
 
 // Get returns a plugin by name, or nil if not found.
@@ -129,11 +139,13 @@ func (r *Registry) LoadFromDir(dir string) error {
 	return nil
 }
 
-// DetectAvailability checks whether each plugin's tool is installed by
-// looking up the binary on PATH. Terminal is always available.
+// DetectAvailability checks whether each plugin's tool is installed.
+// Search order: 1) explicit Path field, 2) PATH lookup, 3) common install locations.
 func (r *Registry) DetectAvailability() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+
+	home, _ := os.UserHomeDir()
 
 	for _, p := range r.plugins {
 		if p.Name == "terminal" {
@@ -141,8 +153,17 @@ func (r *Registry) DetectAvailability() {
 			continue
 		}
 
-		// Determine which binary to look for:
-		// prefer the detect command's binary (first word), fall back to cmd.
+		// 1. Explicit path override (set by user in TOML: path = "C:\\...")
+		if p.Command.Path != "" {
+			if _, err := os.Stat(p.Command.Path); err == nil {
+				p.Available = true
+				p.Command.Cmd = p.Command.Path
+				log.Printf("plugin %s: using explicit path %q", p.Name, p.Command.Path)
+				continue
+			}
+		}
+
+		// Determine which binary to look for
 		bin := p.Command.Cmd
 		if p.Command.DetectCmd != "" {
 			if parts := strings.Fields(p.Command.DetectCmd); len(parts) > 0 {
@@ -150,10 +171,56 @@ func (r *Registry) DetectAvailability() {
 			}
 		}
 
+		// 2. Standard PATH lookup
 		if _, err := exec.LookPath(bin); err == nil {
 			p.Available = true
+			log.Printf("plugin %s: detected %q on PATH", p.Name, bin)
+			continue
+		}
+
+		// 3. Search additional locations (Windows: Explorer-launched apps may have incomplete PATH)
+		if found := searchBinary(p, bin, home); found {
+			continue
+		}
+		log.Printf("plugin %s: %q not found on PATH or common locations", p.Name, bin)
+	}
+}
+
+// searchBinary finds a binary when exec.LookPath fails (common on Windows when
+// launched from Explorer). Re-scans PATH directories with os.Stat which is more
+// reliable than LookPath for Explorer-launched processes with PATHEXT issues.
+func searchBinary(p *PanePlugin, bin, home string) bool {
+	suffixes := []string{"", ".exe"}
+
+	// Common locations
+	var dirs []string
+	if home != "" {
+		dirs = append(dirs, filepath.Join(home, ".local", "bin"))
+	}
+
+	// On Windows, read the full User PATH from environment to cover
+	// directories that may be missing from Explorer-launched processes
+	if userPath := os.Getenv("Path"); userPath != "" {
+		for _, dir := range strings.Split(userPath, string(os.PathListSeparator)) {
+			dir = strings.TrimSpace(dir)
+			if dir != "" {
+				dirs = append(dirs, dir)
+			}
 		}
 	}
+
+	for _, dir := range dirs {
+		for _, suffix := range suffixes {
+			candidate := filepath.Join(dir, bin+suffix)
+			if _, err := os.Stat(candidate); err == nil {
+				p.Available = true
+				p.Command.Cmd = candidate
+				log.Printf("plugin %s: found at %q (fallback search)", p.Name, candidate)
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // tomlPlugin is the on-disk representation of a plugin TOML file.
@@ -166,6 +233,7 @@ type tomlPlugin struct {
 	} `toml:"plugin"`
 	Command struct {
 		Cmd              string   `toml:"cmd"`
+		Path             string   `toml:"path"` // optional: full path to binary
 		Args             []string `toml:"args"`
 		Env              []string `toml:"env"`
 		Detect           string   `toml:"detect"`
@@ -204,6 +272,16 @@ type tomlPlugin struct {
 		Message string `toml:"message"`
 		Action  string `toml:"action"`
 	} `toml:"error_handlers"`
+	NotificationHandlers []struct {
+		Pattern  string `toml:"pattern"`
+		Title    string `toml:"title"`
+		Severity string `toml:"severity"`
+	} `toml:"notification_handlers"`
+	IdleHandlers []struct {
+		Pattern  string `toml:"pattern"`
+		Title    string `toml:"title"`
+		Severity string `toml:"severity"`
+	} `toml:"idle_handlers"`
 }
 
 func loadPluginTOML(path string) (*PanePlugin, error) {
@@ -241,6 +319,7 @@ func loadPluginTOML(path string) (*PanePlugin, error) {
 		Description: tp.Plugin.Description,
 		Command: CommandConfig{
 			Cmd:              tp.Command.Cmd,
+			Path:             tp.Command.Path,
 			Args:             tp.Command.Args,
 			Env:              tp.Command.Env,
 			DetectCmd:        tp.Command.Detect,
@@ -302,6 +381,44 @@ func loadPluginTOML(path string) (*PanePlugin, error) {
 			Title:   eh.Title,
 			Message: eh.Message,
 			Action:  action,
+		})
+	}
+
+	// Convert notification handlers
+	for _, nh := range tp.NotificationHandlers {
+		severity := nh.Severity
+		switch severity {
+		case "info", "warning", "error":
+			// valid
+		case "":
+			severity = "info"
+		default:
+			log.Printf("plugin %q: unknown notification severity %q, defaulting to info", tp.Plugin.Name, severity)
+			severity = "info"
+		}
+		p.NotificationHandlers = append(p.NotificationHandlers, NotificationHandler{
+			Pattern:  nh.Pattern,
+			Title:    nh.Title,
+			Severity: severity,
+		})
+	}
+
+	// Convert idle handlers
+	for _, ih := range tp.IdleHandlers {
+		severity := ih.Severity
+		switch severity {
+		case "info", "warning", "error":
+			// valid
+		case "":
+			severity = "info"
+		default:
+			log.Printf("plugin %q: unknown idle handler severity %q, defaulting to info", tp.Plugin.Name, severity)
+			severity = "info"
+		}
+		p.IdleHandlers = append(p.IdleHandlers, IdleHandler{
+			Pattern:  ih.Pattern,
+			Title:    ih.Title,
+			Severity: severity,
 		})
 	}
 

--- a/internal/plugin/scraper.go
+++ b/internal/plugin/scraper.go
@@ -47,6 +47,47 @@ func MatchError(p *PanePlugin, data []byte) *ErrorHandler {
 	return nil
 }
 
+// Deprecated: MatchNotification is no longer called from the daemon.
+// Notification matching was replaced by idle-time analysis via MatchIdle.
+// Kept for backward compatibility with TOML files that define [[notification_handlers]].
+func MatchNotification(p *PanePlugin, data []byte) *NotificationHandler {
+	if p == nil || len(p.NotificationHandlers) == 0 {
+		return nil
+	}
+
+	for i := range p.NotificationHandlers {
+		nh := &p.NotificationHandlers[i]
+		re := nh.Compiled()
+		if re == nil {
+			continue
+		}
+		if re.Match(data) {
+			return nh
+		}
+	}
+	return nil
+}
+
+// MatchIdle checks ANSI-stripped pane text against a plugin's idle handlers.
+// Called at idle time with the last few lines of output, not on every chunk.
+func MatchIdle(p *PanePlugin, text string) *IdleHandler {
+	if p == nil || len(p.IdleHandlers) == 0 {
+		return nil
+	}
+
+	for i := range p.IdleHandlers {
+		ih := &p.IdleHandlers[i]
+		re := ih.Compiled()
+		if re == nil {
+			continue
+		}
+		if re.MatchString(text) {
+			return ih
+		}
+	}
+	return nil
+}
+
 // ExpandResumeArgs replaces {key} placeholders in resume args with
 // scraped values from plugin state. Returns nil if any placeholder
 // remains unresolved (missing state value).

--- a/internal/shellinit/scripts/bash-init.sh
+++ b/internal/shellinit/scripts/bash-init.sh
@@ -1,9 +1,19 @@
-# Aethel shell integration — OSC 7 for bash
+# Aethel shell integration — OSC 7 + OSC 133 for bash
 # Source user's bashrc (--rcfile replaces normal loading)
 if [ -f ~/.bashrc ]; then . ~/.bashrc; fi
 
 # Emit OSC 7 with current working directory after every command
 __aethel_osc7() { printf '\e]7;file://%s%s\e\\' "${HOSTNAME:-localhost}" "$PWD"; }
+
+# OSC 133: command markers for notification center
+__aethel_precmd() {
+    local ec=$?
+    printf '\e]133;D;%d\e\\' "$ec"
+    printf '\e]133;A\e\\'
+}
+__aethel_preexec() { printf '\e]133;B\e\\'; }
+
 if [[ "${PROMPT_COMMAND}" != *"__aethel_osc7"* ]]; then
-    PROMPT_COMMAND="__aethel_osc7${PROMPT_COMMAND:+;$PROMPT_COMMAND}"
+    PROMPT_COMMAND="__aethel_precmd;__aethel_osc7${PROMPT_COMMAND:+;$PROMPT_COMMAND}"
 fi
+trap '__aethel_preexec' DEBUG

--- a/internal/shellinit/scripts/pwsh-init.ps1
+++ b/internal/shellinit/scripts/pwsh-init.ps1
@@ -1,12 +1,20 @@
-# Aethel shell integration — OSC 7 for PowerShell
+# Aethel shell integration — OSC 7 + OSC 133 for PowerShell
 # Source user's profile (-NoProfile prevents auto-loading)
 if (Test-Path $PROFILE.CurrentUserCurrentHost) { . $PROFILE.CurrentUserCurrentHost }
 
-# Override prompt to emit OSC 7
+# Override prompt to emit OSC 7 + OSC 133 command markers
+# Use [char]0x1b for ESC — compatible with both PowerShell 7+ and Windows PowerShell 5.1
+$__aethel_esc = [char]0x1b
 $__aethel_original_prompt = $function:prompt
 function prompt {
+    # OSC 133;D — report previous command exit code
+    $ec = $LASTEXITCODE; if ($null -eq $ec) { $ec = 0 }
+    $host.UI.Write("$__aethel_esc]133;D;$ec$__aethel_esc\")
+    # OSC 133;A — prompt start
+    $host.UI.Write("$__aethel_esc]133;A$__aethel_esc\")
+    # OSC 7 — current working directory
     $cwd = (Get-Location).Path -replace '\\', '/'
     if ($cwd -match '^[A-Z]:') { $cwd = "/$cwd" }
-    $host.UI.Write("`e]7;file://$([System.Net.Dns]::GetHostName())$cwd`e\")
+    $host.UI.Write("$__aethel_esc]7;file://$([System.Net.Dns]::GetHostName())$cwd$__aethel_esc\")
     & $__aethel_original_prompt
 }

--- a/internal/shellinit/scripts/zsh-init.sh
+++ b/internal/shellinit/scripts/zsh-init.sh
@@ -1,4 +1,4 @@
-# Aethel shell integration — OSC 7 for zsh
+# Aethel shell integration — OSC 7 + OSC 133 for zsh
 # Restore ZDOTDIR permanently, source user's .zshrc
 if [ -n "${AETHEL_ORIG_ZDOTDIR+x}" ]; then
     ZDOTDIR="${AETHEL_ORIG_ZDOTDIR}"
@@ -7,7 +7,19 @@ else
 fi
 [ -f "${ZDOTDIR}/.zshrc" ] && . "${ZDOTDIR}/.zshrc"
 
-# OSC 7 hooks (chpwd fires on cd, precmd fires before each prompt)
+# OSC 7 hooks (chpwd fires on cd)
 __aethel_osc7() { printf '\e]7;file://%s%s\e\\' "${HOST:-localhost}" "${PWD}" }
 (( ! ${chpwd_functions[(Ie)__aethel_osc7]} )) && chpwd_functions+=(__aethel_osc7)
+
+# OSC 133: command markers for notification center
+# precmd must capture $? immediately before any other function clobbers it
+__aethel_precmd() {
+    local ec=$?
+    printf '\e]133;D;%d\e\\' "$ec"
+    printf '\e]133;A\e\\'
+}
+__aethel_preexec() { printf '\e]133;B\e\\'; }
+# Insert precmd FIRST (before osc7) so $? is captured before osc7 runs
+(( ! ${precmd_functions[(Ie)__aethel_precmd]} )) && precmd_functions=(__aethel_precmd $precmd_functions)
 (( ! ${precmd_functions[(Ie)__aethel_osc7]} )) && precmd_functions+=(__aethel_osc7)
+(( ! ${preexec_functions[(Ie)__aethel_preexec]} )) && preexec_functions+=(__aethel_preexec)

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -72,6 +72,21 @@ type setActivePaneMsg struct {
 	PaneID string
 }
 
+// paneEventMsg delivers a notification event from the daemon.
+type paneEventMsg ipc.PaneEventPayload
+
+// pasteRefreshMsg triggers a re-render after paste so the cursor updates.
+type pasteRefreshMsg struct{}
+
+// sidebarTickMsg triggers a periodic sidebar re-render to update relative timestamps.
+type sidebarTickMsg struct{}
+
+// PaneRef stores a pane location for navigation history.
+type PaneRef struct {
+	TabIndex int
+	PaneID   string
+}
+
 // highlightPaneMsg triggers an orange border highlight on a pane for MCP interactions.
 type highlightPaneMsg struct {
 	PaneID string
@@ -167,6 +182,9 @@ type Model struct {
 	disclaimerTipIdx     int                    // random tip index for disclaimer dialog
 	mcpHighlights        map[string]bool        // pane IDs with active MCP highlight
 	mcpHighlightSeq      map[string]int         // sequence number for highlight timer reset
+	notifications        *NotificationCenter    // notification sidebar
+	paneHistory          []PaneRef              // navigation history (bounded, 20 max)
+	sidebarFocused       bool                   // true when notification sidebar has keyboard focus
 }
 
 func NewModel(client *ipc.Client, cfg config.Config, version string, registry *plugin.Registry) Model {
@@ -177,8 +195,9 @@ func NewModel(client *ipc.Client, cfg config.Config, version string, registry *p
 		devMode:        os.Getenv("AETHEL_HOME") != "",
 		pluginRegistry: registry,
 		instanceStore:  LoadInstances(config.InstancesPath()),
-		mcpHighlights:  make(map[string]bool),
+		mcpHighlights:   make(map[string]bool),
 		mcpHighlightSeq: make(map[string]int),
+		notifications:   NewNotificationCenter(cfg.Notification.SidebarWidth, cfg.Notification.MaxEvents),
 	}
 	if cfg.UI.ShowDisclaimer && len(disclaimerTips) > 0 {
 		m.dialog = dialogDisclaimer
@@ -300,7 +319,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				tab := m.activeTabModel()
 				if tab != nil && tab.Root != nil && !tab.FocusMode() {
 					tabH := m.height - chromeHeight
-					if pane := tab.Root.FindPaneAt(m.mouseStartX, m.mouseStartY, 0, 1, m.width, tabH); pane != nil {
+					if pane := tab.Root.FindPaneAt(m.mouseStartX, m.mouseStartY, 0, 1, m.paneAreaWidth(), tabH); pane != nil {
 						if old := tab.ActivePaneModel(); old != nil {
 							old.Active = false
 						}
@@ -333,12 +352,18 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			text := strings.ReplaceAll(msg.Content, "\r", "")
 			m.tomlEditor.InsertMultiLine(text)
 			m.tomlEditor.Dirty = true
+			return m, nil
 		} else if m.dialog != dialogNone && m.dialogEdit {
 			m.dialogInput += sanitizeDialogInput(msg.Content)
+			return m, nil
 		} else {
 			m.sendClipboardToPane(msg.Content)
+			// Schedule re-render after PTY echo arrives to update cursor position
+			return m, tea.Tick(100*time.Millisecond, func(_ time.Time) tea.Msg { return pasteRefreshMsg{} })
 		}
-		return m, nil
+
+	case pasteRefreshMsg:
+		return m, nil // triggers re-render with updated VT emulator cursor
 
 	case dialogPasteMsg:
 		m.dialogInput += sanitizeDialogInput(string(msg))
@@ -441,11 +466,113 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
+	case paneEventMsg:
+		m.notifications.AddEvent(ipc.PaneEventPayload(msg))
+		cmds := []tea.Cmd{m.listenForMessages()}
+		// Refresh sidebar tick if visible (no auto-show — user controls with Alt+N)
+		if m.notifications.visible {
+			cmds = append(cmds, m.sidebarTick())
+		}
+		return m, tea.Batch(cmds...)
+
+	case sidebarTickMsg:
+		// Re-render sidebar to update relative timestamps; schedule next tick if still visible
+		if m.notifications.visible && m.notifications.Count() > 0 {
+			return m, m.sidebarTick()
+		}
+		return m, nil
+
 	case listenContinueMsg:
 		return m, m.listenForMessages()
 	}
 
 	return m, nil
+}
+
+func (m Model) handleNotificationKey(key string) (tea.Model, tea.Cmd) {
+	action, eventID, paneID := m.notifications.HandleKey(key)
+	switch action {
+	case "navigate":
+		// Push current location to history, then jump to event's pane in focus mode
+		m.pushPaneHistory()
+		for i, tab := range m.tabs {
+			if tab.Root != nil && tab.Root.PaneIDs()[paneID] {
+				m.activeTab = i
+				tab.ActivePane = paneID
+				if !tab.FocusMode() {
+					tab.ToggleFocus()
+				}
+				m.sidebarFocused = false
+				break
+			}
+		}
+		return m, nil
+	case "dismiss":
+		if eventID != "" {
+			if msg, err := ipc.NewMessage(ipc.MsgDismissEvent, ipc.DismissEventPayload{EventID: eventID}); err == nil {
+				if err := m.client.Send(msg); err != nil {
+					log.Printf("dismiss event send: %v", err)
+				}
+			}
+		}
+		return m, nil
+	case "dismiss_all":
+		if msg, err := ipc.NewMessage(ipc.MsgDismissEvent, ipc.DismissEventPayload{}); err == nil {
+			if err := m.client.Send(msg); err != nil {
+				log.Printf("dismiss all send: %v", err)
+			}
+		}
+		return m, nil
+	case "unfocus":
+		m.sidebarFocused = false
+		return m, nil
+	}
+	return m, nil
+}
+
+func (m *Model) pushPaneHistory() {
+	if tab := m.activeTabModel(); tab != nil && tab.ActivePane != "" {
+		ref := PaneRef{TabIndex: m.activeTab, PaneID: tab.ActivePane}
+		m.paneHistory = append(m.paneHistory, ref)
+		if len(m.paneHistory) > 20 {
+			m.paneHistory = m.paneHistory[len(m.paneHistory)-20:]
+		}
+	}
+}
+
+func (m Model) popPaneHistory() (tea.Model, tea.Cmd) {
+	for len(m.paneHistory) > 0 {
+		ref := m.paneHistory[len(m.paneHistory)-1]
+		m.paneHistory = m.paneHistory[:len(m.paneHistory)-1]
+		if ref.TabIndex < len(m.tabs) {
+			tab := m.tabs[ref.TabIndex]
+			if tab.Root != nil && tab.Root.PaneIDs()[ref.PaneID] {
+				m.activeTab = ref.TabIndex
+				tab.ActivePane = ref.PaneID
+				return m, nil
+			}
+		}
+	}
+	return m, nil
+}
+
+// paneAreaWidth returns the width available for pane content, accounting for sidebar.
+func (m Model) paneAreaWidth() int {
+	if m.notifications.visible && m.dialog == dialogNone {
+		if tab := m.activeTabModel(); tab != nil && !tab.FocusMode() {
+			sw := m.notifications.width
+			if m.width-sw >= minTermWidth {
+				return m.width - sw
+			}
+		}
+	}
+	return m.width
+}
+
+func (m Model) sidebarTick() tea.Cmd {
+	return tea.Tick(10*time.Second, func(_ time.Time) tea.Msg {
+		return sidebarTickMsg{}
+	})
 }
 
 func (m Model) View() tea.View {
@@ -468,11 +595,20 @@ func (m Model) View() tea.View {
 		// Tab bar (1 line)
 		sections = append(sections, m.renderTabBar())
 
-		// Active tab content
+		// Active tab content + optional notification sidebar
 		tabH := m.height - chromeHeight
+		sidebarW := 0
+		if m.notifications.visible && m.dialog == dialogNone {
+			if tab := m.activeTabModel(); tab != nil && !tab.FocusMode() {
+				sidebarW = m.notifications.width
+				if m.width-sidebarW < minTermWidth {
+					sidebarW = 0 // too narrow for sidebar
+				}
+			}
+		}
 		if m.activeTab < len(m.tabs) {
 			tab := m.tabs[m.activeTab]
-			tab.Resize(m.width, tabH)
+			tab.Resize(m.width-sidebarW, tabH)
 			// Pass per-frame state to panes for rendering
 			if tab.Root != nil {
 				for _, pane := range tab.Root.Leaves() {
@@ -481,7 +617,12 @@ func (m Model) View() tea.View {
 					pane.mcpHighlight = m.mcpHighlights[pane.ID]
 				}
 			}
-			sections = append(sections, tab.View())
+			tabContent := tab.View()
+			if sidebarW > 0 {
+				m.notifications.focused = m.sidebarFocused
+				tabContent = lipgloss.JoinHorizontal(lipgloss.Top, tabContent, m.notifications.View(tabH))
+			}
+			sections = append(sections, tabContent)
 		}
 
 		// Status bar
@@ -513,6 +654,32 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	}
 	if m.renamingPane {
 		return m.handlePaneRenameKey(msg)
+	}
+
+	// Notification sidebar keybindings (always available)
+	switch {
+	case key == kb.NotificationToggle:
+		// Alt+N: toggle visibility only, never focus
+		m.notifications.visible = !m.notifications.visible
+		m.sidebarFocused = false
+		if m.notifications.visible {
+			return m, tea.Batch(tea.ClearScreen, m.resizeAllPanes(), m.sidebarTick())
+		}
+		return m, tea.Batch(tea.ClearScreen, m.resizeAllPanes())
+	case key == kb.NotificationFocus:
+		// Ctrl+Alt+N: open (if hidden) and focus sidebar
+		if !m.notifications.visible {
+			m.notifications.visible = true
+		}
+		m.sidebarFocused = true
+		return m, tea.Batch(tea.ClearScreen, m.resizeAllPanes(), m.sidebarTick())
+	case key == kb.GoBack:
+		return m.popPaneHistory()
+	}
+
+	// Sidebar focused: route keys to notification center
+	if m.sidebarFocused && m.notifications.visible {
+		return m.handleNotificationKey(key)
 	}
 
 	// Selection: Enter copies (tmux convention), Esc clears, Cmd+C for macOS
@@ -1049,7 +1216,7 @@ func (m *Model) replayBufSize() int {
 func (m *Model) resizeTabs() {
 	tabH := m.height - chromeHeight
 	for _, tab := range m.tabs {
-		tab.Resize(m.width, tabH)
+		tab.Resize(m.paneAreaWidth(), tabH)
 	}
 }
 
@@ -1378,6 +1545,9 @@ func (m Model) renderStatusBar() string {
 	if m.devMode {
 		right = "[dev] " + right
 	}
+	if count := m.notifications.Count(); count > 0 && !m.notifications.visible {
+		right = fmt.Sprintf("[%d events] ", count) + right
+	}
 
 	// Fit within width: left takes priority
 	gap := m.width - lipgloss.Width(left) - lipgloss.Width(right) - 2 // 2 for padding
@@ -1460,6 +1630,12 @@ func (m Model) listenForMessages() tea.Cmd {
 			var payload ipc.HighlightPanePayload
 			msg.DecodePayload(&payload)
 			return highlightPaneMsg{PaneID: payload.PaneID}
+
+		case ipc.MsgPaneEvent:
+			var payload ipc.PaneEventPayload
+			msg.DecodePayload(&payload)
+			log.Printf("ipc recv: pane_event %s %s %s", payload.Type, payload.PaneID, payload.Title)
+			return paneEventMsg(payload)
 
 		default:
 			log.Printf("ipc recv: unknown type %q", msg.Type)
@@ -1652,7 +1828,9 @@ func (m Model) pasteClipboard() tea.Cmd {
 			Data:   data,
 		})
 		m.client.Send(msg)
-		return nil
+		// Wait for PTY echo to arrive before triggering re-render
+		time.Sleep(100 * time.Millisecond)
+		return pasteRefreshMsg{}
 	}
 }
 
@@ -1674,22 +1852,38 @@ func (m *Model) updateMouseSelection(tab *TabModel, curX, curY, tabH int) {
 	if tab.Root == nil {
 		return
 	}
-	// Resolve start position to pane
-	startRect := tab.Root.FindPaneRectAt(m.mouseStartX, m.mouseStartY, 0, 1, m.width, tabH)
-	if startRect == nil {
-		return
+
+	var pane *PaneModel
+	var ox, oy int
+
+	if tab.FocusMode() {
+		// Focus mode: active pane fills entire tab, tree splits don't apply
+		pane = tab.ActivePaneModel()
+		if pane == nil {
+			return
+		}
+		ox = 0
+		oy = 1 // tab bar
+	} else {
+		startRect := tab.Root.FindPaneRectAt(m.mouseStartX, m.mouseStartY, 0, 1, m.paneAreaWidth(), tabH)
+		if startRect == nil {
+			return
+		}
+		pane = startRect.Pane
+		ox = startRect.OX
+		oy = startRect.OY
 	}
-	pane := startRect.Pane
+
 	sbLen := pane.vt.ScrollbackLen()
 
 	// Convert start screen coords to pane-local
-	startCol := m.mouseStartX - startRect.OX - 1
-	startRow := m.mouseStartY - startRect.OY - 1
+	startCol := m.mouseStartX - ox - 1
+	startRow := m.mouseStartY - oy - 1
 	startLine := sbLen - pane.scrollBack + startRow
 
 	// Convert current screen coords to pane-local (clamp to same pane)
-	curCol := curX - startRect.OX - 1
-	curRow := curY - startRect.OY - 1
+	curCol := curX - ox - 1
+	curRow := curY - oy - 1
 	curLine := sbLen - pane.scrollBack + curRow
 
 	// Clamp

--- a/internal/tui/notification.go
+++ b/internal/tui/notification.go
@@ -1,0 +1,270 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"charm.land/lipgloss/v2"
+	"github.com/artyomsv/aethel/internal/ipc"
+)
+
+// NotificationCenter manages the notification sidebar state.
+type NotificationCenter struct {
+	events    []ipc.PaneEventPayload
+	cursor    int
+	visible   bool
+	focused   bool
+	width     int
+	maxEvents int
+}
+
+// NewNotificationCenter creates a notification center with the given sidebar width and max events.
+func NewNotificationCenter(width, maxEvents int) *NotificationCenter {
+	if width <= 0 {
+		width = 30
+	}
+	if maxEvents <= 0 {
+		maxEvents = 50
+	}
+	return &NotificationCenter{width: width, maxEvents: maxEvents}
+}
+
+// AddEvent prepends an event, deduplicating by ID.
+func (nc *NotificationCenter) AddEvent(e ipc.PaneEventPayload) {
+	for _, existing := range nc.events {
+		if existing.ID == e.ID {
+			return
+		}
+	}
+	nc.events = append([]ipc.PaneEventPayload{e}, nc.events...)
+	if len(nc.events) > nc.maxEvents {
+		nc.events = nc.events[:nc.maxEvents]
+	}
+}
+
+// DismissSelected removes the selected event and returns its ID.
+func (nc *NotificationCenter) DismissSelected() string {
+	if nc.cursor >= len(nc.events) {
+		return ""
+	}
+	id := nc.events[nc.cursor].ID
+	nc.events = append(nc.events[:nc.cursor], nc.events[nc.cursor+1:]...)
+	if nc.cursor >= len(nc.events) && len(nc.events) > 0 {
+		nc.cursor = len(nc.events) - 1
+	} else if len(nc.events) == 0 {
+		nc.cursor = 0
+	}
+	return id
+}
+
+// DismissAll removes all events.
+func (nc *NotificationCenter) DismissAll() {
+	nc.events = nil
+	nc.cursor = 0
+}
+
+// SelectedEvent returns the currently selected event, or nil.
+func (nc *NotificationCenter) SelectedEvent() *ipc.PaneEventPayload {
+	if nc.cursor >= len(nc.events) {
+		return nil
+	}
+	return &nc.events[nc.cursor]
+}
+
+// Count returns the number of pending events.
+func (nc *NotificationCenter) Count() int {
+	return len(nc.events)
+}
+
+// HandleKey processes a key press when the sidebar is focused.
+// Returns: action ("navigate", "dismiss", "dismiss_all", "unfocus", "none"),
+// eventID (for dismiss), paneID (for navigate).
+func (nc *NotificationCenter) HandleKey(key string) (action, eventID, paneID string) {
+	switch key {
+	case "up", "k":
+		if nc.cursor > 0 {
+			nc.cursor--
+		}
+		return "none", "", ""
+	case "down", "j":
+		if nc.cursor < len(nc.events)-1 {
+			nc.cursor++
+		}
+		return "none", "", ""
+	case "enter":
+		if e := nc.SelectedEvent(); e != nil {
+			return "navigate", e.ID, e.PaneID
+		}
+		return "none", "", ""
+	case "d":
+		id := nc.DismissSelected()
+		return "dismiss", id, ""
+	case "D":
+		nc.DismissAll()
+		return "dismiss_all", "", ""
+	case "esc", "escape":
+		return "unfocus", "", ""
+	default:
+		return "none", "", ""
+	}
+}
+
+// View renders the sidebar at the given height.
+func (nc *NotificationCenter) View(height int) string {
+	innerW := nc.width - 2
+	innerH := height - 2
+	if innerW < 5 || innerH < 3 {
+		return ""
+	}
+
+	var lines []string
+
+	// Title
+	title := " Notifications "
+	title = truncateRunes(title, innerW)
+	lines = append(lines, lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("230")).Render(title))
+
+	separator := lipgloss.NewStyle().Foreground(lipgloss.Color("238")).Render(
+		truncateRunes(strings.Repeat("·", innerW), innerW),
+	)
+
+	if len(nc.events) == 0 {
+		lines = append(lines, separator)
+		noEvents := "No notifications"
+		noEvents = truncateRunes(noEvents, innerW)
+		lines = append(lines, lipgloss.NewStyle().Foreground(lipgloss.Color("243")).Render(noEvents))
+	} else {
+		// Each event = separator + name/time + title = 3 lines
+		maxVisible := (innerH - 3) / 3
+		if maxVisible < 1 {
+			maxVisible = 1
+		}
+		start := 0
+		if nc.cursor >= maxVisible {
+			start = nc.cursor - maxVisible + 1
+		}
+		end := start + maxVisible
+		if end > len(nc.events) {
+			end = len(nc.events)
+		}
+
+		for i := start; i < end; i++ {
+			e := nc.events[i]
+			selected := i == nc.cursor && nc.focused
+
+			// Separator
+			lines = append(lines, separator)
+
+			// Pane name or ID
+			name := e.PaneName
+			if name == "" {
+				name = e.PaneID
+				if len(name) > 12 {
+					name = name[:12]
+				}
+			}
+
+			// Relative time (right-aligned)
+			age := relativeTime(time.UnixMilli(e.Timestamp))
+
+			// Line 1: colored name + right-aligned time
+			nameStyle := severityNameStyle(e.Severity)
+			if selected {
+				nameStyle = nameStyle.Bold(true).Reverse(true)
+			}
+			styledName := nameStyle.Render(name)
+
+			// Pad between name and time
+			nameLen := len([]rune(name))
+			ageLen := len([]rune(age))
+			gap := innerW - nameLen - ageLen
+			if gap < 1 {
+				gap = 1
+			}
+			line1 := styledName + strings.Repeat(" ", gap) + lipgloss.NewStyle().Foreground(lipgloss.Color("243")).Render(age)
+
+			// Line 2: title (indented)
+			titleText := "  " + e.Title
+			titleText = truncateRunes(titleText, innerW)
+			if selected {
+				titleText = lipgloss.NewStyle().Reverse(true).Render(titleText)
+			} else {
+				titleText = lipgloss.NewStyle().Foreground(lipgloss.Color("250")).Render(titleText)
+			}
+
+			lines = append(lines, line1)
+			lines = append(lines, titleText)
+		}
+
+		// Trailing separator
+		if len(lines) < innerH-1 {
+			lines = append(lines, separator)
+		}
+	}
+
+	// Pad to fill height
+	for len(lines) < innerH-1 {
+		lines = append(lines, "")
+	}
+
+	// Key hints at bottom
+	hints := "^!N Focus  Enter Go"
+	if nc.focused {
+		hints = "Up/Dn  Enter  d/D  Esc"
+	}
+	hints = truncateRunes(hints, innerW)
+	lines = append(lines, lipgloss.NewStyle().Foreground(lipgloss.Color("243")).Render(hints))
+
+	content := strings.Join(lines, "\n")
+
+	borderColor := lipgloss.Color("63")
+	if nc.focused {
+		borderColor = lipgloss.Color("57")
+	}
+
+	return lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(borderColor).
+		Width(nc.width).
+		Height(height).
+		Render(content)
+}
+
+// truncateRunes truncates a string to maxWidth runes.
+func truncateRunes(s string, maxWidth int) string {
+	runes := []rune(s)
+	if len(runes) <= maxWidth {
+		return s
+	}
+	return string(runes[:maxWidth])
+}
+
+// severityNameStyle returns a style for the pane name colored by severity.
+func severityNameStyle(severity string) lipgloss.Style {
+	switch severity {
+	case "error":
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("1")) // red
+	case "warning":
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("208")) // orange
+	default:
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("4")) // blue
+	}
+}
+
+func relativeTime(t time.Time) string {
+	d := time.Since(t)
+	if d < 0 {
+		return "now"
+	}
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int(d.Hours()/24))
+	}
+}

--- a/internal/tui/notification_test.go
+++ b/internal/tui/notification_test.go
@@ -1,0 +1,156 @@
+package tui
+
+import (
+	"testing"
+	"time"
+
+	"github.com/artyomsv/aethel/internal/ipc"
+)
+
+func TestNotificationCenter_AddEvent_Dedup(t *testing.T) {
+	nc := NewNotificationCenter(30, 50)
+	nc.AddEvent(ipc.PaneEventPayload{ID: "a", Title: "first"})
+	nc.AddEvent(ipc.PaneEventPayload{ID: "a", Title: "duplicate"})
+	if nc.Count() != 1 {
+		t.Errorf("Count: got %d, want 1 (dedup failed)", nc.Count())
+	}
+}
+
+func TestNotificationCenter_AddEvent_NewestFirst(t *testing.T) {
+	nc := NewNotificationCenter(30, 50)
+	nc.AddEvent(ipc.PaneEventPayload{ID: "a", Title: "first"})
+	nc.AddEvent(ipc.PaneEventPayload{ID: "b", Title: "second"})
+	if nc.events[0].ID != "b" {
+		t.Errorf("events[0].ID: got %q, want %q", nc.events[0].ID, "b")
+	}
+}
+
+func TestNotificationCenter_DismissSelected_CursorClamp(t *testing.T) {
+	nc := NewNotificationCenter(30, 50)
+	nc.AddEvent(ipc.PaneEventPayload{ID: "a"})
+	nc.AddEvent(ipc.PaneEventPayload{ID: "b"})
+	nc.cursor = 1
+
+	nc.DismissSelected()
+	if nc.cursor != 0 {
+		t.Errorf("cursor after dismiss last: got %d, want 0", nc.cursor)
+	}
+}
+
+func TestNotificationCenter_DismissSelected_EmptyList(t *testing.T) {
+	nc := NewNotificationCenter(30, 50)
+	nc.AddEvent(ipc.PaneEventPayload{ID: "a"})
+	nc.DismissSelected()
+	if nc.Count() != 0 {
+		t.Errorf("Count: got %d, want 0", nc.Count())
+	}
+	if nc.cursor != 0 {
+		t.Errorf("cursor: got %d, want 0", nc.cursor)
+	}
+}
+
+func TestNotificationCenter_HandleKey_Navigate(t *testing.T) {
+	nc := NewNotificationCenter(30, 50)
+	nc.focused = true
+	nc.AddEvent(ipc.PaneEventPayload{ID: "a", PaneID: "pane-1"})
+	nc.AddEvent(ipc.PaneEventPayload{ID: "b", PaneID: "pane-2"})
+
+	// Cursor starts at 0; down moves to 1
+	nc.HandleKey("down")
+	if nc.cursor != 1 {
+		t.Errorf("cursor after down: got %d, want 1", nc.cursor)
+	}
+
+	// Up moves back to 0
+	nc.HandleKey("up")
+	if nc.cursor != 0 {
+		t.Errorf("cursor after up: got %d, want 0", nc.cursor)
+	}
+
+	// Enter on selected event returns navigate action
+	action, _, paneID := nc.HandleKey("enter")
+	if action != "navigate" {
+		t.Errorf("action: got %q, want %q", action, "navigate")
+	}
+	if paneID != "pane-2" { // newest first, cursor 0 = "b"
+		t.Errorf("paneID: got %q, want %q", paneID, "pane-2")
+	}
+}
+
+func TestNotificationCenter_HandleKey_Dismiss(t *testing.T) {
+	nc := NewNotificationCenter(30, 50)
+	nc.AddEvent(ipc.PaneEventPayload{ID: "a"})
+	nc.AddEvent(ipc.PaneEventPayload{ID: "b"})
+
+	action, eventID, _ := nc.HandleKey("d")
+	if action != "dismiss" {
+		t.Errorf("action: got %q, want %q", action, "dismiss")
+	}
+	if eventID != "b" { // newest first, cursor 0 = "b"
+		t.Errorf("eventID: got %q, want %q", eventID, "b")
+	}
+	if nc.Count() != 1 {
+		t.Errorf("Count: got %d, want 1", nc.Count())
+	}
+}
+
+func TestNotificationCenter_HandleKey_DismissAll(t *testing.T) {
+	nc := NewNotificationCenter(30, 50)
+	nc.AddEvent(ipc.PaneEventPayload{ID: "a"})
+	nc.AddEvent(ipc.PaneEventPayload{ID: "b"})
+
+	action, _, _ := nc.HandleKey("D")
+	if action != "dismiss_all" {
+		t.Errorf("action: got %q, want %q", action, "dismiss_all")
+	}
+	if nc.Count() != 0 {
+		t.Errorf("Count: got %d, want 0", nc.Count())
+	}
+}
+
+func TestNotificationCenter_HandleKey_Unfocus(t *testing.T) {
+	nc := NewNotificationCenter(30, 50)
+	action, _, _ := nc.HandleKey("esc")
+	if action != "unfocus" {
+		t.Errorf("action: got %q, want %q", action, "unfocus")
+	}
+}
+
+func TestRelativeTime_Ranges(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		age      time.Duration
+		expected string
+	}{
+		{3 * time.Second, "3s"},
+		{90 * time.Second, "1m"},
+		{2 * time.Hour, "2h"},
+		{48 * time.Hour, "2d"},
+	}
+	for _, tt := range tests {
+		got := relativeTime(now.Add(-tt.age))
+		if got != tt.expected {
+			t.Errorf("relativeTime(%v ago): got %q, want %q", tt.age, got, tt.expected)
+		}
+	}
+}
+
+func TestRelativeTime_Future_ReturnsNow(t *testing.T) {
+	got := relativeTime(time.Now().Add(10 * time.Second))
+	if got != "now" {
+		t.Errorf("relativeTime(future): got %q, want %q", got, "now")
+	}
+}
+
+func TestTruncateRunes(t *testing.T) {
+	if got := truncateRunes("hello", 3); got != "hel" {
+		t.Errorf("truncateRunes: got %q, want %q", got, "hel")
+	}
+	if got := truncateRunes("hi", 10); got != "hi" {
+		t.Errorf("truncateRunes no-op: got %q, want %q", got, "hi")
+	}
+	// Multi-byte: 日本語 is 3 runes
+	if got := truncateRunes("日本語test", 3); got != "日本語" {
+		t.Errorf("truncateRunes multi-byte: got %q, want %q", got, "日本語")
+	}
+}

--- a/internal/tui/pane.go
+++ b/internal/tui/pane.go
@@ -276,7 +276,7 @@ func (p *PaneModel) renderContent(sel *Selection) string {
 		content := p.vt.Render()
 		// Only overlay cursor for terminal panes — TUI apps (Claude Code etc.)
 		// render their own cursor.
-		isTerminal := p.Type == "" || p.Type == "terminal"
+		isTerminal := p.Type == "" || p.Type == "terminal" || p.Type == "ssh"
 		if p.Active && p.cursorVisible && isTerminal {
 			content = p.insertCursor(content)
 		}


### PR DESCRIPTION
…(M12)

Daemon event queue with process exit detection, output pattern matching via plugin [[idle_handlers]], bell character detection (30s cooldown), and OSC 133 command markers for bash/zsh/PowerShell.

TUI notification sidebar (Alt+N toggle, F3 focus) with dotted card layout, severity-colored pane names, and pane history (Alt+Backspace). Smart idle analysis: last 5 lines analyzed at idle time against plugin patterns — SSH [Y/n] → "Waiting for confirmation", Claude → "Waiting for input", password prompts detected.

MCP tools: get_notifications (non-blocking), watch_notifications (blocking up to 5 min, replaces polling). requestWithTimeout for long waits.

Plugin system: [[idle_handlers]] TOML section, path field for binary override, searchBinary fallback for Explorer-launched Windows apps.

Fixes: focus mode mouse selection, SSH cursor visibility, paste cursor refresh, DecodePayload error checking on all handlers, shutdown double-close panic (sync.Once), watcher timer leak (time.NewTimer), idle detection race (single lock span), zsh $? capture, PowerShell 5.1 compat ([char]0x1b).