### PR TITLE
docs(changelog): backfill v1.18.2 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.18.2] - 2026-06-10
 
+### Fixed
+
+- **Windows: launching from Windows Terminal froze mouse input to every other app** — restoring a persisted `maximized: true` window state called `ShowWindow(SW_MAXIMIZE)` on the handle returned by `GetConsoleWindow()`. Under a ConPTY host (Windows Terminal, VS Code) there is no real console window — that call returns a hidden `PseudoConsoleWindow`, and maximizing it spawns an invisible full-screen window that swallows mouse clicks for every window beneath it in the Z-order (only the focused window and Alt+Tab kept working; everything else looked frozen). `IsZoomed` on the ghost then stayed true, so exit re-saved `maximized: true` and the bug reproduced on every launch. Window restore and save now gate on `IsWindowVisible` via a new `realConsoleWindow()` helper — a real conhost window is always visible by the time the TUI runs, the ConPTY ghost never is — and save carries the previous session's pixel/maximized values forward so a ConPTY session can no longer poison real conhost geometry.
+
 ## [1.18.1] - 2026-06-10
 
 ### Fixed


### PR DESCRIPTION
## Summary

- v1.18.2 shipped with an **empty GitHub release body**. The release workflow sources release notes from the `CHANGELOG.md` section for the version (`release.yml` extracts text between `## [VERSION]` and the next `## [` header), but PR #46 bumped the patch version without adding an entry under `## [Unreleased]` — so the new `## [1.18.2]` header captured nothing.
- This backfills the `## [1.18.2]` section with the ConPTY ghost-window fix entry, so the changelog (the source of truth) matches the published release.

## Already done

The **live v1.18.2 release body has already been corrected** via `gh release edit` using the exact text added here (extracted with the workflow's own `sed`): https://github.com/artyomsv/quil/releases/tag/v1.18.2

## Note

This is a `docs:` commit — it does not trigger a release (the version-bump step finds no `feat`/`fix` subject since the last tag and skips).

## Follow-up (not in this PR)

This is a recurring failure mode (v1.16.1, v1.17.0, v1.18.0 also shipped empty). Worth a separate PR adding a CI guard that fails/warns when a `feat`/`fix` version bump finds an empty `[Unreleased]` section.