### PR TITLE
docs: document self-healing daemon across docs and site

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Five keys to remember:
 
 That's enough to start. See [docs/quick-start.md](docs/quick-start.md) for the first-launch walkthrough and [docs/keybindings.md](docs/keybindings.md) for the full keymap.
 
+If anything ever hangs: `quil restart` recovers the daemon (escalating stop → fresh start → tabs restored from the last snapshot), and `Alt+R` restarts a single stuck pane in place with its AI session resumed.
+
 ## Let your AI assistant drive Quil
 
 Add this to your AI client's MCP config (Claude Desktop, Claude Code, Cursor, VS Code Copilot):

--- a/docs/features.md
+++ b/docs/features.md
@@ -30,6 +30,7 @@ A capability-by-capability tour of what Quil does. For configuration knobs, see 
   - [Leveled logger + log viewer](#leveled-logger--log-viewer)
 - [Pane notes](#pane-notes)
 - [Operations](#operations)
+  - [Self-healing daemon](#self-healing-daemon)
   - [Client/daemon version handshake](#clientdaemon-version-handshake)
   - [Cross-platform](#cross-platform)
 
@@ -175,6 +176,7 @@ A non-modal sidebar surfaces:
 - OSC 133 command-completion events (shell panes)
 - Bell characters (30 s cooldown to avoid storming)
 - Smart-idle pattern matches (per-plugin `[[idle_handlers]]` regex)
+- **"Pane not accepting input"** — the pane's process stopped reading its stdin (e.g. an AI tool wedged after a context compaction), so the daemon drops the keystrokes instead of letting one stuck pane freeze the app. Recover with `Alt+R` (restart the pane in place — AI sessions resume)
 - **Hook-driven events from Claude Code and OpenCode** — structured events forwarded directly from the AI tool (permission requests, "reply ready", session errors, file edits, etc.) instead of guessed from the PTY byte stream. See `[notification.hooks]` in [configuration.md](configuration.md#notificationhooks) for the tier knob.
 
 Hook-driven events flow:
@@ -238,6 +240,14 @@ Soft-wrap (opt-in via `TextEditor.SoftWrap`): long logical lines wrap onto the n
 ---
 
 ## Operations
+
+### Self-healing daemon
+
+A stuck child process can't take Quil down, and a stuck daemon recovers with one command:
+
+- **`quil restart`** — stop the daemon with bounded escalation (graceful IPC shutdown with a final snapshot → SIGTERM → force-kill, each tier with a timeout so even a deadlocked daemon can't stall it), clean up stale pid/socket files, start fresh, and open the TUI. Prints the target environment first (`production (~/.quil)` vs `dev`) so you can never kill the wrong daemon. `quil daemon restart` / `quil daemon stop` use the same escalation. Tabs and panes respawn from the last snapshot; AI panes resume their sessions.
+- **Isolated pane input** — every pane's stdin is written by its own goroutine behind a bounded queue. A process that stops reading input (an AI tool wedged mid-turn) costs you a "Pane not accepting input" sidebar warning for that one pane; everything else stays interactive. `Alt+R` restarts the stuck pane in place.
+- **Liveness watchdog** — the daemon's snapshot loop doubles as a health canary. If no snapshot completes for 2 minutes, a full goroutine stack dump is written to `~/.quil/quild.log` (`WATCHDOG:` prefix), so a wedge is a diagnosable bug report instead of a silent freeze. Daemon panics and SIGQUIT dumps land in `~/.quil/quild.stderr.log`.
 
 ### Client/daemon version handshake
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -167,8 +167,11 @@ For OpenCode the equivalent files are under `~/.quil/opencodehook/` and `~/.quil
 | `~/.quil/mcp-logs/<pane-id>.log` | Per-pane MCP interaction log (tool name, timestamp, sanitized detail) |
 | `~/.quil/claudehook/hook.log` | Errors from the Claude Code SessionStart hook |
 | `~/.quil/opencodehook/hook.log` | Errors / breadcrumbs from the OpenCode JS plugin |
+| `~/.quil/quild.stderr.log` | Daemon panics and SIGQUIT goroutine dumps (anything the Go runtime writes to stderr) |
 
 From inside the TUI: `F1 → View client log` / `View daemon log` / `View MCP logs` opens a read-only viewer with `Alt+Up` / `Alt+Down` for paged navigation.
+
+**Wedge diagnostics:** if the daemon ever stops responding, search `quild.log` for `WATCHDOG` — when no workspace snapshot completes for 2 minutes, the daemon writes a full goroutine stack dump there. Attach that dump to a bug report; it pinpoints the blocked code path exactly.
 
 ## Enable debug logging
 

--- a/site/src/data/faq.ts
+++ b/site/src/data/faq.ts
@@ -48,6 +48,11 @@ export const homeFaq: FaqItem[] = [
       "Quil detects when your on-disk plugin TOML has a lower schema_version than the version shipped with the new binary. Instead of silently overwriting your config, it opens a full-screen side-by-side merge dialog at startup: your config on the left (editable), the new default on the right (read-only). Lines unique to your config are highlighted red, new lines in the default are highlighted green. Copy what you need from the right, edit on the left, then Ctrl+S to save. You can also press F5 to accept the new default entirely. The dialog blocks until resolved — no risk of running with a stale config.",
   },
   {
+    question: "What if Quil hangs or a pane stops responding?",
+    answer:
+      "One command recovers everything: `quil restart` stops the daemon with escalating force (graceful shutdown with a final state snapshot, then SIGTERM, then force-kill — each step has a timeout, so even a fully deadlocked daemon can't resist), starts a fresh one, and reopens your tabs and panes from the last snapshot. AI panes resume their sessions. If only a single pane stops accepting input (for example an AI tool wedged mid-turn), Quil shows a 'Pane not accepting input' warning in the notification sidebar while every other pane keeps working — press Alt+R to restart just that pane in place.",
+  },
+  {
     question: "Is Quil free?",
     answer:
       "Yes. Quil is open source under the MIT License. There's no hosted version, no paid tier, no telemetry. You self-host it on your own machine and it stores all state locally under ~/.quil/.",

--- a/site/src/data/features.ts
+++ b/site/src/data/features.ts
@@ -235,6 +235,20 @@ export const features: Feature[] = [
     ],
   },
   {
+    slug: "self-healing-daemon",
+    icon: "heart-pulse",
+    title: "Self-healing daemon",
+    blurb:
+      "A wedged AI pane can't freeze your workspace, and `quil restart` recovers anything in one command — tabs and AI sessions restored from the last snapshot.",
+    category: "observability",
+    detail: [
+      "`quil restart` stops the daemon with bounded escalation (graceful IPC shutdown with final snapshot → SIGTERM → force-kill, each tier timed out so even a deadlocked daemon can't stall it), cleans stale pid/socket files, starts fresh, and reopens the TUI.",
+      "Prints the target environment first — production (~/.quil) vs dev (QUIL_HOME) — so you can never kill the wrong daemon. PID-reuse guard: a recorded PID is only signaled if it actually belongs to a quild binary.",
+      "Per-pane input isolation: every pane's stdin is written by its own goroutine behind a bounded queue. A process that stops reading input costs you a 'Pane not accepting input' sidebar warning on that one pane — everything else stays interactive. Alt+R restarts the stuck pane in place with its AI session resumed.",
+      "Liveness watchdog: if no workspace snapshot completes for 2 minutes, the daemon writes a full goroutine stack dump to quild.log — a wedge becomes a precise bug report instead of a silent freeze.",
+    ],
+  },
+  {
     slug: "leveled-logging",
     icon: "book-open",
     title: "Leveled logging + in-app log viewer",


### PR DESCRIPTION
## Summary

- The resilience work from June 11–12 (`quil restart`, per-pane input isolation + "Pane not accepting input" warning, `Alt+R` pane restart, snapshot watchdog, `quild.stderr.log`) only got troubleshooting-page coverage in its code PRs. This syncs the rest of the user-facing surface:
  - **docs/features.md** — new *Operations → Self-healing daemon* section (+ ToC), and the notification-center event list now includes the input-blocked warning with the `Alt+R` recovery pointer
  - **docs/troubleshooting.md** — `quild.stderr.log` added to the log-files table; new pointer to `WATCHDOG` goroutine dumps in `quild.log` for wedge diagnostics
  - **README.md** — one-line recovery note (`quil restart` / `Alt+R`) under Quick start
  - **quil.cc site** — "Self-healing daemon" feature card and a hang-recovery FAQ entry (feeds the FAQPage JSON-LD)

## Test Plan

- [x] Edited site data files (`features.ts`, `faq.ts`) syntax-checked via esbuild (local `astro build` unavailable — `site/node_modules` was installed for another platform; the Pages workflow runs `npm ci` + `astro check && astro build` on merge)
- [x] Markdown anchors verified against existing ToC style
- [ ] After merge: confirm the Pages deploy (site.yml) goes green and quil.cc shows the new card + FAQ
