### PR TITLE
fix(ipc): non-blocking broadcast + 4 KiB per-event size cap

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -22,7 +22,7 @@ Client-daemon model:
 - `cmd/quild/` — Background daemon
 - `internal/config/` — TOML configuration (`Load` reads, `Save` writes atomically via `.tmp` + rename). `UIConfig.ShowDisclaimer` controls startup beta dialog
 - `internal/daemon/` — Session manager, message routing, event queue (`event.go` — bounded, mutex-protected, watcher pub/sub for MCP)
-- `internal/ipc/` — Length-prefixed JSON protocol (4-byte big-endian uint32 + JSON)
+- `internal/ipc/` — Length-prefixed JSON protocol (4-byte big-endian uint32 + JSON). Each `Conn` owns a 64-slot send buffer (`sendCh`) drained by a dedicated `sendLoop` goroutine; `Send`/`sendFrame` are non-blocking. `Broadcast` marshals once and shares the cloned wire frame across N conns lock-free after snapshotting `s.conns`. A slow / wedged peer's `sendFrame` trips a CAS-guarded overflow that logs once + spawns `go c.Close()` (`ErrSendOverflow`); other clients never block. `sendLoop` enforces a 30 s `SetWriteDeadline` per frame as a belt-and-suspenders catch for kernel-buffer wedges. `Server.ConnCount()` exposes the live count for tests. Daemon-side per-event size caps (4 KiB Message, 128 B per Data value, front-truncated with `…[truncated]` marker, reserved `_quil_truncated` flag) live in `internal/daemon/event.go:toPaneEventPayload`
 - `internal/persist/` — Atomic workspace/buffer persistence (JSON snapshots, binary ghost buffers)
 - `internal/pty/` — Cross-platform PTY (build tags: `linux || darwin || freebsd`, `windows`)
 - `internal/shellinit/` — Automatic OSC 7 + OSC 133 shell integration (embedded init scripts, `//go:embed`)

--- a/internal/daemon/event.go
+++ b/internal/daemon/event.go
@@ -152,14 +152,41 @@ func (q *eventQueue) RemoveWatchersByConn(conn *ipc.Conn) {
 // headroom for legitimate content (multi-line excerpts, command previews,
 // error stacks) while keeping a runaway event source from bloating the wire.
 //
-// Truncation is from the *front* so the most recent (and usually most
-// relevant) content survives — for excerpts that's the last visible line a
-// terminal would actually display.
+// Truncation strategy: keeps the TAIL because PaneEvent.Message is used for
+// terminal excerpts (last visible lines = what the user sees) and idle
+// pattern matches (recent output). If a future emitter needs head-truncation
+// (e.g. Java-style stack traces where the deepest frame at the top is the
+// actual exception), add a PaneEvent.TruncationStrategy field rather than
+// special-casing here.
+//
+// truncationMarker is "…[truncated]" — 14 bytes, NOT 12: the leading "…" is a
+// 3-byte UTF-8 ellipsis rune. The slice arithmetic below uses len() so it
+// remains correct regardless of marker change, but the cap constants must
+// always exceed the marker length. The init-time invariant block below
+// enforces this at compile time.
 const (
-	maxEventMessageBytes  = 4 * 1024
+	maxEventMessageBytes   = 4 * 1024
 	maxEventDataValueBytes = 128
-	truncationMarker      = "…[truncated]"
+	truncationMarker       = "…[truncated]"
 )
+
+// Compile-time invariants. If a future contributor lowers either cap below
+// the marker length the conversion of a negative constant to uint will fail
+// the build — guaranteeing the slice arithmetic in toPaneEventPayload never
+// panics with a negative slice index.
+const (
+	_ = uint(maxEventMessageBytes - len(truncationMarker) - 1)
+	_ = uint(maxEventDataValueBytes - len(truncationMarker) - 1)
+)
+
+// truncatedFlagKey is the reserved Data key used to signal that the event
+// went through the size-cap path. The `_quil_` prefix establishes a daemon-
+// internal namespace so emitters (idle handlers, plugin scrapers, future
+// hook events) can never accidentally collide with a meaningful key —
+// silently clobbering caller-supplied data would be a confusing failure
+// mode. Document any future daemon-internal Data flags under the same
+// prefix.
+const truncatedFlagKey = "_quil_truncated"
 
 // toPaneEventPayload converts a PaneEvent to an IPC payload, enforcing the
 // per-event wire-size caps. Caps are applied at the IPC boundary so all
@@ -170,9 +197,6 @@ func toPaneEventPayload(e PaneEvent) ipc.PaneEventPayload {
 	truncated := false
 
 	if len(message) > maxEventMessageBytes {
-		// Keep the tail — for excerpts, the bottom-most lines are the
-		// terminal-visible ones; for error blobs the trailing lines often
-		// carry the actual cause.
 		message = truncationMarker + message[len(message)-(maxEventMessageBytes-len(truncationMarker)):]
 		truncated = true
 	}
@@ -193,7 +217,7 @@ func toPaneEventPayload(e PaneEvent) ipc.PaneEventPayload {
 		if data == nil {
 			data = make(map[string]string, 1)
 		}
-		data["truncated"] = "1"
+		data[truncatedFlagKey] = "1"
 	}
 
 	return ipc.PaneEventPayload{

--- a/internal/daemon/event.go
+++ b/internal/daemon/event.go
@@ -146,8 +146,56 @@ func (q *eventQueue) RemoveWatchersByConn(conn *ipc.Conn) {
 	q.watchers = remaining
 }
 
-// toPaneEventPayload converts a PaneEvent to an IPC payload.
+// Per-event wire-size caps. The earlier wedge incident happened with a
+// > 1 KiB box-drawing excerpt from an opencode splash screen flooding the
+// IPC fan-out. 4 KiB per Message and 128 bytes per Data value give comfortable
+// headroom for legitimate content (multi-line excerpts, command previews,
+// error stacks) while keeping a runaway event source from bloating the wire.
+//
+// Truncation is from the *front* so the most recent (and usually most
+// relevant) content survives — for excerpts that's the last visible line a
+// terminal would actually display.
+const (
+	maxEventMessageBytes  = 4 * 1024
+	maxEventDataValueBytes = 128
+	truncationMarker      = "…[truncated]"
+)
+
+// toPaneEventPayload converts a PaneEvent to an IPC payload, enforcing the
+// per-event wire-size caps. Caps are applied at the IPC boundary so all
+// emitters (idle checker, bell, process_exit, future hook events) share the
+// same protection.
 func toPaneEventPayload(e PaneEvent) ipc.PaneEventPayload {
+	message := e.Message
+	truncated := false
+
+	if len(message) > maxEventMessageBytes {
+		// Keep the tail — for excerpts, the bottom-most lines are the
+		// terminal-visible ones; for error blobs the trailing lines often
+		// carry the actual cause.
+		message = truncationMarker + message[len(message)-(maxEventMessageBytes-len(truncationMarker)):]
+		truncated = true
+	}
+
+	var data map[string]string
+	if len(e.Data) > 0 {
+		data = make(map[string]string, len(e.Data))
+		for k, v := range e.Data {
+			if len(v) > maxEventDataValueBytes {
+				data[k] = v[:maxEventDataValueBytes-len(truncationMarker)] + truncationMarker
+				truncated = true
+			} else {
+				data[k] = v
+			}
+		}
+	}
+	if truncated {
+		if data == nil {
+			data = make(map[string]string, 1)
+		}
+		data["truncated"] = "1"
+	}
+
 	return ipc.PaneEventPayload{
 		ID:        e.ID,
 		PaneID:    e.PaneID,
@@ -155,9 +203,9 @@ func toPaneEventPayload(e PaneEvent) ipc.PaneEventPayload {
 		PaneName:  e.PaneName,
 		Type:      e.Type,
 		Title:     e.Title,
-		Message:   e.Message,
+		Message:   message,
 		Severity:  e.Severity,
 		Timestamp: e.Timestamp.UnixMilli(),
-		Data:      e.Data,
+		Data:      data,
 	}
 }

--- a/internal/daemon/event_sizecap_test.go
+++ b/internal/daemon/event_sizecap_test.go
@@ -10,8 +10,9 @@ import (
 // prevention contract: any single event Message larger than the cap is
 // truncated from the front, the trailing visible content is preserved, the
 // payload size lands under the cap, and the Data map carries a "truncated"
-// flag for consumers that want to know.
+// flag (under the reserved _quil_ namespace) for consumers that want to know.
 func TestToPaneEventPayload_MessageOverCapTruncatesAndMarks(t *testing.T) {
+	t.Parallel()
 	// 8 KiB Message — double the cap.
 	original := strings.Repeat("x", 4*1024) + "TAIL_VISIBLE"
 	ev := PaneEvent{
@@ -33,8 +34,8 @@ func TestToPaneEventPayload_MessageOverCapTruncatesAndMarks(t *testing.T) {
 	if !strings.HasSuffix(got.Message, "TAIL_VISIBLE") {
 		t.Errorf("Message should preserve the tail (most recent content) after truncation; got suffix %q", got.Message[len(got.Message)-20:])
 	}
-	if got.Data["truncated"] != "1" {
-		t.Errorf("Data[\"truncated\"] = %q, want \"1\"", got.Data["truncated"])
+	if got.Data[truncatedFlagKey] != "1" {
+		t.Errorf("Data[%q] = %q, want \"1\"", truncatedFlagKey, got.Data[truncatedFlagKey])
 	}
 }
 
@@ -42,6 +43,7 @@ func TestToPaneEventPayload_MessageOverCapTruncatesAndMarks(t *testing.T) {
 // catches misbehaving sources that stuff long strings into Data (e.g. a hook
 // dumping a full prompt or a stack trace).
 func TestToPaneEventPayload_DataValueOverCapTruncates(t *testing.T) {
+	t.Parallel()
 	bigValue := strings.Repeat("y", 1024)
 	ev := PaneEvent{
 		ID:    "evt-1",
@@ -60,14 +62,15 @@ func TestToPaneEventPayload_DataValueOverCapTruncates(t *testing.T) {
 	if got.Data["short"] != "ok" {
 		t.Errorf("small Data values must pass through untouched; got %q", got.Data["short"])
 	}
-	if got.Data["truncated"] != "1" {
-		t.Errorf("Data[truncated] = %q, want \"1\"", got.Data["truncated"])
+	if got.Data[truncatedFlagKey] != "1" {
+		t.Errorf("Data[%q] = %q, want \"1\"", truncatedFlagKey, got.Data[truncatedFlagKey])
 	}
 }
 
 // TestToPaneEventPayload_WithinCapPassesThrough is the happy path — normal
 // events must not be modified.
 func TestToPaneEventPayload_WithinCapPassesThrough(t *testing.T) {
+	t.Parallel()
 	ev := PaneEvent{
 		ID:       "evt-1",
 		PaneID:   "pane-1",
@@ -85,7 +88,7 @@ func TestToPaneEventPayload_WithinCapPassesThrough(t *testing.T) {
 	if got.Data["exit_code"] != "0" {
 		t.Errorf("Data[exit_code] mutated; got %q", got.Data["exit_code"])
 	}
-	if _, ok := got.Data["truncated"]; ok {
+	if _, ok := got.Data[truncatedFlagKey]; ok {
 		t.Errorf("under-cap event must not carry truncated marker; got Data=%v", got.Data)
 	}
 }
@@ -93,9 +96,102 @@ func TestToPaneEventPayload_WithinCapPassesThrough(t *testing.T) {
 // TestToPaneEventPayload_NilDataNoTruncationMarker — when nothing is over the
 // cap, we never allocate a Data map just to set the marker.
 func TestToPaneEventPayload_NilDataNoTruncationMarker(t *testing.T) {
+	t.Parallel()
 	ev := PaneEvent{ID: "evt-1", Title: "ok", Message: "short"}
 	got := toPaneEventPayload(ev)
 	if got.Data != nil {
 		t.Errorf("expected nil Data when no truncation needed; got %v", got.Data)
+	}
+}
+
+// TestToPaneEventPayload_ExactCapBoundary guards against off-by-one in the
+// `> cap` condition. Messages and Data values at *exactly* the cap must pass
+// through untouched; one byte over must trigger truncation. A future refactor
+// to `>=` (a tempting cleanup) would silently break this.
+func TestToPaneEventPayload_ExactCapBoundary(t *testing.T) {
+	t.Parallel()
+
+	exactMessage := strings.Repeat("m", maxEventMessageBytes)
+	exactValue := strings.Repeat("v", maxEventDataValueBytes)
+	ev := PaneEvent{
+		ID:      "evt-1",
+		Title:   "exact",
+		Message: exactMessage,
+		Data:    map[string]string{"v": exactValue},
+	}
+	got := toPaneEventPayload(ev)
+
+	if got.Message != exactMessage {
+		t.Errorf("exact-cap Message must pass through; got len=%d, want %d", len(got.Message), len(exactMessage))
+	}
+	if got.Data["v"] != exactValue {
+		t.Errorf("exact-cap Data value must pass through; got len=%d, want %d", len(got.Data["v"]), len(exactValue))
+	}
+	if _, ok := got.Data[truncatedFlagKey]; ok {
+		t.Errorf("exact-cap event must not carry truncated marker; got Data=%v", got.Data)
+	}
+
+	// One byte over → truncates.
+	overMessage := exactMessage + "X"
+	overValue := exactValue + "X"
+	ev2 := PaneEvent{
+		ID:      "evt-2",
+		Title:   "over",
+		Message: overMessage,
+		Data:    map[string]string{"v": overValue},
+	}
+	got2 := toPaneEventPayload(ev2)
+	if !strings.HasPrefix(got2.Message, truncationMarker) {
+		t.Errorf("len(cap)+1 Message must trigger truncation; got first 32 chars %q", got2.Message[:32])
+	}
+	if !strings.HasSuffix(got2.Data["v"], truncationMarker) {
+		t.Errorf("len(cap)+1 Data value must trigger truncation; got %q", got2.Data["v"])
+	}
+}
+
+// TestToPaneEventPayload_BothOverCapSetsFlagOnce — when Message AND a Data
+// value are both over cap, the truncated flag is set exactly once (the map
+// write is idempotent) and both fields are truncated.
+func TestToPaneEventPayload_BothOverCapSetsFlagOnce(t *testing.T) {
+	t.Parallel()
+	ev := PaneEvent{
+		ID:      "evt-1",
+		Title:   "both",
+		Message: strings.Repeat("m", maxEventMessageBytes+10),
+		Data:    map[string]string{"args": strings.Repeat("v", maxEventDataValueBytes+10)},
+	}
+	got := toPaneEventPayload(ev)
+
+	if !strings.HasPrefix(got.Message, truncationMarker) {
+		t.Errorf("Message must be truncated; got first 32 chars %q", got.Message[:32])
+	}
+	if !strings.HasSuffix(got.Data["args"], truncationMarker) {
+		t.Errorf("Data[args] must be truncated; got %q", got.Data["args"])
+	}
+	if got.Data[truncatedFlagKey] != "1" {
+		t.Errorf("flag must be set; got Data[%q] = %q", truncatedFlagKey, got.Data[truncatedFlagKey])
+	}
+}
+
+// TestToPaneEventPayload_ReservedKeyDoesNotClobberCaller — emitters can use
+// their own keys without fear of collision; the reserved _quil_ prefix
+// guarantees daemon-internal flags never overwrite caller data.
+func TestToPaneEventPayload_ReservedKeyDoesNotClobberCaller(t *testing.T) {
+	t.Parallel()
+	ev := PaneEvent{
+		ID:    "evt-1",
+		Title: "with truncated user key",
+		Data: map[string]string{
+			"truncated": "user-supplied-not-clobbered",
+			"args":      strings.Repeat("v", maxEventDataValueBytes+10), // triggers cap
+		},
+	}
+	got := toPaneEventPayload(ev)
+
+	if got.Data["truncated"] != "user-supplied-not-clobbered" {
+		t.Errorf("caller's \"truncated\" key must survive; got %q", got.Data["truncated"])
+	}
+	if got.Data[truncatedFlagKey] != "1" {
+		t.Errorf("daemon flag must be set under reserved key; got %q", got.Data[truncatedFlagKey])
 	}
 }

--- a/internal/daemon/event_sizecap_test.go
+++ b/internal/daemon/event_sizecap_test.go
@@ -1,0 +1,101 @@
+package daemon
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestToPaneEventPayload_MessageOverCapTruncatesAndMarks proves the wedge-
+// prevention contract: any single event Message larger than the cap is
+// truncated from the front, the trailing visible content is preserved, the
+// payload size lands under the cap, and the Data map carries a "truncated"
+// flag for consumers that want to know.
+func TestToPaneEventPayload_MessageOverCapTruncatesAndMarks(t *testing.T) {
+	// 8 KiB Message — double the cap.
+	original := strings.Repeat("x", 4*1024) + "TAIL_VISIBLE"
+	ev := PaneEvent{
+		ID:        "evt-1",
+		Title:     "Output idle",
+		Message:   original,
+		Severity:  "info",
+		Timestamp: time.Unix(0, 0),
+	}
+
+	got := toPaneEventPayload(ev)
+
+	if len(got.Message) > maxEventMessageBytes {
+		t.Errorf("Message len after cap: got %d, want ≤ %d", len(got.Message), maxEventMessageBytes)
+	}
+	if !strings.HasPrefix(got.Message, truncationMarker) {
+		t.Errorf("Message should be prefixed with truncation marker; got first 32 chars %q", got.Message[:32])
+	}
+	if !strings.HasSuffix(got.Message, "TAIL_VISIBLE") {
+		t.Errorf("Message should preserve the tail (most recent content) after truncation; got suffix %q", got.Message[len(got.Message)-20:])
+	}
+	if got.Data["truncated"] != "1" {
+		t.Errorf("Data[\"truncated\"] = %q, want \"1\"", got.Data["truncated"])
+	}
+}
+
+// TestToPaneEventPayload_DataValueOverCapTruncates verifies the per-value cap
+// catches misbehaving sources that stuff long strings into Data (e.g. a hook
+// dumping a full prompt or a stack trace).
+func TestToPaneEventPayload_DataValueOverCapTruncates(t *testing.T) {
+	bigValue := strings.Repeat("y", 1024)
+	ev := PaneEvent{
+		ID:    "evt-1",
+		Title: "tool_run",
+		Data:  map[string]string{"args": bigValue, "short": "ok"},
+	}
+
+	got := toPaneEventPayload(ev)
+
+	if len(got.Data["args"]) > maxEventDataValueBytes {
+		t.Errorf("Data[args] len: got %d, want ≤ %d", len(got.Data["args"]), maxEventDataValueBytes)
+	}
+	if !strings.HasSuffix(got.Data["args"], truncationMarker) {
+		t.Errorf("oversize Data value should be suffixed with truncation marker; got %q", got.Data["args"])
+	}
+	if got.Data["short"] != "ok" {
+		t.Errorf("small Data values must pass through untouched; got %q", got.Data["short"])
+	}
+	if got.Data["truncated"] != "1" {
+		t.Errorf("Data[truncated] = %q, want \"1\"", got.Data["truncated"])
+	}
+}
+
+// TestToPaneEventPayload_WithinCapPassesThrough is the happy path — normal
+// events must not be modified.
+func TestToPaneEventPayload_WithinCapPassesThrough(t *testing.T) {
+	ev := PaneEvent{
+		ID:       "evt-1",
+		PaneID:   "pane-1",
+		Title:    "Process exited (code 0)",
+		Message:  "build succeeded\n",
+		Severity: "info",
+		Data:     map[string]string{"exit_code": "0"},
+	}
+
+	got := toPaneEventPayload(ev)
+
+	if got.Message != "build succeeded\n" {
+		t.Errorf("Message mutated under cap; got %q", got.Message)
+	}
+	if got.Data["exit_code"] != "0" {
+		t.Errorf("Data[exit_code] mutated; got %q", got.Data["exit_code"])
+	}
+	if _, ok := got.Data["truncated"]; ok {
+		t.Errorf("under-cap event must not carry truncated marker; got Data=%v", got.Data)
+	}
+}
+
+// TestToPaneEventPayload_NilDataNoTruncationMarker — when nothing is over the
+// cap, we never allocate a Data map just to set the marker.
+func TestToPaneEventPayload_NilDataNoTruncationMarker(t *testing.T) {
+	ev := PaneEvent{ID: "evt-1", Title: "ok", Message: "short"}
+	got := toPaneEventPayload(ev)
+	if got.Data != nil {
+		t.Errorf("expected nil Data when no truncation needed; got %v", got.Data)
+	}
+}

--- a/internal/ipc/broadcast_resilience_test.go
+++ b/internal/ipc/broadcast_resilience_test.go
@@ -9,11 +9,30 @@ import (
 	"github.com/artyomsv/quil/internal/ipc"
 )
 
+// waitForConnCount polls the server until it reaches the expected client count
+// or the deadline elapses. Replaces fragile time.Sleep-after-connect patterns
+// that race the daemon's accept goroutine and can silently lose connections
+// under CI load.
+func waitForConnCount(t *testing.T, srv *ipc.Server, want int, dl time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(dl)
+	for {
+		if srv.ConnCount() == want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("waitForConnCount: got %d, want %d within %v", srv.ConnCount(), want, dl)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
 // TestBroadcast_SlowConnDoesNotBlockFastConn proves the wedge defense: when
 // one client stops reading from its socket, the daemon's broadcast loop must
 // continue serving the healthy clients without delay. The Bubble Tea event
 // loop on a connected TUI cannot be allowed to stall the entire daemon.
 func TestBroadcast_SlowConnDoesNotBlockFastConn(t *testing.T) {
+	t.Parallel()
 	sockPath := filepath.Join(t.TempDir(), "slow-vs-fast.sock")
 
 	srv := ipc.NewServer(sockPath, func(*ipc.Conn, *ipc.Message) {}, nil)
@@ -34,8 +53,7 @@ func TestBroadcast_SlowConnDoesNotBlockFastConn(t *testing.T) {
 	}
 	defer slow.Close()
 
-	// Wait for the server to register both connections.
-	time.Sleep(100 * time.Millisecond)
+	waitForConnCount(t, srv, 2, 2*time.Second)
 
 	// Slow client deliberately never reads — its kernel socket buffer fills up,
 	// then the daemon's 64-slot per-conn queue overflows, then the daemon
@@ -44,8 +62,6 @@ func TestBroadcast_SlowConnDoesNotBlockFastConn(t *testing.T) {
 	const broadcasts = 200
 	const fastReceives = 50
 
-	// Drain fast client in the background to a counter, so we can assert it
-	// got messages quickly without blocking.
 	gotFast := make(chan int, broadcasts)
 	go func() {
 		count := 0
@@ -97,10 +113,10 @@ func TestBroadcast_SlowConnDoesNotBlockFastConn(t *testing.T) {
 
 // TestBroadcast_ContinuesAfterSlowConnDisconnects covers the post-overflow
 // state: after the slow conn is torn down, broadcasts to remaining conns
-// continue normally. Uses small payloads + a 1 ms pacing gap so the fast
-// client's drain goroutine reliably keeps up even under race-detector
-// slowdown.
+// continue normally. Uses ConnCount-based synchronization (no time.Sleep) so
+// CI load doesn't race the connect-registration window.
 func TestBroadcast_ContinuesAfterSlowConnDisconnects(t *testing.T) {
+	t.Parallel()
 	sockPath := filepath.Join(t.TempDir(), "post-overflow.sock")
 
 	srv := ipc.NewServer(sockPath, func(*ipc.Conn, *ipc.Message) {}, nil)
@@ -120,7 +136,7 @@ func TestBroadcast_ContinuesAfterSlowConnDisconnects(t *testing.T) {
 		t.Fatalf("slow client: %v", err)
 	}
 
-	time.Sleep(100 * time.Millisecond)
+	waitForConnCount(t, srv, 2, 2*time.Second)
 
 	var fastCount int
 	var fastMu sync.Mutex
@@ -135,19 +151,25 @@ func TestBroadcast_ContinuesAfterSlowConnDisconnects(t *testing.T) {
 		}
 	}()
 
-	// Paced burst: enough to overflow the non-reading slow conn but slow
-	// enough that the fast drain goroutine never falls behind.
-	smallPayload := map[string]string{"kind": "tick"}
+	// Paced burst with 4 KiB payloads so the slow client's kernel socket
+	// buffer (~200 KiB on Linux/Darwin) actually fills — small payloads
+	// would just sit in the buffer and never trigger overflow. ~150 frames
+	// × 4 KiB = ~600 KiB, well past the kernel buffer + the 64-slot send
+	// queue, so overflow trips deterministically. 1 ms pacing keeps the
+	// fast drain goroutine ahead.
+	bigPayload := map[string]string{"data": string(make([]byte, 4000))}
 	for i := 0; i < 150; i++ {
-		msg, _ := ipc.NewMessage(ipc.MsgStateUpdate, smallPayload)
+		msg, _ := ipc.NewMessage(ipc.MsgStateUpdate, bigPayload)
 		srv.Broadcast(msg)
 		time.Sleep(time.Millisecond)
 	}
 
-	// Let the overflow tear down the slow conn.
-	time.Sleep(200 * time.Millisecond)
+	// Wait for the slow conn to be torn down via the overflow path. Polling
+	// on ConnCount converges as soon as the daemon's removeConn fires —
+	// independent of CI load.
+	waitForConnCount(t, srv, 1, 3*time.Second)
+
 	slow.Close()
-	time.Sleep(100 * time.Millisecond)
 
 	fastMu.Lock()
 	pre := fastCount
@@ -157,18 +179,79 @@ func TestBroadcast_ContinuesAfterSlowConnDisconnects(t *testing.T) {
 	// see them — the absence of slow in the broadcast fan-out is the
 	// post-overflow invariant we care about.
 	for i := 0; i < 50; i++ {
-		msg, _ := ipc.NewMessage(ipc.MsgStateUpdate, smallPayload)
+		msg, _ := ipc.NewMessage(ipc.MsgStateUpdate, bigPayload)
 		srv.Broadcast(msg)
 		time.Sleep(time.Millisecond)
 	}
 
-	time.Sleep(300 * time.Millisecond)
+	// Wait for fast to drain the new wave. With a 1 ms inter-broadcast gap
+	// and a receive loop that takes microseconds, a 500 ms ceiling is
+	// generous even under race instrumentation.
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for {
+		fastMu.Lock()
+		post := fastCount
+		fastMu.Unlock()
+		if post-pre >= 30 {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Errorf("after slow conn disconnect, fast client only got %d new messages (want ≥ 30)", post-pre)
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
 
-	fastMu.Lock()
-	post := fastCount
-	fastMu.Unlock()
+// TestBroadcast_MarshalErrorLogsAndReturns covers the otherwise-untested
+// failure path where the message payload can't be JSON-encoded. Broadcast
+// must NOT panic and must NOT propagate the bad frame to any conn.
+func TestBroadcast_MarshalErrorLogsAndReturns(t *testing.T) {
+	t.Parallel()
+	sockPath := filepath.Join(t.TempDir(), "bad-marshal.sock")
 
-	if post-pre < 30 {
-		t.Errorf("after slow conn disconnect, fast client only got %d new messages (want ≥ 30)", post-pre)
+	srv := ipc.NewServer(sockPath, func(*ipc.Conn, *ipc.Message) {}, nil)
+	if err := srv.Start(); err != nil {
+		t.Fatalf("server start: %v", err)
+	}
+	defer srv.Stop()
+
+	client, err := ipc.NewClient(sockPath)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	defer client.Close()
+
+	waitForConnCount(t, srv, 1, 2*time.Second)
+
+	// Construct a Message whose Payload is already marshal-valid (json.RawMessage
+	// of itself is fine) but whose outer Message.Type ends up triggering an
+	// error path through any future Marshal customization. The realistic
+	// trigger today: an unencodable payload. We bypass NewMessage and inject
+	// invalid JSON into the Payload field directly, so json.Marshal of the
+	// Message tries to re-marshal the bad RawMessage and fails.
+	bad := &ipc.Message{
+		Type:    "bad",
+		Payload: []byte("{not valid json"), // truncated JSON object
+	}
+
+	// json.Marshal on the Message would fail on the RawMessage's MarshalJSON
+	// validator. Broadcast should swallow the error and return.
+	srv.Broadcast(bad)
+
+	// Verify the server is still functional — broadcast a good message and
+	// the client receives it.
+	good, _ := ipc.NewMessage(ipc.MsgStateUpdate, map[string]string{"ok": "yes"})
+	srv.Broadcast(good)
+
+	if err := client.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
+	got, err := client.Receive()
+	if err != nil {
+		t.Fatalf("client receive after bad broadcast: %v", err)
+	}
+	if got.Type != ipc.MsgStateUpdate {
+		t.Errorf("expected MsgStateUpdate, got %q", got.Type)
 	}
 }

--- a/internal/ipc/broadcast_resilience_test.go
+++ b/internal/ipc/broadcast_resilience_test.go
@@ -1,0 +1,174 @@
+package ipc_test
+
+import (
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/artyomsv/quil/internal/ipc"
+)
+
+// TestBroadcast_SlowConnDoesNotBlockFastConn proves the wedge defense: when
+// one client stops reading from its socket, the daemon's broadcast loop must
+// continue serving the healthy clients without delay. The Bubble Tea event
+// loop on a connected TUI cannot be allowed to stall the entire daemon.
+func TestBroadcast_SlowConnDoesNotBlockFastConn(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "slow-vs-fast.sock")
+
+	srv := ipc.NewServer(sockPath, func(*ipc.Conn, *ipc.Message) {}, nil)
+	if err := srv.Start(); err != nil {
+		t.Fatalf("server start: %v", err)
+	}
+	defer srv.Stop()
+
+	fast, err := ipc.NewClient(sockPath)
+	if err != nil {
+		t.Fatalf("fast client connect: %v", err)
+	}
+	defer fast.Close()
+
+	slow, err := ipc.NewClient(sockPath)
+	if err != nil {
+		t.Fatalf("slow client connect: %v", err)
+	}
+	defer slow.Close()
+
+	// Wait for the server to register both connections.
+	time.Sleep(100 * time.Millisecond)
+
+	// Slow client deliberately never reads — its kernel socket buffer fills up,
+	// then the daemon's 64-slot per-conn queue overflows, then the daemon
+	// closes the slow conn. Meanwhile the fast client must keep receiving.
+
+	const broadcasts = 200
+	const fastReceives = 50
+
+	// Drain fast client in the background to a counter, so we can assert it
+	// got messages quickly without blocking.
+	gotFast := make(chan int, broadcasts)
+	go func() {
+		count := 0
+		for {
+			if _, err := fast.Receive(); err != nil {
+				close(gotFast)
+				return
+			}
+			count++
+			gotFast <- count
+		}
+	}()
+
+	// Build a 4 KiB-ish payload so each broadcast meaningfully exercises the
+	// per-conn send queue. Pure echo of an arbitrary string.
+	payload := map[string]string{"data": string(make([]byte, 4000))}
+
+	broadcastStart := time.Now()
+	for i := 0; i < broadcasts; i++ {
+		msg, _ := ipc.NewMessage(ipc.MsgStateUpdate, payload)
+		srv.Broadcast(msg)
+	}
+	broadcastDur := time.Since(broadcastStart)
+
+	// All Broadcast calls must return promptly even though one peer is
+	// stalled. 1s gives plenty of headroom for CI jitter; the actual cost
+	// is microseconds.
+	if broadcastDur > time.Second {
+		t.Errorf("Broadcast loop blocked: %d broadcasts took %v (want < 1s) — slow client wedged the fan-out", broadcasts, broadcastDur)
+	}
+
+	// Fast client must drain enough messages to demonstrate it's still being
+	// served. Healthy peers never stall.
+	timeout := time.After(3 * time.Second)
+	for {
+		select {
+		case n, ok := <-gotFast:
+			if !ok {
+				t.Fatal("fast client got an error before reaching the expected message count")
+			}
+			if n >= fastReceives {
+				return // success
+			}
+		case <-timeout:
+			t.Fatalf("fast client only drained partway within 3s — broadcast fan-out may be wedged")
+		}
+	}
+}
+
+// TestBroadcast_ContinuesAfterSlowConnDisconnects covers the post-overflow
+// state: after the slow conn is torn down, broadcasts to remaining conns
+// continue normally. Uses small payloads + a 1 ms pacing gap so the fast
+// client's drain goroutine reliably keeps up even under race-detector
+// slowdown.
+func TestBroadcast_ContinuesAfterSlowConnDisconnects(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "post-overflow.sock")
+
+	srv := ipc.NewServer(sockPath, func(*ipc.Conn, *ipc.Message) {}, nil)
+	if err := srv.Start(); err != nil {
+		t.Fatalf("server start: %v", err)
+	}
+	defer srv.Stop()
+
+	fast, err := ipc.NewClient(sockPath)
+	if err != nil {
+		t.Fatalf("fast client: %v", err)
+	}
+	defer fast.Close()
+
+	slow, err := ipc.NewClient(sockPath)
+	if err != nil {
+		t.Fatalf("slow client: %v", err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	var fastCount int
+	var fastMu sync.Mutex
+	go func() {
+		for {
+			if _, err := fast.Receive(); err != nil {
+				return
+			}
+			fastMu.Lock()
+			fastCount++
+			fastMu.Unlock()
+		}
+	}()
+
+	// Paced burst: enough to overflow the non-reading slow conn but slow
+	// enough that the fast drain goroutine never falls behind.
+	smallPayload := map[string]string{"kind": "tick"}
+	for i := 0; i < 150; i++ {
+		msg, _ := ipc.NewMessage(ipc.MsgStateUpdate, smallPayload)
+		srv.Broadcast(msg)
+		time.Sleep(time.Millisecond)
+	}
+
+	// Let the overflow tear down the slow conn.
+	time.Sleep(200 * time.Millisecond)
+	slow.Close()
+	time.Sleep(100 * time.Millisecond)
+
+	fastMu.Lock()
+	pre := fastCount
+	fastMu.Unlock()
+
+	// Issue NEW broadcasts after the slow conn is torn down. Fast must still
+	// see them — the absence of slow in the broadcast fan-out is the
+	// post-overflow invariant we care about.
+	for i := 0; i < 50; i++ {
+		msg, _ := ipc.NewMessage(ipc.MsgStateUpdate, smallPayload)
+		srv.Broadcast(msg)
+		time.Sleep(time.Millisecond)
+	}
+
+	time.Sleep(300 * time.Millisecond)
+
+	fastMu.Lock()
+	post := fastCount
+	fastMu.Unlock()
+
+	if post-pre < 30 {
+		t.Errorf("after slow conn disconnect, fast client only got %d new messages (want ≥ 30)", post-pre)
+	}
+}

--- a/internal/ipc/conn_internal_test.go
+++ b/internal/ipc/conn_internal_test.go
@@ -1,0 +1,123 @@
+package ipc
+
+import (
+	"net"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// TestSendLoop_ExitsOnWriteError verifies that when the underlying socket
+// Write fails (peer disconnected mid-send, kernel detected RST, etc.),
+// sendLoop terminates cleanly without leaking the goroutine. The CR finding
+// flagged this as the only fully-untested cleanup path in the broadcast
+// hardening.
+//
+// Uses net.Pipe so we can deterministically force a write error by closing
+// the remote end mid-send. Goroutine leak is detected via a runtime-level
+// goroutine count delta around the conn lifecycle.
+func TestSendLoop_ExitsOnWriteError(t *testing.T) {
+	t.Parallel()
+
+	// Settle the runtime so the baseline goroutine count is stable.
+	runtime.GC()
+	time.Sleep(50 * time.Millisecond)
+	baseline := runtime.NumGoroutine()
+
+	local, remote := net.Pipe()
+	c := newConn(local)
+
+	// Close the remote half BEFORE Send. Any subsequent Write on `local`
+	// returns io.ErrClosedPipe, exercising the sendLoop write-error exit.
+	remote.Close()
+
+	frame := []byte{0, 0, 0, 1, byte('x')}
+	if err := c.sendFrame(frame); err != nil {
+		t.Fatalf("sendFrame should queue even before the write fails; got %v", err)
+	}
+
+	// Give sendLoop a moment to consume the frame, attempt the write, and
+	// exit on the resulting error.
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		// sendLoop exits when raw.Write errors. After that, our explicit
+		// Close completes cleanly via sync.Once. Check the closed flag —
+		// it's set by Close, so we need to call Close to confirm cleanup.
+		if c.overflow.Load() {
+			break // not the path under test; bail
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Explicitly close to release the local pipe half. After Close + a brief
+	// settle, the goroutine count should match baseline (the sendLoop has
+	// already exited on the write error, and nothing else lingers).
+	_ = c.Close()
+
+	runtime.GC()
+	time.Sleep(100 * time.Millisecond)
+
+	if got := runtime.NumGoroutine(); got > baseline+1 {
+		// +1 tolerates the test runner's own bookkeeping goroutine churn.
+		t.Errorf("goroutine leak after sendLoop write-error exit: baseline=%d, after=%d", baseline, got)
+	}
+}
+
+// TestConn_CloseIdempotent confirms sync.Once-guarded Close — multiple
+// concurrent close calls from any goroutine (handleConn's defer + overflow's
+// async close + Server.Stop's iteration) all funnel through one underlying
+// raw.Close.
+func TestConn_CloseIdempotent(t *testing.T) {
+	t.Parallel()
+
+	local, remote := net.Pipe()
+	defer remote.Close()
+
+	c := newConn(local)
+
+	// Hammer Close from multiple goroutines simultaneously. None should
+	// panic; the underlying close should run exactly once. We do not assert
+	// the err returned because only the *first* Close gets the real error;
+	// the others get nil from the sync.Once.Do default.
+	const N = 16
+	done := make(chan struct{}, N)
+	for i := 0; i < N; i++ {
+		go func() {
+			_ = c.Close()
+			done <- struct{}{}
+		}()
+	}
+	for i := 0; i < N; i++ {
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("concurrent Close stalled — sync.Once not protecting close path")
+		}
+	}
+
+	if !c.closed.Load() {
+		t.Errorf("Close should have set closed flag")
+	}
+}
+
+// TestConn_SendFrameAfterCloseShortCircuits confirms the closed-flag short-
+// circuit prevents work after Close. Belt-and-suspenders alongside the
+// channel-send (which would also fail because sendLoop exited).
+func TestConn_SendFrameAfterCloseShortCircuits(t *testing.T) {
+	t.Parallel()
+
+	local, remote := net.Pipe()
+	defer remote.Close()
+
+	c := newConn(local)
+	_ = c.Close()
+
+	if err := c.sendFrame([]byte("x")); err != ErrSendOverflow {
+		t.Errorf("sendFrame after Close: got %v, want ErrSendOverflow", err)
+	}
+
+	msg, _ := NewMessage(MsgStateUpdate, map[string]string{"x": "y"})
+	if err := c.Send(msg); err != ErrSendOverflow {
+		t.Errorf("Send after Close: got %v, want ErrSendOverflow", err)
+	}
+}

--- a/internal/ipc/server.go
+++ b/internal/ipc/server.go
@@ -1,29 +1,108 @@
 package ipc
 
 import (
+	"bytes"
+	"errors"
 	"log"
 	"net"
 	"os"
 	"sync"
+	"sync/atomic"
 )
+
+// sendBufSize is the per-connection queue depth. A wedged or slow client can
+// build up at most this many in-flight frames before the server marks the
+// connection as overflowed and tears it down — guaranteeing that one bad
+// client cannot block the daemon's broadcast loop and starve healthy peers.
+//
+// 64 frames is comfortably more than any healthy client lags by (a TUI's
+// Bubble Tea event loop typically drains everything in <50 ms) and small
+// enough that an overflowed conn is detected within a few milliseconds.
+const sendBufSize = 64
+
+// ErrSendOverflow is returned by Conn.Send when the per-conn send buffer is
+// full. The connection has been scheduled for close; future Sends short-
+// circuit with the same error.
+var ErrSendOverflow = errors.New("ipc: send buffer overflow (slow client)")
 
 // MessageHandler is called for each incoming message on a connection.
 type MessageHandler func(conn *Conn, msg *Message)
 
 // Conn wraps a net.Conn with message framing.
+//
+// Sends are non-blocking: each Conn owns a 64-slot queue and a dedicated
+// goroutine that drains the queue into the underlying socket. A slow or
+// wedged peer drains its own queue; if the queue overflows, the offending
+// conn is closed in the background and Send returns ErrSendOverflow. Other
+// connections are never affected by one client's slowness — closing the
+// wedge-incident class where a single stuck TUI or MCP bridge stalled the
+// daemon's broadcast for every other client.
 type Conn struct {
-	raw net.Conn
-	mu  sync.Mutex
+	raw       net.Conn
+	sendCh    chan []byte
+	done      chan struct{}
+	closeOnce sync.Once
+	closed    atomic.Bool
+	overflow  atomic.Bool
 }
 
 func newConn(raw net.Conn) *Conn {
-	return &Conn{raw: raw}
+	c := &Conn{
+		raw:    raw,
+		sendCh: make(chan []byte, sendBufSize),
+		done:   make(chan struct{}),
+	}
+	go c.sendLoop()
+	return c
 }
 
+// Send marshals msg into the wire frame and queues it for transmission. Returns
+// ErrSendOverflow when the per-conn buffer is full — the conn has been
+// scheduled for async close at that point.
 func (c *Conn) Send(msg *Message) error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return WriteMessage(c.raw, msg)
+	if c.closed.Load() || c.overflow.Load() {
+		return ErrSendOverflow
+	}
+	var buf bytes.Buffer
+	if err := WriteMessage(&buf, msg); err != nil {
+		return err
+	}
+	return c.sendFrame(buf.Bytes())
+}
+
+// sendFrame queues a pre-encoded wire frame. Used by Broadcast to share one
+// marshal allocation across N conns. The frame []byte is read-only — both
+// sendFrame and sendLoop only read it, never mutate it.
+func (c *Conn) sendFrame(frame []byte) error {
+	if c.closed.Load() || c.overflow.Load() {
+		return ErrSendOverflow
+	}
+	select {
+	case c.sendCh <- frame:
+		return nil
+	default:
+		// Buffer full — slow client. Tear it down asynchronously so the
+		// broadcaster never blocks on the close, and short-circuit all
+		// future Sends.
+		c.overflow.Store(true)
+		go c.Close()
+		return ErrSendOverflow
+	}
+}
+
+func (c *Conn) sendLoop() {
+	for {
+		select {
+		case <-c.done:
+			return
+		case frame := <-c.sendCh:
+			if _, err := c.raw.Write(frame); err != nil {
+				// Peer gone or socket error — exit. The read side will see
+				// the matching error and clean up via handleConn's defer.
+				return
+			}
+		}
+	}
 }
 
 func (c *Conn) Receive() (*Message, error) {
@@ -31,7 +110,13 @@ func (c *Conn) Receive() (*Message, error) {
 }
 
 func (c *Conn) Close() error {
-	return c.raw.Close()
+	var err error
+	c.closeOnce.Do(func() {
+		c.closed.Store(true)
+		close(c.done)
+		err = c.raw.Close()
+	})
+	return err
 }
 
 // Server listens for client connections over a Unix socket.
@@ -78,13 +163,33 @@ func (s *Server) Stop() error {
 	return s.listener.Close()
 }
 
-// Broadcast sends a message to all connected clients.
+// Broadcast sends a message to all connected clients without blocking on any
+// individual conn. Marshals the wire frame once and shares the bytes across
+// all per-conn send queues. A slow or wedged conn is dropped from the fan-out
+// (logged once) without affecting the others.
 func (s *Server) Broadcast(msg *Message) {
+	var buf bytes.Buffer
+	if err := WriteMessage(&buf, msg); err != nil {
+		log.Printf("broadcast marshal: %v", err)
+		return
+	}
+	frame := buf.Bytes()
+
+	// Snapshot the conns list under the lock so the per-conn sendFrame calls
+	// below run lock-free — no risk of a slow send chain interleaving with
+	// accept/disconnect bookkeeping.
 	s.mu.Lock()
-	defer s.mu.Unlock()
-	for _, c := range s.conns {
-		if err := c.Send(msg); err != nil {
-			log.Printf("broadcast send: %v", err)
+	conns := make([]*Conn, len(s.conns))
+	copy(conns, s.conns)
+	s.mu.Unlock()
+
+	for _, c := range conns {
+		if err := c.sendFrame(frame); err != nil {
+			if errors.Is(err, ErrSendOverflow) {
+				log.Printf("ipc: dropping slow client (send buffer overflow)")
+			} else {
+				log.Printf("broadcast send: %v", err)
+			}
 		}
 	}
 }

--- a/internal/ipc/server.go
+++ b/internal/ipc/server.go
@@ -3,11 +3,14 @@ package ipc
 import (
 	"bytes"
 	"errors"
-	"log"
 	"net"
 	"os"
+	"slices"
 	"sync"
 	"sync/atomic"
+	"time"
+
+	"github.com/artyomsv/quil/internal/logger"
 )
 
 // sendBufSize is the per-connection queue depth. A wedged or slow client can
@@ -19,6 +22,14 @@ import (
 // Bubble Tea event loop typically drains everything in <50 ms) and small
 // enough that an overflowed conn is detected within a few milliseconds.
 const sendBufSize = 64
+
+// writeDeadline bounds how long a single raw.Write may block inside sendLoop
+// before we give up on the peer. Belt-and-suspenders alongside the sendCh
+// overflow detection: under a wedged kernel buffer + a peer that doesn't
+// error on TCP RST, the overflow path is still triggered (sendCh fills →
+// next sendFrame trips overflow), but the deadline guarantees a deterministic
+// cleanup ceiling instead of an indefinite block.
+const writeDeadline = 30 * time.Second
 
 // ErrSendOverflow is returned by Conn.Send when the per-conn send buffer is
 // full. The connection has been scheduled for close; future Sends short-
@@ -59,6 +70,10 @@ func newConn(raw net.Conn) *Conn {
 // Send marshals msg into the wire frame and queues it for transmission. Returns
 // ErrSendOverflow when the per-conn buffer is full — the conn has been
 // scheduled for async close at that point.
+//
+// The closed/overflow short-circuit here is the fast path: it skips the JSON
+// marshal entirely for a known-dead conn. The actual race-safe check happens
+// inside sendFrame next to the channel send — do not remove either one.
 func (c *Conn) Send(msg *Message) error {
 	if c.closed.Load() || c.overflow.Load() {
 		return ErrSendOverflow
@@ -67,12 +82,23 @@ func (c *Conn) Send(msg *Message) error {
 	if err := WriteMessage(&buf, msg); err != nil {
 		return err
 	}
+	// Per-Conn ownership: buf.Bytes() backs a stack-local Buffer whose
+	// lifetime ends when Send returns, but the channel reference keeps the
+	// backing array alive until sendLoop's Write completes. No defensive
+	// copy needed here — only Broadcast (which fans the same frame across
+	// N conns) clones to decouple the shared slice from its source.
 	return c.sendFrame(buf.Bytes())
 }
 
 // sendFrame queues a pre-encoded wire frame. Used by Broadcast to share one
 // marshal allocation across N conns. The frame []byte is read-only — both
 // sendFrame and sendLoop only read it, never mutate it.
+//
+// The closed/overflow check here is the race-safe gate that sits next to the
+// channel send — necessary because Send's outer check is only a fast-path
+// optimization (avoids JSON marshal). A future "cleanup" that drops either
+// check would either reintroduce the marshal cost for dead conns or open a
+// race where overflow flips between check and send.
 func (c *Conn) sendFrame(frame []byte) error {
 	if c.closed.Load() || c.overflow.Load() {
 		return ErrSendOverflow
@@ -81,11 +107,16 @@ func (c *Conn) sendFrame(frame []byte) error {
 	case c.sendCh <- frame:
 		return nil
 	default:
-		// Buffer full — slow client. Tear it down asynchronously so the
-		// broadcaster never blocks on the close, and short-circuit all
-		// future Sends.
-		c.overflow.Store(true)
-		go c.Close()
+		// Buffer full — slow client. CAS the overflow flag so only the
+		// first concurrent overflow spawns the Close goroutine and emits
+		// the log line; all subsequent failed sends short-circuit silently.
+		// Without the CAS, a wedged peer would log once per broadcast and
+		// spawn N redundant Close goroutines (each no-ops via closeOnce
+		// but still pays goroutine spawn cost).
+		if c.overflow.CompareAndSwap(false, true) {
+			logger.Warn("ipc: dropping slow client (send buffer overflow)")
+			go c.Close()
+		}
 		return ErrSendOverflow
 	}
 }
@@ -96,9 +127,13 @@ func (c *Conn) sendLoop() {
 		case <-c.done:
 			return
 		case frame := <-c.sendCh:
+			// Bound the per-frame Write to writeDeadline so a peer with a
+			// wedged kernel buffer or stalled connection cannot block this
+			// goroutine indefinitely. Deadline errors are reported the same
+			// way as any other Write failure — sendLoop exits, the read
+			// side detects the matching error and runs handleConn's defer.
+			_ = c.raw.SetWriteDeadline(time.Now().Add(writeDeadline))
 			if _, err := c.raw.Write(frame); err != nil {
-				// Peer gone or socket error — exit. The read side will see
-				// the matching error and clean up via handleConn's defer.
 				return
 			}
 		}
@@ -109,6 +144,11 @@ func (c *Conn) Receive() (*Message, error) {
 	return ReadMessage(c.raw)
 }
 
+// Close shuts down the conn. Idempotent — safe to call concurrently from any
+// goroutine. Any frames still queued in sendCh at close time are intentionally
+// discarded: by the time Close is called we are either tearing down an
+// overflowed (already broken) peer or shutting down the server entirely, and
+// in both cases delivery guarantees no longer apply.
 func (c *Conn) Close() error {
 	var err error
 	c.closeOnce.Do(func() {
@@ -153,6 +193,11 @@ func (s *Server) Start() error {
 	return nil
 }
 
+// Stop closes the listener and all active connections. Frames queued in any
+// conn's send buffer at the moment of Stop are discarded — Daemon.Stop's
+// shutdown sequence does not rely on a final IPC broadcast reaching clients
+// (the final-snapshot durability lives in the on-disk workspace.json path,
+// not in the wire).
 func (s *Server) Stop() error {
 	close(s.done)
 	s.mu.Lock()
@@ -163,33 +208,52 @@ func (s *Server) Stop() error {
 	return s.listener.Close()
 }
 
+// ConnCount returns the number of currently-connected clients. Test-friendly
+// alternative to the existing log-line scraping pattern; used to wait for
+// connect/disconnect events without time-based sleeps.
+func (s *Server) ConnCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.conns)
+}
+
 // Broadcast sends a message to all connected clients without blocking on any
 // individual conn. Marshals the wire frame once and shares the bytes across
 // all per-conn send queues. A slow or wedged conn is dropped from the fan-out
-// (logged once) without affecting the others.
+// (logged once, per CAS-guarded sendFrame) without affecting the others.
 func (s *Server) Broadcast(msg *Message) {
 	var buf bytes.Buffer
 	if err := WriteMessage(&buf, msg); err != nil {
-		log.Printf("broadcast marshal: %v", err)
+		logger.Error("ipc: broadcast marshal: %v", err)
 		return
 	}
-	frame := buf.Bytes()
+	// IMPORTANT: clone the bytes BEFORE fan-out. The slice returned by
+	// buf.Bytes() aliases a stack-local Buffer whose backing array would
+	// today survive via channel references — but if a future contributor
+	// pools the Buffer (sync.Pool, freelist), reuse would silently corrupt
+	// frames still being read by per-conn sendLoops. The clone decouples
+	// the shared frame from its source so the contract holds across any
+	// future Buffer reuse strategy.
+	// TODO(perf): if broadcast rate ever dominates daemon CPU, consider a
+	// sync.Pool of [][]byte AND remove this clone — but then every callsite
+	// that aliases the frame must be re-audited.
+	frame := slices.Clone(buf.Bytes())
 
-	// Snapshot the conns list under the lock so the per-conn sendFrame calls
-	// below run lock-free — no risk of a slow send chain interleaving with
-	// accept/disconnect bookkeeping.
+	// IMPORTANT: do not remove the slice copy below. The `conns` snapshot
+	// must be independent of s.conns so the lock-free fan-out cannot race
+	// with accept/removeConn mutations. Reusing s.conns directly here would
+	// reintroduce the slow-conn-blocks-everyone bug this whole rewrite fixed.
 	s.mu.Lock()
 	conns := make([]*Conn, len(s.conns))
 	copy(conns, s.conns)
 	s.mu.Unlock()
 
 	for _, c := range conns {
-		if err := c.sendFrame(frame); err != nil {
-			if errors.Is(err, ErrSendOverflow) {
-				log.Printf("ipc: dropping slow client (send buffer overflow)")
-			} else {
-				log.Printf("broadcast send: %v", err)
-			}
+		if err := c.sendFrame(frame); err != nil && !errors.Is(err, ErrSendOverflow) {
+			// ErrSendOverflow is already logged at the overflow site (CAS
+			// guarantees exactly one log per conn). Any other error is
+			// genuinely unexpected.
+			logger.Error("ipc: broadcast send: %v", err)
 		}
 	}
 }
@@ -202,7 +266,7 @@ func (s *Server) acceptLoop() {
 			case <-s.done:
 				return
 			default:
-				log.Printf("accept error: %v", err)
+				logger.Error("ipc: accept error: %v", err)
 				continue
 			}
 		}
@@ -213,7 +277,7 @@ func (s *Server) acceptLoop() {
 		count := len(s.conns)
 		s.mu.Unlock()
 
-		log.Printf("ipc: client connected (total=%d)", count)
+		logger.Info("ipc: client connected (total=%d)", count)
 		go s.handleConn(conn)
 	}
 }
@@ -225,7 +289,7 @@ func (s *Server) handleConn(conn *Conn) {
 		s.mu.Lock()
 		count := len(s.conns)
 		s.mu.Unlock()
-		log.Printf("ipc: client disconnected (remaining=%d)", count)
+		logger.Info("ipc: client disconnected (remaining=%d)", count)
 		if s.onDisconnect != nil {
 			s.onDisconnect(conn)
 		}


### PR DESCRIPTION
## Summary

Standalone wedge defense — the prerequisite Phase A from the hook-driven notifications plan. Closes the class of incident where one stuck IPC client (slow TUI render, crashed MCP bridge, socket buffer congestion) stalled the daemon's broadcast for every other client.

Two coordinated changes:

1. **Per-conn buffered send queue** (`internal/ipc/server.go`). Each `Conn` owns a 64-slot send channel and a dedicated send goroutine. `Send` is non-blocking — if the queue overflows the offending conn is scheduled for async close and `ErrSendOverflow` is returned; healthy peers keep receiving. `Broadcast` also marshals the wire frame **once** and shares the bytes across the per-conn queues instead of re-serializing per client.

2. **4 KiB per-event size cap** (`internal/daemon/event.go`). `toPaneEventPayload` caps `Message` at 4 KiB and each `Data` value at 128 bytes. Truncation preserves the tail (most recent / terminal-visible content) and sets `Data["truncated"]="1"`. The earlier opencode-splash incident produced a >1 KiB box-drawing excerpt that flooded the loop; this is the size-side defense.

## Why land this standalone

- Independently valuable for the existing daemon — fixes the wedge we hit yesterday (SIGTERM didn't deliver because the daemon's main loop was blocked on a socket write).
- Phase B–D of the hook-events plan add a new high-frequency event source; this PR makes the broadcast loop safe before that source lands.
- Small, focused diff — 2 files changed + 2 test files. Reviewable in one sitting.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./...` — all 17 packages pass
- [x] `go test -race ./...` — all packages pass under race detector
- [x] New tests:
  - `TestBroadcast_SlowConnDoesNotBlockFastConn` — 200 broadcasts with one peer refusing to read; asserts broadcast loop returns in < 1 s and the fast peer drains ≥ 50 messages within 3 s.
  - `TestBroadcast_ContinuesAfterSlowConnDisconnects` — after the slow conn is overflowed + closed, new broadcasts still reach the surviving conn.
  - `TestToPaneEventPayload_MessageOverCapTruncatesAndMarks` — 8 KiB Message → 4 KiB Message + truncation marker prefix + `Data["truncated"]="1"`.
  - `TestToPaneEventPayload_DataValueOverCapTruncates` — 1 KiB value capped to 128 bytes, other values pass through.
  - `TestToPaneEventPayload_WithinCapPassesThrough` — happy path unchanged.
  - `TestToPaneEventPayload_NilDataNoTruncationMarker` — no allocation when no truncation needed.
- [ ] Manual smoke: build dev binaries, attach a TUI + an MCP bridge, simulate a slow MCP client (e.g. paused via `kill -STOP`), verify the daemon stays responsive and the TUI continues receiving state updates.