### PR TITLE
fix(ci): release notes not applied + site version pill stuck at 1.2.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,16 @@ jobs:
           DATE=$(date +%Y-%m-%d)
           sed -i "s/## \[Unreleased\]/## [Unreleased]\n\n## [${VERSION}] - ${DATE}/" CHANGELOG.md
 
-          echo "::notice::Updated VERSION to ${VERSION} and CHANGELOG.md"
+          # Bump the marketing site's version pill so quil.cc reflects the
+          # release. seo.ts is the single source of truth for the home page
+          # hero pill — without this update the site keeps showing the old
+          # version even though the binary moved on. Touching site/** also
+          # triggers .github/workflows/site.yml on the release commit, which
+          # rebuilds and redeploys the site automatically.
+          sed -i -E "s/(version: )\"[0-9]+\\.[0-9]+\\.[0-9]+\"/\\1\"${VERSION}\"/" site/src/data/seo.ts
+          sed -i -E "s/(releaseDate: )\"[0-9]{4}-[0-9]{2}-[0-9]{2}\"/\\1\"${DATE}\"/" site/src/data/seo.ts
+
+          echo "::notice::Updated VERSION to ${VERSION}, CHANGELOG.md, and site/src/data/seo.ts"
 
       - name: Run tests
         if: steps.bump.outputs.skip != 'true'
@@ -120,7 +129,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add VERSION CHANGELOG.md
+          git add VERSION CHANGELOG.md site/src/data/seo.ts
           git commit -m "chore(release): v${VERSION}"
           git tag "v${VERSION}"
           git push origin master --tags
@@ -155,10 +164,15 @@ jobs:
         env:
           VERSION: ${{ needs.release.outputs.version }}
         run: |
+          # IMPORTANT: write the file inside GITHUB_WORKSPACE, not /tmp.
+          # `hashFiles()` (used in `if:` conditions on later steps) only
+          # matches files inside GITHUB_WORKSPACE, so a /tmp path always
+          # hashes to empty string and any guarded step gets skipped.
+          # See: https://docs.github.com/en/actions/learn-github-actions/expressions#hashfiles
           sed -n "/^## \[${VERSION}\]/,/^## \[/{ /^## \[${VERSION}\]/d; /^## \[/d; p; }" CHANGELOG.md \
-            | tr -d '\r' > /tmp/release-notes.md
-          echo "::notice::Release notes for v${VERSION}:"
-          cat /tmp/release-notes.md
+            | tr -d '\r' > release-notes.md
+          echo "::notice::Release notes for v${VERSION} ($(wc -c < release-notes.md) bytes):"
+          cat release-notes.md
 
       - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a  # v6
         with:
@@ -169,13 +183,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set release notes
-        if: hashFiles('/tmp/release-notes.md') != ''
+        # No `if: hashFiles(...)` guard here. Earlier versions used
+        # `hashFiles('/tmp/release-notes.md') != ''` which always evaluated
+        # false because /tmp is outside GITHUB_WORKSPACE — the step was
+        # silently skipped on every release. The inner `[ -s ... ]` check
+        # is the real safety net.
         env:
           VERSION: ${{ needs.release.outputs.version }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ -s /tmp/release-notes.md ]; then
-            gh release edit "v${VERSION}" --notes-file /tmp/release-notes.md
+          if [ -s release-notes.md ]; then
+            gh release edit "v${VERSION}" --notes-file release-notes.md
             echo "::notice::Release notes applied to v${VERSION}"
           else
             echo "::warning::Release notes file is empty — skipping"

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,11 @@ Thumbs.db
 
 # Dev instance data
 /.quil/
+
+# Release pipeline scratch — release.yml writes the extracted CHANGELOG
+# notes to ./release-notes.md inside GITHUB_WORKSPACE so hashFiles() can
+# find it. We never want that file committed.
+/release-notes.md
+
+# Local scratch directory used for ad-hoc API responses, payloads, etc.
+/.scratch/

--- a/site/src/data/seo.ts
+++ b/site/src/data/seo.ts
@@ -39,10 +39,12 @@ export const SITE = {
 
   /** Software metadata for the SoftwareApplication JSON-LD schema
    *  that ships on the home page. The version is the single source
-   *  of truth for the home page hero pill — bump it whenever VERSION
-   *  at the repo root moves. */
+   *  of truth for the home page hero pill. The release.yml workflow
+   *  bumps these two fields automatically as part of its version
+   *  bump step — manual edits are normally unnecessary but harmless
+   *  (the next release will overwrite both via sed). */
   software: {
-    version: "1.2.1",
+    version: "1.3.0",
     license: "MIT",
     operatingSystem: "Linux, macOS, Windows",
     applicationCategory: "DeveloperApplication",


### PR DESCRIPTION
## Summary

Three bugs fixed in the release pipeline:

- **Release notes never applied to GitHub Releases.** The `Set release notes` step used `hashFiles("/tmp/release-notes.md")`, but `hashFiles()` only matches files inside `GITHUB_WORKSPACE`. Since `/tmp/` is outside the workspace, the condition was always false and the step was always skipped — silently. Every release since v1.0.0 had empty notes. Fix: write the file inside the workspace root, remove the broken guard, let the inner `[ -s ... ]` check be the safety net.
- **quil.cc showed v1.2.1 while the binary was at v1.3.0.** `site/src/data/seo.ts` is the single source of truth for the home page version pill, but the release workflow only bumped `VERSION` and `CHANGELOG.md`. Fix: add two `sed` substitutions to the `Update version files` step (version + releaseDate), include `seo.ts` in `git add`. Touching `site/**` in the release commit also triggers `site.yml`, so the site redeploys automatically on every release.
- **Manual catch-up**: bumped `seo.ts` from 1.2.1 → 1.3.0 in this commit. The v1.3.0 release notes were retroactively applied to the GitHub Release via a REST API PATCH (already done, no code change needed).

Also adds `/release-notes.md` and `/.scratch/` to `.gitignore`.

## Test plan

- [x] Local sed test: extracted v1.3.0 notes from CHANGELOG (8695 bytes) — confirms the extraction regex works
- [x] Local sed test: applied version `1.4.0` and date `2026-05-01` to seo.ts via the same sed expressions the workflow will use — fields updated correctly
- [x] Astro check + build in Docker: 0 errors, 0 warnings, 11 pages built clean, `v1.3.0` appears in the generated `dist/index.html`
- [x] v1.3.0 release notes retroactively applied via REST API — https://github.com/artyomsv/quil/releases/tag/v1.3.0 now shows the full Added/Changed/Fixed/Security sections
- [ ] After merge: push a `docs:` or `chore:` commit to master and verify release.yml skips the release (no version-bumping commit type)
- [ ] After a future `feat:` merge: verify release.yml creates a release with populated notes AND the site.yml redeploy shows the new version pill on quil.cc

🤖 Generated with [Claude Code](https://claude.com/claude-code)