### PR TITLE
fix(ci): use gh release edit for release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,6 +164,19 @@ jobs:
         with:
           distribution: goreleaser
           version: "~> v2"
-          args: release --clean --release-notes /tmp/release-notes.md
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set release notes
+        if: hashFiles('/tmp/release-notes.md') != ''
+        env:
+          VERSION: ${{ needs.release.outputs.version }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ -s /tmp/release-notes.md ]; then
+            gh release edit "v${VERSION}" --notes-file /tmp/release-notes.md
+            echo "::notice::Release notes applied to v${VERSION}"
+          else
+            echo "::warning::Release notes file is empty — skipping"
+          fi


### PR DESCRIPTION
GoReleaser's --release-notes flag is silently ignored when changelog.disable: true is set in .goreleaser.yml. This broke release notes starting with v0.12.0 when a newer GoReleaser v2.x binary was picked up.

Replace --release-notes with a post-goreleaser step that uses gh release edit to apply notes via the GitHub API, decoupling release notes from GoReleaser's changelog system entirely.