### PR TITLE
feat(lifecycle): client/daemon version handshake with auto-restart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ Thumbs.db
 
 # Local scratch directory used for ad-hoc API responses, payloads, etc.
 /.scratch/
+
+# Superpowers brainstorm runtime scratch (plugin state, server.pid, etc.)
+/.superpowers/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Client/daemon version negotiation** — the TUI now performs a version handshake with the running daemon before attaching. If the daemon is older (or pre-dates version negotiation), the TUI prompts before gracefully stopping it and auto-spawning the matching daemon from alongside the TUI binary. If the daemon is newer (i.e., the TUI is stale), the TUI refuses to attach and points the user at the releases page. Eliminates the manual "stop daemon → replace both binaries → restart" dance on every upgrade. Dev/debug builds and unstamped local builds skip the check. New IPC pair `MsgVersionReq`/`MsgVersionResp` added to the protocol; new shared `internal/version/` package provides proper semver comparison (no more lexical-ordering traps with `1.10.0` vs `1.9.0`).
+
 ## [1.7.0] - 2026-04-18
 
 ### Added

--- a/cmd/quil/handshake.go
+++ b/cmd/quil/handshake.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"time"
+
+	"github.com/artyomsv/quil/internal/ipc"
+	versionpkg "github.com/artyomsv/quil/internal/version"
+)
+
+// handshakeTimeout caps how long the TUI will wait for MsgVersionResp.
+// Daemons from before the version-negotiation protocol silently ignore
+// the request; the timeout is the only way to notice.
+const handshakeTimeout = 2 * time.Second
+
+// handshakeResult bundles the outcome of asking the daemon its version.
+type handshakeResult struct {
+	// Matched is true only when both versions parse as semver and compare equal.
+	Matched bool
+
+	// Cmp is -1 when TUI < daemon, +1 when TUI > daemon, 0 when equal.
+	// Zero when ClientSkipped or DaemonUnknown is true.
+	Cmp int
+
+	// DaemonVersion is the raw version string the daemon reported. Empty
+	// when the request timed out or failed to parse.
+	DaemonVersion string
+
+	// DaemonUnknown is true when the response timed out, errored, or
+	// returned an unparseable version. Callers treat this as "pre-
+	// versioning daemon" and drive it through the restart-confirm flow.
+	DaemonUnknown bool
+
+	// ClientSkipped is true when the client is running a non-release
+	// build (`dev`, empty, garbage) and the handshake was skipped. No
+	// action should be taken.
+	ClientSkipped bool
+}
+
+// versionHandshake sends MsgVersionReq to the daemon and interprets the
+// response. Callers use the returned handshakeResult to decide whether
+// to attach normally, open the upgrade-client dialog, or enter the
+// daemon-restart confirmation flow.
+//
+// The function is defensive: any transport error, parse error, or
+// timeout becomes DaemonUnknown = true rather than an error return.
+// Propagating errors here would force every caller to branch the same
+// way twice (error vs match vs mismatch); encoding the "unknown" state
+// in the result keeps the call site simple.
+func versionHandshake(client *ipc.Client) handshakeResult {
+	tuiVer := versionpkg.Current()
+
+	// Skip the handshake entirely for non-release builds. A `dev` TUI
+	// running against any daemon is almost certainly a developer's own
+	// build — they can deal with version drift manually. Skipping also
+	// sidesteps false positives when `main.version` was never set via
+	// ldflags.
+	if !versionpkg.IsRelease() {
+		log.Printf("handshake: skipping — TUI version %q is not a release build", tuiVer)
+		return handshakeResult{ClientSkipped: true}
+	}
+
+	reqID := fmt.Sprintf("hs-%d", time.Now().UnixNano())
+	req, err := ipc.NewMessage(ipc.MsgVersionReq, struct{}{})
+	if err != nil {
+		log.Printf("handshake: build request: %v", err)
+		return handshakeResult{DaemonUnknown: true}
+	}
+	req.ID = reqID
+
+	if err := client.Send(req); err != nil {
+		log.Printf("handshake: send MsgVersionReq: %v", err)
+		return handshakeResult{DaemonUnknown: true}
+	}
+
+	// Install a read deadline so a pre-versioning daemon (which drops
+	// the request silently) doesn't block us forever.
+	deadline := time.Now().Add(handshakeTimeout)
+	if err := client.SetReadDeadline(deadline); err != nil {
+		log.Printf("handshake: set read deadline: %v", err)
+		return handshakeResult{DaemonUnknown: true}
+	}
+	defer client.SetReadDeadline(time.Time{})
+
+	// Loop until we see a matching response or hit the deadline. Any
+	// unrelated messages (there shouldn't be any pre-attach) are ignored.
+	for {
+		msg, err := client.Receive()
+		if err != nil {
+			var netErr net.Error
+			if errors.As(err, &netErr) && netErr.Timeout() {
+				log.Printf("handshake: timeout waiting for MsgVersionResp — treating daemon as pre-versioning")
+			} else {
+				log.Printf("handshake: receive: %v", err)
+			}
+			return handshakeResult{DaemonUnknown: true}
+		}
+		if msg.Type != ipc.MsgVersionResp || msg.ID != reqID {
+			log.Printf("handshake: ignoring unrelated message type=%q id=%q", msg.Type, msg.ID)
+			continue
+		}
+
+		var payload ipc.VersionRespPayload
+		if err := msg.DecodePayload(&payload); err != nil {
+			log.Printf("handshake: decode payload: %v", err)
+			return handshakeResult{DaemonUnknown: true}
+		}
+
+		cmp, err := versionpkg.Compare(tuiVer, payload.Version)
+		if err != nil {
+			log.Printf("handshake: compare %q vs %q: %v", tuiVer, payload.Version, err)
+			return handshakeResult{DaemonVersion: payload.Version, DaemonUnknown: true}
+		}
+		return handshakeResult{
+			Matched:       cmp == 0,
+			Cmp:           cmp,
+			DaemonVersion: payload.Version,
+		}
+	}
+}

--- a/cmd/quil/main.go
+++ b/cmd/quil/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/artyomsv/quil/internal/logger"
 	"github.com/artyomsv/quil/internal/plugin"
 	"github.com/artyomsv/quil/internal/tui"
+	versionpkg "github.com/artyomsv/quil/internal/version"
 )
 
 var (
@@ -33,6 +34,11 @@ const (
 )
 
 func main() {
+	// Publish this binary's version to the shared version package so
+	// subcommands (MCP bridge, handshake logic) and the TUI all read
+	// from one place.
+	versionpkg.SetCurrent(version)
+
 	// Build-time dev mode: if baked in via ldflags, auto-set QUIL_HOME
 	// before anything else. The --dev flag and QUIL_HOME env var still
 	// take precedence (they're checked first).
@@ -254,8 +260,15 @@ func launchTUI() {
 		fmt.Fprintf(os.Stderr, "cannot connect to daemon: %v\nRun 'quil daemon start' first.\n", err)
 		os.Exit(1)
 	}
-	defer client.Close()
 	log.Print("connected to daemon")
+
+	// Version gate: compare TUI and daemon versions before attaching.
+	// gateVersionCheck either returns the same client (match / skipped),
+	// returns a NEW client connected to a freshly-spawned daemon (after
+	// user-confirmed upgrade restart), or exits the process outright
+	// (TUI older than daemon — blocking dialog path).
+	client = gateVersionCheck(client, sockPath)
+	defer client.Close()
 
 	// Ensure default plugins exist and detect stale ones needing migration
 	stalePlugins, ensureErr := plugin.EnsureDefaultPlugins(config.PluginsDir())

--- a/cmd/quil/version_gate.go
+++ b/cmd/quil/version_gate.go
@@ -1,0 +1,250 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/artyomsv/quil/internal/config"
+	"github.com/artyomsv/quil/internal/ipc"
+	versionpkg "github.com/artyomsv/quil/internal/version"
+)
+
+// reconnectRetryAttempts bounds how long we wait for the respawned
+// daemon to open its socket after a graceful restart.
+const reconnectRetryAttempts = 50
+
+// restartDaemonWaitInterval paces the polling loops that watch the
+// socket disappear (after MsgShutdown) and reappear (after respawn).
+const restartDaemonWaitInterval = 100 * time.Millisecond
+
+// releasesURL is shown to users running an older TUI against a newer
+// daemon. Kept in one place so future URL changes don't need to hunt
+// through the prompt text.
+const releasesURL = "https://github.com/artyomsv/quil/releases"
+
+// gateVersionCheck runs the version handshake against the daemon the
+// caller has already connected to. If versions match it returns the
+// same client unchanged. On mismatch or pre-versioning daemon it either
+// exits the process (client-is-older path) or orchestrates a graceful
+// daemon restart and returns a new client connected to the freshly
+// spawned daemon.
+//
+// Returns the client the caller should use from here on, or exits.
+func gateVersionCheck(client *ipc.Client, sockPath string) *ipc.Client {
+	res := versionHandshake(client)
+
+	switch {
+	case res.ClientSkipped:
+		log.Printf("version gate: skipped (non-release TUI)")
+		return client
+
+	case res.Matched:
+		log.Printf("version gate: match — TUI %s == daemon %s", versionpkg.Current(), res.DaemonVersion)
+		return client
+
+	case res.Cmp < 0 && !res.DaemonUnknown:
+		// TUI is older than the running daemon. Blocking path: we
+		// refuse to attach, print actionable instructions, exit.
+		client.Close()
+		promptUpgradeClient(versionpkg.Current(), res.DaemonVersion)
+		os.Exit(0)
+		return nil
+
+	default:
+		// Either TUI > daemon, or the daemon timed out / returned an
+		// unparseable version (treated as "pre-versioning daemon", same
+		// handling: offer to restart).
+		if !promptRestartDaemon(versionpkg.Current(), res.DaemonVersion, res.DaemonUnknown) {
+			fmt.Fprintln(os.Stderr, "Aborted — daemon left running at the older version.")
+			client.Close()
+			os.Exit(0)
+		}
+		newClient, err := restartDaemonForUpgrade(client, sockPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Daemon restart failed: %v\n", err)
+			os.Exit(1)
+		}
+		// Verify the freshly spawned daemon is actually the expected
+		// version. If PATH has an older quild shadowing the bundled
+		// binary, the restart would loop; bail out with a pointer.
+		verify := versionHandshake(newClient)
+		if !verify.Matched && !verify.ClientSkipped {
+			newClient.Close()
+			fmt.Fprintf(os.Stderr,
+				"Restarted daemon still reports version %q (TUI is %q).\n"+
+					"Another quild binary on PATH may be shadowing the bundled one.\n"+
+					"Locate the quild alongside this quil executable and ensure it's\n"+
+					"the same version, or remove the stale quild from PATH.\n",
+				verify.DaemonVersion, versionpkg.Current(),
+			)
+			os.Exit(1)
+		}
+		log.Printf("version gate: reconnected to daemon %s after restart", verify.DaemonVersion)
+		return newClient
+	}
+}
+
+// promptUpgradeClient tells the user their TUI is too old and exits.
+// No confirmation — this path is blocking by design.
+func promptUpgradeClient(tuiVer, daemonVer string) {
+	fmt.Fprintf(os.Stderr,
+		"\n"+
+			"  Quil needs an update.\n"+
+			"\n"+
+			"    TUI version:    %s\n"+
+			"    Daemon version: %s\n"+
+			"\n"+
+			"  Please download %s (or newer) from:\n"+
+			"    %s\n"+
+			"\n"+
+			"  The TUI refuses to attach to a newer daemon to avoid undefined behaviour.\n"+
+			"  Your workspace, panes, and notes are safe — the running daemon is untouched.\n"+
+			"\n",
+		tuiVer, daemonVer, daemonVer, releasesURL,
+	)
+}
+
+// promptRestartDaemon asks the user whether to restart the daemon to
+// match the TUI's version. Returns true only on an explicit "y" / "yes".
+// An empty response (just Enter) defaults to no — mismatches should
+// never be resolved accidentally.
+func promptRestartDaemon(tuiVer, daemonVer string, unknown bool) bool {
+	daemonLabel := daemonVer
+	if unknown || daemonLabel == "" {
+		daemonLabel = "unknown (pre-versioning daemon)"
+	}
+	fmt.Fprintf(os.Stderr,
+		"\n"+
+			"  Daemon restart required.\n"+
+			"\n"+
+			"    TUI version:    %s\n"+
+			"    Daemon version: %s\n"+
+			"\n"+
+			"  Continue to restart the daemon to %s. This will respawn all panes;\n"+
+			"  your tabs, layouts, working directories, and notes are preserved via\n"+
+			"  the workspace snapshot. In-flight commands in shells will be killed.\n"+
+			"\n"+
+			"  Restart daemon now? [y/N] ",
+		tuiVer, daemonLabel, tuiVer,
+	)
+	reader := bufio.NewReader(os.Stdin)
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		log.Printf("prompt read: %v", err)
+		return false
+	}
+	answer := strings.ToLower(strings.TrimSpace(line))
+	return answer == "y" || answer == "yes"
+}
+
+// restartDaemonForUpgrade gracefully stops the current daemon, spawns
+// a fresh one from the TUI's own install directory, and returns a
+// connected client to the new daemon. The old client is closed.
+func restartDaemonForUpgrade(oldClient *ipc.Client, sockPath string) (*ipc.Client, error) {
+	// 1. Send MsgShutdown so the old daemon exits cleanly (defers in its
+	//    main() run: PID file removal, log close, snapshot flush).
+	shutdown, err := ipc.NewMessage(ipc.MsgShutdown, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build shutdown msg: %w", err)
+	}
+	if err := oldClient.Send(shutdown); err != nil {
+		// Non-fatal — the daemon may already be crashing. Proceed to
+		// the wait-for-socket-gone step either way.
+		log.Printf("restart: send MsgShutdown: %v", err)
+	}
+	oldClient.Close()
+
+	// 2. Wait for the socket file to go away, bounded. If the daemon
+	//    hangs, remove stale socket/PID files so the respawn path
+	//    doesn't refuse to claim them.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(sockPath); os.IsNotExist(err) {
+			break
+		}
+		time.Sleep(restartDaemonWaitInterval)
+	}
+	if _, err := os.Stat(sockPath); err == nil {
+		log.Printf("restart: socket %s still present after shutdown — removing", sockPath)
+		os.Remove(sockPath)
+	}
+	// Stale PID file removal is best-effort; the daemon's normal boot
+	// path also cleans these up, so a failure here isn't blocking.
+	if pidPath := config.PidPath(); pidPath != "" {
+		if _, err := os.Stat(pidPath); err == nil {
+			os.Remove(pidPath)
+		}
+	}
+
+	// 3. Spawn a fresh daemon. Prefer the executable-adjacent binary
+	//    over PATH so a stale `quild` earlier on PATH doesn't shadow
+	//    the bundled one the user just upgraded to.
+	binary := findDaemonBinaryForUpgrade()
+	log.Printf("restart: spawning %s", binary)
+	cmd := exec.Command(binary, "--background")
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	cmd.SysProcAttr = daemonSysProcAttr()
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("spawn daemon %q: %w", binary, err)
+	}
+	if cmd.Process != nil {
+		cmd.Process.Release()
+	}
+
+	// 4. Wait for the new daemon's socket and reconnect.
+	var newClient *ipc.Client
+	for i := 0; i < reconnectRetryAttempts; i++ {
+		time.Sleep(restartDaemonWaitInterval)
+		c, err := ipc.NewClient(sockPath)
+		if err == nil {
+			newClient = c
+			break
+		}
+	}
+	if newClient == nil {
+		return nil, fmt.Errorf("daemon did not open socket %s within %s",
+			sockPath, time.Duration(reconnectRetryAttempts)*restartDaemonWaitInterval)
+	}
+	return newClient, nil
+}
+
+// findDaemonBinaryForUpgrade is the upgrade-path analogue of
+// findDaemonBinary: it prefers the binary alongside the running TUI
+// executable over any `quild` on PATH. During an upgrade, the TUI's
+// adjacent daemon is almost always the matching version (shipped in
+// the same release archive); an older `quild` on PATH would cause a
+// post-restart mismatch loop.
+func findDaemonBinaryForUpgrade() string {
+	name := "quild"
+	if daemonBinary != "" {
+		name = daemonBinary
+	}
+
+	// Executable-adjacent first.
+	if exe, err := os.Executable(); err == nil {
+		dir := filepath.Dir(exe)
+		candidate := filepath.Join(dir, name)
+		if runtime.GOOS == "windows" {
+			candidate += ".exe"
+		}
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+	}
+
+	// PATH fallback.
+	if p, err := exec.LookPath(name); err == nil {
+		return p
+	}
+
+	// Last resort — let the OS try. Same behaviour as findDaemonBinary.
+	return name
+}

--- a/cmd/quild/main.go
+++ b/cmd/quild/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/artyomsv/quil/internal/config"
 	"github.com/artyomsv/quil/internal/daemon"
 	"github.com/artyomsv/quil/internal/logger"
+	versionpkg "github.com/artyomsv/quil/internal/version"
 )
 
 var (
@@ -18,6 +19,10 @@ var (
 )
 
 func main() {
+	// Publish this binary's version to the shared version package so the
+	// IPC MsgVersionReq handler can report it back to connecting clients.
+	versionpkg.SetCurrent(version)
+
 	// Build-time dev mode: auto-set QUIL_HOME before anything else.
 	if buildDevMode == "true" && os.Getenv("QUIL_HOME") == "" {
 		exe, err := os.Executable()

--- a/docs/plans/2026-04-18-client-daemon-version-negotiation.md
+++ b/docs/plans/2026-04-18-client-daemon-version-negotiation.md
@@ -1,0 +1,302 @@
+# Client-Daemon Version Negotiation — Implementation Plan
+
+**Date:** 2026-04-18
+**Target release:** 1.8.0
+
+> **For agentic workers:** Use `superpowers:subagent-driven-development` or `superpowers:executing-plans` to implement task-by-task. Steps use `- [ ]` checkboxes for tracking.
+
+## Goal
+
+Remove the manual "stop daemon → replace both binaries → restart" dance on Quil upgrade. At TUI launch, compare TUI and daemon versions:
+
+| Situation | Action |
+|---|---|
+| Same version | Attach normally (current behavior) |
+| TUI < daemon | Blocking dialog nudging upgrade; **TUI refuses to attach** |
+| TUI > daemon | Confirmation dialog; on OK, gracefully stop daemon and auto-start new one |
+| No daemon running | Spawn new daemon (current behavior) |
+| Version req times out or unparseable | Treat as "pre-versioning daemon" → upgrade-confirmation flow |
+
+## Non-Goals
+
+- Two-way IPC protocol versioning (we version binaries, not message schemas)
+- Hot-swap without restart
+- Dev-mode enforcement (dev/debug variants and unparseable versions skip the check entirely)
+
+## Architecture
+
+1. **Version source.** Both binaries already embed `main.version` via GoReleaser ldflags. Introduce a tiny shared `internal/version/` package so TUI, daemon, and tests all read/compare from one place.
+2. **New IPC pair.** `MsgVersionReq` (client → daemon, empty payload) and `MsgVersionResp` (daemon → client, `{Version string}`), correlated via `Message.ID` (request-response pattern already used by MCP bridge).
+3. **Handshake before attach.** The TUI's existing daemon-connect path (`cmd/quil/main.go`) gains a thin handshake step:
+   - Connect socket (already auto-starts a daemon if socket missing).
+   - Send `MsgVersionReq` with a request ID. Wait up to 2 seconds for `MsgVersionResp`.
+   - Compare via semver.
+   - If mismatched, open the TUI into a blocking full-screen dialog variant (`dialogVersionMismatch`) instead of the normal post-attach flow.
+4. **Restart flow (client > daemon).** On user confirmation: send `MsgShutdown`, wait for socket file to disappear (poll, 5s cap), then call the existing daemon-spawn path. When the new socket appears, re-handshake and — if versions match this time — attach normally. If they still don't match, show an error dialog pointing at the PATH hazard.
+5. **Dev-mode skip.** When `QUIL_HOME` is overridden or the binary is the `-dev` variant, skip the handshake entirely. Same daemon/client pair always match in the project's `.quil/` dir.
+
+## File Structure
+
+| File | Responsibility |
+|------|----------------|
+| `internal/version/version.go` (new) | `Current()`, `SetCurrent(string)`, `Compare(a, b string) (int, error)` |
+| `internal/version/version_test.go` (new) | Semver compare table-driven tests (pre-release suffixes tolerated) |
+| `internal/ipc/messages.go` | Add `MsgVersionReq`, `MsgVersionResp`, `VersionRespPayload` |
+| `internal/daemon/daemon.go` | Handler for `MsgVersionReq` → responds with `version.Current()` |
+| `internal/daemon/daemon_test.go` (if present) | Roundtrip test: MsgVersionReq → MsgVersionResp |
+| `cmd/quild/main.go` | Call `version.SetCurrent(version)` before serving IPC |
+| `cmd/quil/main.go` | Call `version.SetCurrent(version)`; invoke new `versionHandshake()` before Model startup |
+| `cmd/quil/handshake.go` (new) | `versionHandshake(client) → (matched bool, daemonVer string, err error)` |
+| `cmd/quil/restart_daemon.go` (new) | `restartDaemon(client)` — shutdown + wait + respawn |
+| `internal/tui/dialog.go` | Add `dialogVersionMismatch` iota; render + key handler for both variants |
+| `internal/tui/model.go` | Model gets `versionMismatch *versionMismatchState` carrying state for the dialog |
+
+## Tasks
+
+### Task 1: `internal/version/` package
+
+**Files:** `internal/version/version.go` (new), `internal/version/version_test.go` (new)
+
+- [ ] **Step 1: Write package**
+
+```go
+// Package version is the single source of truth for the running binary's
+// version string. Both quil (TUI) and quild (daemon) set Current() from
+// their main.version ldflag; tests and runtime code read via Current().
+package version
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+var current = "dev"
+
+// SetCurrent stores the binary's version. Call exactly once from main().
+func SetCurrent(v string) { current = strings.TrimSpace(v) }
+
+// Current returns the version set by SetCurrent, or "dev" if unset.
+func Current() string { return current }
+
+// Parsed returns the numeric major.minor.patch from a semver-like string.
+// Accepts "1.2.3", "1.2.3-rc1", "v1.2.3". Strips leading "v" and any
+// pre-release / build suffix after the first "-" or "+".
+func Parsed(v string) (major, minor, patch int, err error) {
+	s := strings.TrimPrefix(strings.TrimSpace(v), "v")
+	for _, sep := range []string{"-", "+"} {
+		if i := strings.Index(s, sep); i >= 0 {
+			s = s[:i]
+		}
+	}
+	parts := strings.Split(s, ".")
+	if len(parts) != 3 {
+		return 0, 0, 0, fmt.Errorf("not semver: %q", v)
+	}
+	nums := make([]int, 3)
+	for i, p := range parts {
+		n, convErr := strconv.Atoi(p)
+		if convErr != nil {
+			return 0, 0, 0, fmt.Errorf("not numeric %q in %q: %w", p, v, convErr)
+		}
+		nums[i] = n
+	}
+	return nums[0], nums[1], nums[2], nil
+}
+
+// Compare returns -1 if a<b, 0 if a==b, +1 if a>b. Returns a non-nil error
+// when either side is unparseable; callers must decide how to interpret.
+func Compare(a, b string) (int, error) {
+	am, an, ap, err := Parsed(a)
+	if err != nil {
+		return 0, err
+	}
+	bm, bn, bp, err := Parsed(b)
+	if err != nil {
+		return 0, err
+	}
+	switch {
+	case am != bm:
+		return sign(am - bm), nil
+	case an != bn:
+		return sign(an - bn), nil
+	case ap != bp:
+		return sign(ap - bp), nil
+	}
+	return 0, nil
+}
+
+func sign(x int) int {
+	switch {
+	case x > 0:
+		return 1
+	case x < 0:
+		return -1
+	}
+	return 0
+}
+```
+
+- [ ] **Step 2: Table-driven tests**
+
+Cover: equal, major/minor/patch wins, `v` prefix stripped, `1.10.0 > 1.9.0` (lexical trap), pre-release/build suffix stripped, empty/garbage → error.
+
+### Task 2: IPC message
+
+**Files:** `internal/ipc/messages.go`, `internal/daemon/daemon.go`, daemon tests
+
+- [ ] **Step 1: Add message types**
+
+In `internal/ipc/messages.go`, add to the `Msg*` constant block:
+```go
+MsgVersionReq  = "version_req"
+MsgVersionResp = "version_resp"
+```
+And add the payload struct:
+```go
+type VersionRespPayload struct {
+    Version string `json:"version"`
+}
+```
+`MsgVersionReq` has no payload — empty body.
+
+- [ ] **Step 2: Daemon handler**
+
+In `internal/daemon/daemon.go` dispatch switch (look for other `case ipc.Msg...` examples — same pattern as `MsgScreenshotPaneReq`):
+```go
+case ipc.MsgVersionReq:
+    respondTo(conn, msg.ID, ipc.MsgVersionResp, ipc.VersionRespPayload{
+        Version: version.Current(),
+    })
+```
+Add the import.
+
+- [ ] **Step 3: Roundtrip test**
+
+Either extend an existing daemon IPC test or add one that spins up a daemon, sends `MsgVersionReq` with an ID, awaits `MsgVersionResp`, asserts version field matches `version.Current()`.
+
+### Task 3: Wire version into both binaries
+
+**Files:** `cmd/quil/main.go`, `cmd/quild/main.go`
+
+- [ ] Both mains already have a `var version = "dev"` (or equivalent ldflag sink). Call `version.SetCurrent(version)` EARLY in `main()` — before any IPC starts, before any config load that might log it. One line each.
+
+### Task 4: Client-side handshake
+
+**Files:** `cmd/quil/handshake.go` (new), `cmd/quil/main.go`
+
+- [ ] **Step 1: Write the handshake function**
+
+```go
+// versionHandshake sends MsgVersionReq and compares the response to the
+// TUI's own version. Returns:
+//   matched  - true when versions are byte-for-byte equal
+//   cmp      - -1 if TUI < daemon, +1 if TUI > daemon, 0 if equal
+//   daemonVer - raw string the daemon reported (for UI)
+//   err      - transport or parse error; callers typically treat as "old daemon"
+func versionHandshake(client *ipc.Client) (matched bool, cmp int, daemonVer string, err error) { ... }
+```
+Timeout: 2s. If the response never arrives, return `err == ErrTimeout` with `daemonVer == ""`.
+
+- [ ] **Step 2: Call from main** right after `client.Connect()` and before `NewModel()`.
+
+- [ ] **Step 3: Dev-mode skip**
+
+If `config.IsDevMode()` (detect via `QUIL_HOME` set, or build-tag ldflag `buildDevMode`), skip the handshake and proceed. Log at debug level.
+
+- [ ] **Step 4: Unparseable skip**
+
+If `version.Current()` parses with error (e.g., `"dev"`), skip the handshake with a debug log.
+
+### Task 5: Dialog variants
+
+**Files:** `internal/tui/dialog.go`, `internal/tui/model.go`
+
+- [ ] **Step 1: Add dialog iota**
+
+```go
+dialogVersionMismatch
+```
+- [ ] **Step 2: State struct on Model**
+
+```go
+type versionMismatchState struct {
+    tuiVer    string
+    daemonVer string // may be empty when handshake timed out
+    clientOlder bool // true when TUI < daemon, drives which variant renders
+    cursor    int   // focused button index
+}
+```
+- [ ] **Step 3: Render**
+
+When `clientOlder == true`:
+```
+Quil needs an update
+
+ Your TUI is v{tuiVer}.
+ The running daemon is v{daemonVer}.
+ 
+ Please download v{daemonVer} (or newer) from:
+ https://github.com/artyomsv/quil/releases
+
+ [Copy URL]   [Quit]
+```
+When `clientOlder == false`:
+```
+Daemon restart required
+
+ TUI version: v{tuiVer}
+ Daemon version: v{daemonVer}   (or "unknown — pre-versioning daemon")
+ 
+ Continue to restart the daemon to v{tuiVer}. This will respawn all
+ panes. Your workspace (tabs, layouts, CWDs, notes) is preserved.
+
+ [Restart daemon]   [Quit]
+```
+
+- [ ] **Step 4: Key handler**
+
+Tab / Left / Right cycle buttons; Enter fires. No Esc bypass when `clientOlder` (blocking). When `!clientOlder`, Esc = Quit for consistency.
+
+### Task 6: Restart flow
+
+**Files:** `cmd/quil/restart_daemon.go` (new)
+
+- [ ] **Step 1: Send MsgShutdown**
+
+Use existing IPC client.
+
+- [ ] **Step 2: Wait for socket disappearance**
+
+Poll `os.Stat(config.SocketPath())` every 100 ms up to 5 s. After timeout, try to remove stale PID file (mirroring the startup cleanup path).
+
+- [ ] **Step 3: Spawn new daemon**
+
+Reuse `findDaemonBinary()` + the existing `proc_{unix,windows}.go` spawn path. **Important:** for the restart path, prefer executable-adjacent binary over PATH (reverse of the default order) to avoid spawning an older `quild` that happens to be on PATH. If the current TUI is `quil-1.7.0.exe`, its adjacent `quild.exe` is almost certainly the matching 1.7.0 daemon. Accept a small helper like `findDaemonBinaryForUpgrade()`.
+
+- [ ] **Step 4: Wait for socket appearance + re-handshake**
+
+Poll up to 5 s. On connect, call `versionHandshake` again. If versions now match, continue with normal attach. If still mismatched, show an error dialog: "Restarted daemon still reports {v}. Check PATH — another quild may be shadowing the bundled one."
+
+### Task 7: Tests and manual smoke
+
+- [ ] Unit: `internal/version` table-driven cases (see Task 1 Step 2)
+- [ ] Unit: handshake function with a fake IPC (timeout path, success path, parse-error path)
+- [ ] Integration: spin up real daemon on a temp socket path, perform handshake, assert payload
+- [ ] Manual smoke on Windows after building two variants at different versions:
+  1. Run `quil-1.6.0.exe`, keep TUI open in another pane to start daemon 1.6.0.
+  2. Close TUI. Leave daemon 1.6.0 running.
+  3. Run `quil-1.7.0.exe`. Expect: "Daemon restart required" dialog → confirm → panes respawn → version badge reads 1.7.0.
+  4. Now close TUI but keep daemon 1.7.0. Run `quil-1.6.0.exe`. Expect blocking "Quil needs an update" dialog; TUI refuses to enter.
+
+## Rollout Notes
+
+- This is the FIRST release that speaks `MsgVersionReq`. Running the new TUI against a 1.7.0 daemon will hit the timeout path — that's expected and handled: it falls into the upgrade-confirmation flow. One manual "Restart daemon" click, and the user is on matched-version forever after.
+- Ship in 1.8.0. The `feat:` of this plan triggers minor bump via the newly-hardened parser.
+
+## Risks
+
+- **PATH shadowing**: addressed via `findDaemonBinaryForUpgrade()` preferring adjacent over PATH, plus the post-restart re-handshake guard.
+- **Windows .exe file lock during restart**: the new daemon file is already on disk (user extracted archive). We don't replace files at runtime — we just stop the old process and start the new one. No lock issue.
+- **Daemon hang on MsgShutdown**: the 5-second socket-disappearance timeout is the safety net; if exceeded, we log and attempt to proceed with spawn (new daemon will refuse if old socket still listening, giving a clean error).
+- **Future IPC wire-format changes**: handshake timeout is 2 s — a much older daemon that crashes on unknown message types would cause us to re-handshake against the freshly spawned daemon. Old daemons today just log-and-ignore unknown types, so timeout is the expected path.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -28,6 +28,7 @@ import (
 	apty "github.com/artyomsv/quil/internal/pty"
 	"github.com/artyomsv/quil/internal/ringbuf"
 	"github.com/artyomsv/quil/internal/shellinit"
+	"github.com/artyomsv/quil/internal/version"
 )
 
 // oscBellRe matches OSC sequences terminated by BEL (\x07), e.g., \x1b]0;title\x07.
@@ -493,6 +494,13 @@ func (d *Daemon) handleMessage(conn *ipc.Conn, msg *ipc.Message) {
 		d.handleGetNotificationsReq(conn, msg)
 	case ipc.MsgWatchNotificationsReq:
 		d.handleWatchNotificationsReq(conn, msg)
+
+	// Version negotiation — reply with the running daemon's version so the
+	// client can gate attach on matching binaries.
+	case ipc.MsgVersionReq:
+		respondTo(conn, msg.ID, ipc.MsgVersionResp, ipc.VersionRespPayload{
+			Version: version.Current(),
+		})
 	}
 }
 

--- a/internal/ipc/client.go
+++ b/internal/ipc/client.go
@@ -1,6 +1,9 @@
 package ipc
 
-import "net"
+import (
+	"net"
+	"time"
+)
 
 // Client connects to the daemon over a Unix socket.
 type Client struct {
@@ -21,6 +24,14 @@ func (c *Client) Send(msg *Message) error {
 
 func (c *Client) Receive() (*Message, error) {
 	return c.conn.Receive()
+}
+
+// SetReadDeadline installs a read deadline on the underlying socket.
+// Pass the zero time to disable it. Used by the pre-attach version
+// handshake to cap how long we wait for MsgVersionResp from daemons
+// that may predate the version-negotiation protocol.
+func (c *Client) SetReadDeadline(t time.Time) error {
+	return c.conn.raw.SetReadDeadline(t)
 }
 
 func (c *Client) Close() error {

--- a/internal/ipc/protocol.go
+++ b/internal/ipc/protocol.go
@@ -72,6 +72,13 @@ const (
 	MsgGetNotificationsResp   = "get_notifications_resp"   // MCP response
 	MsgWatchNotificationsReq  = "watch_notifications_req"  // MCP request (blocking)
 	MsgWatchNotificationsResp = "watch_notifications_resp" // MCP response
+
+	// Version negotiation — TUI asks daemon for its version string before
+	// attaching so mismatches can be surfaced as a blocking dialog or an
+	// auto-restart prompt. A daemon built before this pair existed will
+	// silently drop MsgVersionReq; the client handles the timeout.
+	MsgVersionReq  = "version_req"  // client → daemon (empty payload)
+	MsgVersionResp = "version_resp" // daemon → client (VersionRespPayload)
 )
 
 // Message is the wire format for IPC communication.
@@ -298,6 +305,12 @@ type WatchNotificationsReqPayload struct {
 type WatchNotificationsRespPayload struct {
 	Event   *PaneEventPayload `json:"event,omitempty"`
 	Timeout bool              `json:"timeout"`
+}
+
+// VersionRespPayload carries the daemon's version string. MsgVersionReq
+// has no payload — the request is just "what version are you running?".
+type VersionRespPayload struct {
+	Version string `json:"version"`
 }
 
 // NewMessage creates a Message with a typed payload.

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,111 @@
+// Package version is the single source of truth for the running binary's
+// version string. Both quil (TUI) and quild (daemon) call SetCurrent from
+// their main.version ldflag sink during startup; runtime code reads via
+// Current(). Parsed() and Compare() provide proper semver ordering so
+// comparisons work across multi-digit components ("1.10.0" > "1.9.0").
+package version
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// fallback is returned by Current() when SetCurrent has not been called.
+// "dev" matches the existing main.go sentinel for unstamped local builds.
+const fallback = "dev"
+
+var current = fallback
+
+// SetCurrent stores the binary's version. Call exactly once from main()
+// early in startup, before any code path reads Current(). Whitespace is
+// trimmed. An empty string is coerced to the fallback so Current() never
+// returns "" (which would complicate version-response IPC payloads).
+func SetCurrent(v string) {
+	trimmed := strings.TrimSpace(v)
+	if trimmed == "" {
+		current = fallback
+		return
+	}
+	current = trimmed
+}
+
+// Current returns the version set by SetCurrent, or the "dev" fallback
+// for local builds where main.version was never overridden via ldflags.
+func Current() string { return current }
+
+// IsRelease reports whether Current() parses as a proper semver (i.e.,
+// this is a release build, not "dev" or an unstamped binary). Callers
+// use this to decide whether version-negotiation logic should engage
+// or be skipped.
+func IsRelease() bool {
+	_, _, _, err := Parsed(current)
+	return err == nil
+}
+
+// Parsed extracts the numeric major.minor.patch components from a
+// semver-like string. Accepts "1.2.3", "1.2.3-rc1", "v1.2.3". Leading
+// "v" and any pre-release or build suffix after the first "-" or "+"
+// are stripped before parsing.
+func Parsed(v string) (major, minor, patch int, err error) {
+	s := strings.TrimPrefix(strings.TrimSpace(v), "v")
+	for _, sep := range []string{"-", "+"} {
+		if i := strings.Index(s, sep); i >= 0 {
+			s = s[:i]
+		}
+	}
+	parts := strings.Split(s, ".")
+	if len(parts) != 3 {
+		return 0, 0, 0, fmt.Errorf("not semver: %q", v)
+	}
+	nums := make([]int, 3)
+	for i, p := range parts {
+		if p == "" {
+			return 0, 0, 0, fmt.Errorf("empty component in %q", v)
+		}
+		n, convErr := strconv.Atoi(p)
+		if convErr != nil {
+			return 0, 0, 0, fmt.Errorf("not numeric %q in %q", p, v)
+		}
+		if n < 0 {
+			return 0, 0, 0, fmt.Errorf("negative component %d in %q", n, v)
+		}
+		nums[i] = n
+	}
+	return nums[0], nums[1], nums[2], nil
+}
+
+// Compare returns -1 if a<b, 0 if a==b, +1 if a>b by semver ordering.
+// Pre-release and build suffixes are ignored: "1.2.3-rc1" compares equal
+// to "1.2.3". Returns a non-nil error when either side is unparseable so
+// callers can decide how to interpret (typically: skip the check or treat
+// as mismatch depending on context).
+func Compare(a, b string) (int, error) {
+	am, an, ap, err := Parsed(a)
+	if err != nil {
+		return 0, err
+	}
+	bm, bn, bp, err := Parsed(b)
+	if err != nil {
+		return 0, err
+	}
+	switch {
+	case am != bm:
+		return sign(am - bm), nil
+	case an != bn:
+		return sign(an - bn), nil
+	case ap != bp:
+		return sign(ap - bp), nil
+	}
+	return 0, nil
+}
+
+func sign(x int) int {
+	switch {
+	case x > 0:
+		return 1
+	case x < 0:
+		return -1
+	}
+	return 0
+}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,139 @@
+package version
+
+import "testing"
+
+func TestParsed(t *testing.T) {
+	cases := []struct {
+		in            string
+		wantMaj       int
+		wantMin       int
+		wantPatch     int
+		wantErr       bool
+	}{
+		{"1.2.3", 1, 2, 3, false},
+		{"v1.2.3", 1, 2, 3, false},
+		{"  v1.2.3  ", 1, 2, 3, false}, // trimmed
+		{"1.10.0", 1, 10, 0, false},    // multi-digit component
+		{"10.0.0", 10, 0, 0, false},
+		{"1.2.3-rc1", 1, 2, 3, false},     // pre-release stripped
+		{"1.2.3-rc.1+build.5", 1, 2, 3, false}, // pre-release + build stripped
+		{"1.2.3+build", 1, 2, 3, false},
+		{"0.0.0", 0, 0, 0, false},
+		// Error cases
+		{"", 0, 0, 0, true},
+		{"dev", 0, 0, 0, true},
+		{"1.2", 0, 0, 0, true},        // too few
+		{"1.2.3.4", 0, 0, 0, true},    // too many
+		{"1.2.x", 0, 0, 0, true},      // non-numeric
+		{"-1.0.0", 0, 0, 0, true},     // negative
+		{"1..3", 0, 0, 0, true},       // empty component
+		{"v", 0, 0, 0, true},          // bare v
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			maj, min, patch, err := Parsed(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got maj=%d min=%d patch=%d", maj, min, patch)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if maj != tc.wantMaj || min != tc.wantMin || patch != tc.wantPatch {
+				t.Errorf("got %d.%d.%d, want %d.%d.%d", maj, min, patch, tc.wantMaj, tc.wantMin, tc.wantPatch)
+			}
+		})
+	}
+}
+
+func TestCompare(t *testing.T) {
+	cases := []struct {
+		a, b    string
+		want    int
+		wantErr bool
+	}{
+		// Equal
+		{"1.2.3", "1.2.3", 0, false},
+		{"v1.2.3", "1.2.3", 0, false},                 // v prefix
+		{"1.2.3-rc1", "1.2.3", 0, false},              // suffix ignored
+		{"1.2.3-rc1", "1.2.3-rc2", 0, false},          // both suffixes ignored — same core
+		// Major wins
+		{"2.0.0", "1.99.99", 1, false},
+		{"1.0.0", "2.0.0", -1, false},
+		// Minor wins (lexical trap: "1.10.0" > "1.9.0")
+		{"1.10.0", "1.9.0", 1, false},
+		{"1.9.0", "1.10.0", -1, false},
+		// Patch wins
+		{"1.2.10", "1.2.9", 1, false},
+		{"1.2.0", "1.2.1", -1, false},
+		// Errors propagate
+		{"dev", "1.2.3", 0, true},
+		{"1.2.3", "dev", 0, true},
+		{"", "1.2.3", 0, true},
+	}
+	for _, tc := range cases {
+		name := tc.a + "_vs_" + tc.b
+		t.Run(name, func(t *testing.T) {
+			got, err := Compare(tc.a, tc.b)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %d", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("Compare(%q,%q) = %d, want %d", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSetCurrent_EmptyFallsBackToDev(t *testing.T) {
+	orig := current
+	t.Cleanup(func() { current = orig })
+
+	SetCurrent("1.7.0")
+	if Current() != "1.7.0" {
+		t.Errorf("after SetCurrent(1.7.0): Current() = %q, want 1.7.0", Current())
+	}
+
+	SetCurrent("  v2.0.0  ") // trimmed (leading/trailing whitespace)
+	if Current() != "v2.0.0" {
+		t.Errorf("after whitespace SetCurrent: Current() = %q, want v2.0.0", Current())
+	}
+
+	SetCurrent("")
+	if Current() != fallback {
+		t.Errorf("after SetCurrent(\"\"): Current() = %q, want %q (fallback)", Current(), fallback)
+	}
+}
+
+func TestIsRelease(t *testing.T) {
+	orig := current
+	t.Cleanup(func() { current = orig })
+
+	SetCurrent("1.7.0")
+	if !IsRelease() {
+		t.Error("1.7.0 should be release")
+	}
+
+	SetCurrent("dev")
+	if IsRelease() {
+		t.Error("dev should NOT be release")
+	}
+
+	SetCurrent("")
+	if IsRelease() {
+		t.Error("empty (fallback to dev) should NOT be release")
+	}
+
+	SetCurrent("1.2.3-rc1")
+	if !IsRelease() {
+		t.Error("1.2.3-rc1 should be release (pre-release tag is still semver)")
+	}
+}


### PR DESCRIPTION
Remove the manual "stop daemon → replace both binaries → restart" dance on Quil upgrade. Before attaching, the TUI asks the daemon what version it's running via a new MsgVersionReq/MsgVersionResp IPC pair, then acts on the result:

- Match: attach normally (current behaviour).
- TUI < daemon: refuse to attach, print a blocking message pointing at the releases page. User's running daemon is untouched.
- TUI > daemon: prompt "Restart daemon now? [y/N]". On confirmation, send MsgShutdown, wait for the socket to disappear, spawn the daemon adjacent to the TUI executable (preferred over PATH so a stale `quild` earlier on PATH can't shadow the bundled one), and reconnect. Panes respawn via the existing workspace snapshot.
- Timeout / unparseable response: treat as "pre-versioning daemon" (any release before this one) → same restart-confirmation flow.
- Dev/debug builds and unstamped local builds skip the handshake entirely.

New shared `internal/version/` package provides proper semver parsing and comparison, so 1.10.0 > 1.9.0 correctly (lexical ordering would have said the opposite).

Rollout: this is the first release to speak MsgVersionReq; existing 1.7.x daemons drop the message silently. The client's 2-second read deadline handles that — users see one confirmation prompt on their first upgrade to this version, and the mechanism is self-sustaining from then on.

Plan: docs/plans/2026-04-18-client-daemon-version-negotiation.md