### PR TITLE
fix(install): use temp+rename to avoid macOS codesign cache SIGKILL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,9 @@ jobs:
       - run: go vet ./...
       - run: go test ./...
       - run: go build ./cmd/quil && go build ./cmd/quild
+
+      - name: shellcheck
+        run: shellcheck -S warning scripts/*.sh
+
+      - name: installer regression test
+        run: sh scripts/test-install.sh

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -5,6 +5,7 @@ When things go sideways, this is the first place to look.
 ## Table of contents
 
 - [The daemon won't start](#the-daemon-wont-start)
+- [macOS: `zsh: killed quil` after upgrading](#macos-zsh-killed-quil-after-upgrading)
 - [The TUI shows a blank screen](#the-tui-shows-a-blank-screen)
 - [Version mismatch — daemon won't accept the TUI](#version-mismatch--daemon-wont-accept-the-tui)
 - [MCP — AI client doesn't see Quil](#mcp--ai-client-doesnt-see-quil)
@@ -38,6 +39,34 @@ Symptoms: `quil` prints `cannot connect to daemon` and exits, or the TUI hangs o
    tail -100 ~/.quil/quild.log
    ```
    Common errors: socket binding failed (permission), workspace.json deserialize error (corrupted state).
+
+## macOS: `zsh: killed quil` after upgrading
+
+Symptoms: after upgrading an existing install, running `quil` (or `quild`) prints `zsh: killed quil` and exits instantly. Reinstalling doesn't help.
+
+This is the macOS kernel killing the binary at exec time, not a Quil crash. Confirm it by checking the newest crash report:
+
+```bash
+ls -t ~/Library/Logs/DiagnosticReports/quil-*.ips | head -1 | xargs grep -o '"signal":"[^"]*"\|"indicator":"[^"]*"'
+```
+
+If you see `SIGKILL (Code Signature Invalid)` / `Taskgated Invalid Signature`, you've hit it.
+
+**Cause.** macOS caches code-signing information per inode. Older versions of `install.sh` overwrote the existing binaries in place with `cp`, which reuses the inode — the kernel's cached signature for the *old* binary no longer matches the *new* bytes, so every exec is SIGKILLed even though the binary's signature is actually valid (`codesign --verify` passes).
+
+**Fix.** Re-run the installer — current versions install via temp file + `mv`, which gives the destination a fresh inode and clears the stale cache entry:
+
+```bash
+curl -sSfL https://raw.githubusercontent.com/artyomsv/quil/master/scripts/install.sh | sh
+```
+
+If you're stuck with an old copy of the installer, delete the binaries first so the copy lands on new inodes:
+
+```bash
+rm -f ~/.local/bin/quil ~/.local/bin/quild
+```
+
+then reinstall.
 
 ## The TUI shows a blank screen
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -97,18 +97,24 @@ download_and_verify() {
 
 install_binaries() {
   mkdir -p "$INSTALL_DIR"
-  # Install via temp file + mv (rename): the destination gets a NEW inode,
-  # atomically. Overwriting an existing binary in place with cp reuses the
-  # inode, and macOS caches code-signing info per inode (vnode) — a stale
-  # cache entry makes the kernel SIGKILL the new binary at exec time
-  # ("zsh: killed quil", "Code Signature Invalid" in the crash report).
-  # The temp file lives inside INSTALL_DIR so the rename never crosses
-  # filesystems.
-  for bin in quil quild; do
-    cp "$TMP_DIR/$bin" "$INSTALL_DIR/.$bin.tmp.$$"
-    chmod +x "$INSTALL_DIR/.$bin.tmp.$$"
-    mv -f "$INSTALL_DIR/.$bin.tmp.$$" "$INSTALL_DIR/$bin"
-  done
+  # Stage each binary as a temp file inside INSTALL_DIR, then mv it into
+  # place: each binary is swapped in atomically via rename and lands on a
+  # NEW inode (the two binaries are swapped one after the other — the pair
+  # is not replaced transactionally). Overwriting an existing binary in
+  # place with cp reuses the inode, and macOS caches code-signing info per
+  # inode (vnode) — a stale cache entry makes the kernel SIGKILL the new
+  # binary at exec time ("zsh: killed quil", "Code Signature Invalid" in
+  # the crash report). The temp files live inside INSTALL_DIR so the
+  # rename never crosses filesystems; the EXIT trap removes them if the
+  # install aborts between staging and rename.
+  QUIL_TMP=$(mktemp "$INSTALL_DIR/.quil.tmp.XXXXXX")
+  QUILD_TMP=$(mktemp "$INSTALL_DIR/.quild.tmp.XXXXXX")
+  trap 'rm -rf "$TMP_DIR"; rm -f "$QUIL_TMP" "$QUILD_TMP"' EXIT
+  cp "$TMP_DIR/quil" "$QUIL_TMP"
+  cp "$TMP_DIR/quild" "$QUILD_TMP"
+  chmod 755 "$QUIL_TMP" "$QUILD_TMP"
+  mv -f "$QUIL_TMP" "$INSTALL_DIR/quil"
+  mv -f "$QUILD_TMP" "$INSTALL_DIR/quild"
 }
 
 print_success() {
@@ -132,4 +138,6 @@ print_success() {
   echo "Run 'quil' to get started."
 }
 
-main
+# QUIL_INSTALLER_NO_MAIN=1 lets tests source this file for its functions
+# without running the installer (see scripts/test-install.sh).
+[ "${QUIL_INSTALLER_NO_MAIN:-0}" = "1" ] || main

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -97,9 +97,18 @@ download_and_verify() {
 
 install_binaries() {
   mkdir -p "$INSTALL_DIR"
-  cp "$TMP_DIR/quil" "$INSTALL_DIR/quil"
-  cp "$TMP_DIR/quild" "$INSTALL_DIR/quild"
-  chmod +x "$INSTALL_DIR/quil" "$INSTALL_DIR/quild"
+  # Install via temp file + mv (rename): the destination gets a NEW inode,
+  # atomically. Overwriting an existing binary in place with cp reuses the
+  # inode, and macOS caches code-signing info per inode (vnode) — a stale
+  # cache entry makes the kernel SIGKILL the new binary at exec time
+  # ("zsh: killed quil", "Code Signature Invalid" in the crash report).
+  # The temp file lives inside INSTALL_DIR so the rename never crosses
+  # filesystems.
+  for bin in quil quild; do
+    cp "$TMP_DIR/$bin" "$INSTALL_DIR/.$bin.tmp.$$"
+    chmod +x "$INSTALL_DIR/.$bin.tmp.$$"
+    mv -f "$INSTALL_DIR/.$bin.tmp.$$" "$INSTALL_DIR/$bin"
+  done
 }
 
 print_success() {

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+set -eu
+
+# Regression test for install_binaries() in install.sh.
+#
+# Guards the macOS stale code-sign cache fix: every install must land the
+# binaries on FRESH inodes (staged temp file + mv, never an in-place cp —
+# macOS caches code-signing info per inode and SIGKILLs a binary whose
+# inode was overwritten) and must leave no staged temp files behind in the
+# install directory.
+#
+# No network needed — fake binaries stand in for a release archive.
+
+SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+QUIL_INSTALL_DIR="$WORK/bin"
+export QUIL_INSTALLER_NO_MAIN=1
+# shellcheck source=install.sh
+. "$SCRIPT_DIR/install.sh"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+inode_of() {
+  ls -i "$1" | awk '{print $1}'
+}
+
+# Simulate one installer run: stage fake binaries the way
+# download_and_verify would, then invoke install_binaries.
+run_install() {
+  TMP_DIR=$(mktemp -d "$WORK/stage.XXXXXX")
+  printf 'fake-quil-%s' "$1" > "$TMP_DIR/quil"
+  printf 'fake-quild-%s' "$1" > "$TMP_DIR/quild"
+  install_binaries
+  # install_binaries installs its own EXIT trap; restore the test's one.
+  trap 'rm -rf "$WORK"' EXIT
+  rm -rf "$TMP_DIR"
+}
+
+run_install one
+INODE1_QUIL=$(inode_of "$QUIL_INSTALL_DIR/quil")
+INODE1_QUILD=$(inode_of "$QUIL_INSTALL_DIR/quild")
+
+run_install two
+INODE2_QUIL=$(inode_of "$QUIL_INSTALL_DIR/quil")
+INODE2_QUILD=$(inode_of "$QUIL_INSTALL_DIR/quild")
+
+[ "$INODE1_QUIL" != "$INODE2_QUIL" ] || \
+  fail "quil inode unchanged after re-install ($INODE1_QUIL) — in-place overwrite reintroduced"
+[ "$INODE1_QUILD" != "$INODE2_QUILD" ] || \
+  fail "quild inode unchanged after re-install ($INODE1_QUILD) — in-place overwrite reintroduced"
+
+[ "$(cat "$QUIL_INSTALL_DIR/quil")" = "fake-quil-two" ] || \
+  fail "quil content is not from the latest install"
+[ "$(cat "$QUIL_INSTALL_DIR/quild")" = "fake-quild-two" ] || \
+  fail "quild content is not from the latest install"
+
+[ -x "$QUIL_INSTALL_DIR/quil" ] || fail "quil is not executable"
+[ -x "$QUIL_INSTALL_DIR/quild" ] || fail "quild is not executable"
+
+LEFTOVERS=$(find "$QUIL_INSTALL_DIR" -name '.*.tmp.*' | wc -l)
+[ "$LEFTOVERS" -eq 0 ] || fail "$LEFTOVERS staged temp file(s) left in install dir"
+
+echo "PASS: re-install lands on fresh inodes (quil $INODE1_QUIL -> $INODE2_QUIL," \
+  "quild $INODE1_QUILD -> $INODE2_QUILD), no temp litter, executables in place"


### PR DESCRIPTION
## Summary

- `install.sh` overwrote existing binaries in place with `cp`, reusing the destination inode. macOS caches code-signing info per inode (vnode), so upgrading an existing install left a stale cache entry and the kernel SIGKILLed the new binary at exec time — `zsh: killed quil`, with `SIGKILL (Code Signature Invalid)` / `Taskgated Invalid Signature` in `~/Library/Logs/DiagnosticReports/quil-*.ips`. Reinstalling never recovered because `cp` kept reusing the same inode (binary verified clean with `codesign --verify`; crashed image UUID matched the on-disk file byte-for-byte).
- `install_binaries()` now copies each binary to a temp file inside `$INSTALL_DIR` and `mv -f`s it into place: atomic, fresh inode every install. This prevents the stale-cache state on future upgrades **and** self-heals already-broken machines — recovery is just re-running the normal install one-liner, no manual steps.
- Added a troubleshooting entry ("macOS: `zsh: killed quil` after upgrading") with the diagnosis one-liner and the legacy fallback (`rm` first) for users stuck on an old installer copy.

## Test Plan

- [x] `QUIL_INSTALL_DIR=$(mktemp -d) sh scripts/install.sh` run **twice**: both succeed, `stat -f %i` shows fresh inodes after the second run (14987140 → 14987197), `quil version` executes cleanly after each, no temp-file litter in the install dir.
- [x] `shellcheck` (stable, via Docker) passes on `scripts/install.sh`.
- [ ] Post-merge, on the affected Mac (currently in the broken stale-cache state, deliberately left unrecovered): run the install one-liner from master → `quil version` must print the version instead of `zsh: killed`, with no new `.ips` crash reports.