### PR TITLE
chore(ci): scan only commit subjects for version-bump classification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,21 +40,35 @@ jobs:
           LAST_TAG="v${CURRENT}"
           echo "current=${CURRENT}" >> $GITHUB_OUTPUT
 
-          # Scan BOTH subject (%s) and body (%b) so squash-merged PRs whose
-          # subject was defaulted from the branch name (`Feat/foo-bar`) still
-          # get classified by the proper `feat(scope):` lines in the body.
-          # `--oneline` would have stripped bodies and missed those.
+          # Scan SUBJECTS only for type-bump classification. A previous
+          # version of this script also scanned commit bodies ("%s%n%b"),
+          # which produced a false-positive minor bump on PR #35 (docs
+          # restructure) because the PR description contained the literal
+          # string `feat(tui): add Stop daemon action` — a back-tick-wrapped
+          # reference to another open PR — that the body regex matched as
+          # if it were a real `feat(tui):` commit. The squash subject set
+          # by the merger is the authoritative classification; if a
+          # contributor's branch-name-derived subject is non-conventional
+          # the `[(:/]` regex below still accepts `feat/foo-bar` form.
+          #
+          # BREAKING CHANGE is read from bodies because per the Conventional
+          # Commits spec it lives in the footer, not the subject. The
+          # `^BREAKING[ -]CHANGE:` anchor matches the footer form
+          # specifically (line-start + colon) so prose references like
+          # "this is not a BREAKING CHANGE" do NOT match.
           if git rev-parse "$LAST_TAG" >/dev/null 2>&1; then
-            COMMITS=$(git log "${LAST_TAG}..HEAD" --format='%s%n%b%n---')
+            SUBJECTS=$(git log "${LAST_TAG}..HEAD" --format='%s')
+            BODIES=$(git log "${LAST_TAG}..HEAD" --format='%b')
           else
-            COMMITS=$(git log --format='%s%n%b%n---')
+            SUBJECTS=$(git log --format='%s')
+            BODIES=$(git log --format='%b')
           fi
 
-          echo "--- Commits since ${LAST_TAG} ---"
-          echo "$COMMITS"
+          echo "--- Subjects since ${LAST_TAG} ---"
+          echo "$SUBJECTS"
           echo "---"
 
-          if [ -z "$COMMITS" ]; then
+          if [ -z "$SUBJECTS" ]; then
             echo "::notice::No commits since last tag — skipping release"
             echo "skip=true" >> $GITHUB_OUTPUT
             exit 0
@@ -67,11 +81,12 @@ jobs:
           #   accidentally matching `feat`.
           # - `[(:/]`: accepts `feat:`, `feat(scope):`, AND `feat/branch-name`
           #   (the last appears when the squash subject came from the branch).
-          if echo "$COMMITS" | grep -qiE '\b(feat!|fix!|refactor!)|BREAKING CHANGE'; then
+          if echo "$SUBJECTS" | grep -qiE '\b(feat!|fix!|refactor!)[(:/]?' \
+             || echo "$BODIES" | grep -qE '^BREAKING[ -]CHANGE:'; then
             BUMP="major"
-          elif echo "$COMMITS" | grep -qiE '\bfeat[(:/]'; then
+          elif echo "$SUBJECTS" | grep -qiE '\bfeat[(:/]'; then
             BUMP="minor"
-          elif echo "$COMMITS" | grep -qiE '\b(fix|perf)[(:/]'; then
+          elif echo "$SUBJECTS" | grep -qiE '\b(fix|perf)[(:/]'; then
             BUMP="patch"
           else
             echo "::notice::No version-bumping commits found (only chore/docs/test/ci) — skipping release"


### PR DESCRIPTION
## Summary

Fixes the false-positive minor bump on PR #35 (docs restructure) that shipped **v1.13.0 with no user-visible changes**.

The release pipeline was scanning both subject AND body of every commit since the last tag, hoping to catch type lines preserved in squash bodies when the subject was branch-name-derived. That heuristic produced this false positive: the #35 PR description contained the literal back-tick-wrapped reference

> This PR is independent of #34 (`` `feat(tui): add Stop daemon action` ``).

…and the regex `\bfeat[(:/]` matched the substring `feat(` inside the backticks just as readily as it would have matched a real `feat(tui):` commit. The release job classified the PR as `minor` and shipped v1.13.0 with nothing user-facing in it.

## Fix

| What | Before | After |
|---|---|---|
| Type classification (feat/fix/perf/bang) | scans `%s%n%b` (subject + body) | scans `%s` (subject only) — the merger sets the squash subject explicitly and it IS the authoritative classification |
| `BREAKING CHANGE` detection | matched anywhere in subject+body via `BREAKING CHANGE` | matches `^BREAKING[ -]CHANGE:` in body **anchored to line start with trailing colon** — the Conventional Commits footer form. Prose mentions like "this is not a BREAKING CHANGE" no longer match. |
| Branch-name fallback (`feat/foo-bar`) | covered via body scan | still covered — the existing `[(:/]` regex on subjects accepts `feat/foo-bar` form natively |

Diff is ~30 lines, all in `.github/workflows/release.yml`.

## Why this never bit before

The body-scan was a defense-in-depth measure for branch-name-derived squash subjects. In practice, every merge in this repo's history has had a properly conventional subject set by the merger, so the body scan never had to do its intended job — it just sat there waiting to false-positive. PR #35 was the first PR whose description text contained a conventional-commit-style reference to another PR, and that's when the bug surfaced.

## Self-test

Smoke-tested the new regex on the prose vs. footer distinction:

```
$ echo "BREAKING CHANGE: yes" | grep -qE '^BREAKING[ -]CHANGE:'
→ match (correct — real footer)

$ echo "no BREAKING CHANGE here" | grep -qE '^BREAKING[ -]CHANGE:'
→ no match (correct — prose mention)

$ echo "feat(api): add foo" | grep -qiE '\bfeat[(:/]'
→ match (correct — real subject)

$ echo "ref to feat(api)" | grep -qiE '\bfeat[(:/]'
→ matches the regex but the body is no longer scanned for feat —
  irrelevant to the bump path now
```

## Why this PR doesn't bump

The PR is committed as `chore(ci):`, which falls through to the "skip release" branch in the workflow itself. No `v1.14.1` release will be cut by merging this; the next user-visible feature PR will bump as normal.

## Test plan

- [x] Inspected the PR #35 squash body to confirm the matching string (`` `feat(tui)` `` inside backticks)
- [x] Verified the new `^BREAKING[ -]CHANGE:` anchor matches the Conventional Commits footer form but not casual prose
- [x] Confirmed `chore(ci):` does not match the bump regexes — this PR's own merge will skip the release job (no v1.14.1 will ship)
- [x] Diff is small and reviewable (~30 lines, single file)