### PR TITLE
fix(tui): paste images on empty bracketed paste (Ctrl+V)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Windows: Ctrl+V stopped pasting screenshots** — pressing Ctrl+V on a clipboard holding an image (but no text) did nothing, while F8 still worked. Windows Terminal performs its own paste on Ctrl+V and delivers it to Quil as a bracketed `tea.PasteMsg`; for an image-only clipboard that message's content is empty, and the empty-content branch called `sendClipboardToPane("")` and silently no-oped. The image→PNG proxy (save the image under `~/.quil/paste/`, type the file path into the pane) lived only in the F8/Ctrl+Alt+V keypress path (`pasteClipboard`), so F8 worked while Ctrl+V did not — a regression introduced when bracketed-paste handling was added. An empty bracketed paste now routes to that same image-capable path, restoring Ctrl+V screenshot paste. The paste flow's clipboard readers were made injectable so the routing is covered by a unit test.
+
 ## [1.18.4] - 2026-06-10
 
 ### Fixed

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -629,6 +629,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.notesEditor.HandlePaste(text)
 			return m, nil
 		} else {
+			// Empty bracketed-paste content means the terminal (e.g. Windows
+			// Terminal on Ctrl+V) fired a paste for a clipboard that holds an
+			// image but no text. Route to the same image-capable path the
+			// F8/Ctrl+Alt+V keypress uses (pasteClipboard's image fallback) so
+			// screenshot paste works on Ctrl+V again.
+			if msg.Content == "" {
+				logger.Debug("PasteMsg: empty content, routing to image-capable pasteClipboard")
+				return m, m.pasteClipboard()
+			}
 			m.sendClipboardToPane(msg.Content)
 			// Schedule re-render after PTY echo arrives to update cursor position
 			return m, tea.Tick(100*time.Millisecond, func(_ time.Time) tea.Msg { return pasteRefreshMsg{} })
@@ -2872,6 +2881,14 @@ func (m Model) forwardInputBytes(data []byte) tea.Cmd {
 	}
 }
 
+// clipboardReadText and clipboardReadImage indirect over the clipboard package
+// so the paste flow can be exercised hermetically in tests (the real readers
+// touch the OS clipboard). Production leaves them at the package functions.
+var (
+	clipboardReadText  = clipboard.Read
+	clipboardReadImage = clipboard.ReadImage
+)
+
 func (m Model) pasteClipboard() tea.Cmd {
 	return func() tea.Msg {
 		logger.Debug("pasteClipboard: invoked")
@@ -2881,7 +2898,7 @@ func (m Model) pasteClipboard() tea.Cmd {
 		// reading the image ourselves, saving it as a PNG under
 		// config.PasteDir(), and pasting the absolute path so any PTY tool
 		// can pick it up via its file-reading tools.
-		text, textErr := clipboard.Read() // text-only error is non-fatal — fall through
+		text, textErr := clipboardReadText() // text-only error is non-fatal — fall through
 		logger.Debug("pasteClipboard: clipboard.Read() text_len=%d err=%v", len(text), textErr)
 		if text == "" {
 			logger.Debug("pasteClipboard: text empty, attempting image fallback")
@@ -2932,7 +2949,7 @@ func (m Model) pasteClipboard() tea.Cmd {
 // the OS clipboard itself, drops it in a known location, and types the path
 // into the PTY. Any AI tool with file-reading tools can then pick it up.
 func (m Model) tryPasteClipboardImage() (string, bool) {
-	pngBytes, err := clipboard.ReadImage()
+	pngBytes, err := clipboardReadImage()
 	if err != nil {
 		if !errors.Is(err, clipboard.ErrNoImage) {
 			log.Printf("clipboard image: read failed: %v", err)

--- a/internal/tui/paste_test.go
+++ b/internal/tui/paste_test.go
@@ -1,0 +1,102 @@
+package tui
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/artyomsv/quil/internal/config"
+	"github.com/artyomsv/quil/internal/ipc"
+)
+
+// pasteTestModel builds a minimal Model with one active terminal pane and the
+// supplied recording IPC client — enough to drive the tea.PasteMsg branch in
+// Update without a live daemon.
+func pasteTestModel(client tuiClient) Model {
+	cfg := config.Default()
+	pane := NewPaneModel("p1", 1024)
+	pane.Active = true
+	tab := NewTabModel("t1", "Test")
+	tab.Root = NewLeaf(pane)
+	tab.ActivePane = "p1"
+	m := Model{
+		cfg:           cfg,
+		client:        client,
+		tabs:          []*TabModel{tab},
+		activeTab:     0,
+		width:         80,
+		height:        24,
+		notifications: NewNotificationCenter(cfg.Notification.SidebarWidth, cfg.Notification.MaxEvents),
+	}
+	m.resizeTabs()
+	return m
+}
+
+func paneInputData(t *testing.T, msg *ipc.Message) []byte {
+	t.Helper()
+	var p ipc.PaneInputPayload
+	if err := json.Unmarshal(msg.Payload, &p); err != nil {
+		t.Fatalf("unmarshal PaneInputPayload: %v", err)
+	}
+	return p.Data
+}
+
+// TestUpdate_PasteMsgEmptyContent_FallsBackToImagePaste guards the Ctrl+V
+// screenshot-paste regression. Windows Terminal performs its own paste on
+// Ctrl+V and delivers it to Quil as a bracketed tea.PasteMsg. For a clipboard
+// that holds an image but no text, msg.Content is empty — the old code called
+// sendClipboardToPane("") and silently no-oped, so the image proxy never ran
+// (only the F8 keypress path had it). An empty bracketed paste must now route
+// to the same image-capable path: save the PNG and type its path.
+func TestUpdate_PasteMsgEmptyContent_FallsBackToImagePaste(t *testing.T) {
+	t.Setenv("QUIL_HOME", t.TempDir()) // PasteDir() writes here, never production
+
+	origText, origImg := clipboardReadText, clipboardReadImage
+	t.Cleanup(func() { clipboardReadText, clipboardReadImage = origText, origImg })
+	clipboardReadText = func() (string, error) { return "", nil }
+	pngBytes := []byte("\x89PNG\r\n\x1a\nFAKE-IMAGE-BYTES")
+	clipboardReadImage = func() ([]byte, error) { return pngBytes, nil }
+
+	fake := &fakeSender{}
+	m := pasteTestModel(fake)
+
+	_, cmd := m.Update(tea.PasteMsg{Content: ""})
+	if cmd == nil {
+		t.Fatal("empty PasteMsg returned a nil command; want the image-paste command")
+	}
+	// pasteClipboard sends the input from inside the returned command closure.
+	_ = cmd()
+
+	if len(fake.sent) != 1 {
+		t.Fatalf("want exactly 1 IPC send (the pasted image path), got %d", len(fake.sent))
+	}
+	if fake.sent[0].Type != ipc.MsgPaneInput {
+		t.Fatalf("sent type = %q, want %q", fake.sent[0].Type, ipc.MsgPaneInput)
+	}
+	data := string(paneInputData(t, fake.sent[0]))
+	if !strings.Contains(data, ".png") {
+		t.Errorf("pasted data %q does not contain a .png path", data)
+	}
+	if !strings.HasPrefix(data, "\x1b[200~") || !strings.HasSuffix(data, "\x1b[201~") {
+		t.Errorf("pasted data %q is not wrapped in bracketed paste sequences", data)
+	}
+}
+
+// TestUpdate_PasteMsgWithText_SendsTextVerbatim is the regression guard for the
+// fix: a bracketed paste carrying real text must still be typed verbatim and
+// must NOT be hijacked by the image fallback.
+func TestUpdate_PasteMsgWithText_SendsTextVerbatim(t *testing.T) {
+	fake := &fakeSender{}
+	m := pasteTestModel(fake)
+
+	_, _ = m.Update(tea.PasteMsg{Content: "hello world"})
+
+	if len(fake.sent) != 1 {
+		t.Fatalf("want exactly 1 IPC send, got %d", len(fake.sent))
+	}
+	if got := string(paneInputData(t, fake.sent[0])); got != "hello world" {
+		t.Errorf("sent data = %q, want %q", got, "hello world")
+	}
+}


### PR DESCRIPTION
Windows Terminal performs its own paste on Ctrl+V and delivers it to Quil as a bracketed tea.PasteMsg. For an image-only clipboard the message content is empty, and the empty-content branch called sendClipboardToPane("") and silently no-oped — so the image->PNG proxy that lived only in the F8/Ctrl+Alt+V keypress path never ran. F8 worked while Ctrl+V did not, a regression introduced when bracketed-paste handling was added.

An empty bracketed paste now routes to the same image-capable path (pasteClipboard), restoring Ctrl+V screenshot paste. The paste flow's clipboard readers were made injectable so the routing is covered by a unit test.