### PR TITLE
feat(plugin): add Chrome support toggle to claude-code

### DIFF
--- a/.claude/reviews/quil/claude-code-chrome-toggle.md
+++ b/.claude/reviews/quil/claude-code-chrome-toggle.md
@@ -1,0 +1,15 @@
+# Code Review State: quil / claude-code-chrome-toggle
+
+Last reviewed: 2026-06-14
+Rounds completed: 1
+
+## Resolved (fixed in code; do not re-raise)
+- [qa/GAP-1] setupDialogWidth() unit test added — TestSetupDialogWidth_FloorGrowthAndCap covers floor / label-growth / terminal-cap branches — round 1
+- [code-quality/L-3] toggleChrome=6 comment now covers all box glyphs ([x]/[ ]/(•)/( )), not just the checkbox form — round 1
+- [code-quality/L-5] m.width>2 clamp guard now has an intent comment (skip until first WindowSizeMsg) — round 1
+- [rules/L-6] test renamed TestLoadPluginTOML_ClaudeCodeSetup_ParsesPromptsCWDAndToggles (dropped stale "Permission" scope, now asserts chrome too) — round 1
+
+## Dismissed (acknowledged, will not fix; agents may escalate with explicit justification)
+- [security/L-1] --chrome capability expansion — informational only; correctly user-gated (default=false, independent opt-in, honest label). Quil just forwards a documented upstream flag (round 1)
+- [code-quality/L-2] setupDialogWidth recomputed per render — negligible cost (map lookup + ~3-iter loop once per frame); not worth threading the value as a param (round 1)
+- [code-quality/L-4] browsed CWD path raw-print can wrap on long paths — pre-existing behavior, not introduced by this diff; out of scope for the chrome-toggle change (round 1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Claude Code Chrome support toggle** — the Claude Code pane setup dialog now offers a standalone "Chrome support" checkbox that appends `--chrome` to the launch command, connecting the CLI to the Claude in Chrome browser extension. It is independent of the permission-mode radio buttons, so it can be combined with either mode (or neither). Requires the Claude in Chrome extension (v1.0.36+) and `claude` ≥ 2.0.73. The pane setup dialog now also auto-sizes its width to fit the longest toggle label instead of a fixed width, so long option descriptions render on one line.
+
 ## [1.22.0] - 2026-06-13
 
 ### Added

--- a/internal/plugin/defaults/claude-code.toml
+++ b/internal/plugin/defaults/claude-code.toml
@@ -6,7 +6,7 @@ name = "claude-code"
 display_name = "Claude Code"
 category = "ai"
 description = "AI coding assistant"
-schema_version = 4
+schema_version = 5
 
 [command]
 cmd = "claude"
@@ -34,6 +34,16 @@ label = "Enable auto mode (safer alternative to skipping permissions)"
 args_when_on = ["--enable-auto-mode"]
 default = false
 group = "permission_mode"
+
+# Chrome support is independent of the permission mode (no group), so it
+# renders as a standalone checkbox the user can combine with either mode.
+# Requires the "Claude in Chrome" browser extension (v1.0.36+) and
+# claude >= 2.0.73; the flag only connects the CLI to the extension.
+[[command.toggles]]
+name = "chrome"
+label = "Chrome support (connect to the Claude in Chrome browser extension)"
+args_when_on = ["--chrome"]
+default = false
 
 [persistence]
 strategy = "preassign_id"

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -104,12 +104,12 @@ severity = "warning"
 	}
 }
 
-// TestLoadPluginTOML_ClaudeCodeSetup_ParsesPromptsCWDAndPermissionToggles verifies
+// TestLoadPluginTOML_ClaudeCodeSetup_ParsesPromptsCWDAndToggles verifies
 // the prompts_cwd and [[command.toggles]] opt-ins parse correctly from the
-// embedded claude-code default TOML, including the mutually-exclusive
-// permission_mode group that guards the user from enabling both
-// --dangerously-skip-permissions and --enable-auto-mode simultaneously.
-func TestLoadPluginTOML_ClaudeCodeSetup_ParsesPromptsCWDAndPermissionToggles(t *testing.T) {
+// embedded claude-code default TOML: the mutually-exclusive permission_mode
+// group that guards the user from enabling both --dangerously-skip-permissions
+// and --enable-auto-mode simultaneously, plus the independent --chrome toggle.
+func TestLoadPluginTOML_ClaudeCodeSetup_ParsesPromptsCWDAndToggles(t *testing.T) {
 	dir := t.TempDir()
 	if _, err := EnsureDefaultPlugins(dir); err != nil {
 		t.Fatalf("EnsureDefaultPlugins: %v", err)
@@ -127,8 +127,8 @@ func TestLoadPluginTOML_ClaudeCodeSetup_ParsesPromptsCWDAndPermissionToggles(t *
 	if !p.Command.PromptsCWD {
 		t.Error("expected PromptsCWD = true on claude-code plugin")
 	}
-	if len(p.Command.Toggles) != 2 {
-		t.Fatalf("expected 2 toggles on claude-code, got %d", len(p.Command.Toggles))
+	if len(p.Command.Toggles) != 3 {
+		t.Fatalf("expected 3 toggles on claude-code, got %d", len(p.Command.Toggles))
 	}
 
 	byName := map[string]Toggle{}
@@ -168,6 +168,25 @@ func TestLoadPluginTOML_ClaudeCodeSetup_ParsesPromptsCWDAndPermissionToggles(t *
 	}
 	if auto.Label == "" {
 		t.Error("auto.Label should not be empty")
+	}
+
+	// chrome is independent of the permission_mode group (empty Group), so it
+	// renders as a standalone checkbox combinable with either permission mode.
+	chrome, ok := byName["chrome"]
+	if !ok {
+		t.Fatalf("missing chrome toggle")
+	}
+	if chrome.Default != false {
+		t.Error("chrome default should be false")
+	}
+	if len(chrome.ArgsWhenOn) != 1 || chrome.ArgsWhenOn[0] != "--chrome" {
+		t.Errorf("chrome.ArgsWhenOn = %v, want [--chrome]", chrome.ArgsWhenOn)
+	}
+	if chrome.Group != "" {
+		t.Errorf("chrome.Group = %q, want empty (independent toggle)", chrome.Group)
+	}
+	if chrome.Label == "" {
+		t.Error("chrome.Label should not be empty")
 	}
 }
 

--- a/internal/tui/dialog.go
+++ b/internal/tui/dialog.go
@@ -666,7 +666,7 @@ func (m Model) renderDialog() string {
 	case dialogCreatePane:
 		content = m.renderCreatePaneDialog()
 	case dialogCreatePaneSetup:
-		width = 70 // wider to fit paths and toggle labels comfortably
+		width = m.setupDialogWidth() // grows to fit the longest toggle label
 		content = m.renderCreatePaneSetupDialog()
 	case dialogPluginError:
 		content = m.renderPluginErrorDialog()
@@ -2638,6 +2638,36 @@ func sanitizePastedPath(s string) string {
 	return b.String()
 }
 
+// setupDialogWidth returns the box width for the pane setup dialog. The text
+// area inside the box is width-4 (Padding(1,2) on dialogBorder; the border
+// itself sits outside Width). Each toggle row costs 6 cells of chrome — the
+// 2-char cursor prefix plus "[x] " — on top of its label, so a long label
+// wraps onto a second line once it exceeds the text area. Grow the box to fit
+// the widest toggle row instead of hardcoding a constant that the next long
+// label silently breaks. Floored at 70 (keeps CWD paths comfortable) and
+// capped to the terminal width so the box never renders off-screen.
+func (m Model) setupDialogWidth() int {
+	const (
+		floor        = 70
+		toggleChrome = 6 // 2 prefix ("> "/"  ") + 4 box+space ([x]/[ ]/(•)/( ) are all 4)
+		padding      = 4 // dialogBorder Padding(1,2) → 2 cells each side
+	)
+	width := floor
+	if p := m.pluginRegistry.Get(m.selectedPlugin); p != nil {
+		for _, t := range p.Command.Toggles {
+			if need := toggleChrome + lipgloss.Width(t.Label) + padding; need > width {
+				width = need
+			}
+		}
+	}
+	// Skip the clamp until the first WindowSizeMsg sets m.width (>2 keeps
+	// m.width-2 ≥ 1); the border adds +2 so this caps the rendered box at m.width.
+	if m.width > 2 && width > m.width-2 {
+		width = m.width - 2
+	}
+	return width
+}
+
 // renderCreatePaneSetupDialog renders the setup dialog: a CWD directory
 // browser (optional) + one checkbox per plugin Toggle + a Continue button.
 // The focused field is highlighted; inside the browser the selected entry
@@ -2685,8 +2715,10 @@ func (m Model) renderCreatePaneSetupDialog() string {
 			// Repo pick-list mode: show discovered git repo candidates plus a
 			// trailing "Browse…" escape hatch. Uses the same cursor-row
 			// prefix/style as the directory browser for visual consistency.
-			// Setup dialog width is 70; 4-char prefix + 2-char border → 64 usable.
-			const setupPickMaxWidth = 64
+			// Track the dialog width: 6 cells go to the "  > " prefix + border,
+			// the rest is usable for the repo path (matches the historical 64 at
+			// the floor width of 70).
+			setupPickMaxWidth := m.setupDialogWidth() - 6
 			rows := len(m.repoCandidates) + 1 // +1 for Browse…
 			for i := 0; i < rows; i++ {
 				var displayName string

--- a/internal/tui/setup_dialog_test.go
+++ b/internal/tui/setup_dialog_test.go
@@ -1354,3 +1354,86 @@ func TestEnterSetupOrSplit_GitDiscover_CapsCandidates(t *testing.T) {
 		t.Fatalf("len(repoCandidates) = %d, want %d (capped)", len(m.repoCandidates), maxRepoCandidates)
 	}
 }
+
+// TestSetupDialogWidth_FloorGrowthAndCap exercises the three branches of
+// setupDialogWidth: the floor (no/short labels), label-driven growth (the box
+// widens to fit the longest toggle row), and the terminal-width cap (the box
+// never exceeds m.width). The growth/cap expectations are derived from the same
+// label length the registry is built with, so the test stays correct if the
+// helper's overhead constants change meaning but not value.
+func TestSetupDialogWidth_FloorGrowthAndCap(t *testing.T) {
+	// rowOverhead mirrors setupDialogWidth: "> " prefix (2) + "[x] " box (4) +
+	// dialogBorder Padding(1,2) → 4 = 10 cells on top of the label width.
+	const rowOverhead = 10
+
+	// A label long enough to push the box well past the floor of 70.
+	longLabel := strings.Repeat("x", 80) // 80 cells wide (ASCII → 1 cell each)
+	grownWidth := rowOverhead + len(longLabel) // 90
+
+	dir := t.TempDir()
+	// Plugin "wide" has a long label; "narrow" has only a short label.
+	wideTOML := fmt.Sprintf(`[plugin]
+name = "wide"
+display_name = "Wide"
+category = "ai"
+
+[command]
+cmd = "true"
+
+[[command.toggles]]
+name = "long"
+label = %q
+args_when_on = ["--long"]
+default = false
+`, longLabel)
+	narrowTOML := `[plugin]
+name = "narrow"
+display_name = "Narrow"
+category = "ai"
+
+[command]
+cmd = "true"
+
+[[command.toggles]]
+name = "short"
+label = "Short"
+args_when_on = ["--short"]
+default = false
+`
+	if err := os.WriteFile(filepath.Join(dir, "wide.toml"), []byte(wideTOML), 0644); err != nil {
+		t.Fatalf("write wide.toml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "narrow.toml"), []byte(narrowTOML), 0644); err != nil {
+		t.Fatalf("write narrow.toml: %v", err)
+	}
+	r := plugin.NewRegistry()
+	if err := r.LoadFromDir(dir); err != nil {
+		t.Fatalf("LoadFromDir: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		width    int
+		selected string
+		want     int
+	}{
+		{"unknown plugin falls back to floor", 200, "no-such-plugin", 70},
+		{"short label stays at floor", 200, "narrow", 70},
+		{"long label grows past floor", 200, "wide", grownWidth},
+		{"grown width capped to terminal", 80, "wide", 80 - 2},
+		{"unset width skips cap", 0, "wide", grownWidth},
+		{"floor capped to tiny terminal", 40, "narrow", 40 - 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := Model{
+				pluginRegistry: r,
+				selectedPlugin: tt.selected,
+				width:          tt.width,
+			}
+			if got := m.setupDialogWidth(); got != tt.want {
+				t.Errorf("setupDialogWidth() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds an independent **"Chrome support"** checkbox to the Claude Code pane setup dialog (Ctrl+N → AI → Claude Code). When enabled it appends `--chrome` to the `claude` launch, connecting the CLI to the Claude in Chrome browser extension. It carries no `group`, so it renders as a standalone checkbox combinable with either permission mode (or neither).
- Bumps the claude-code plugin `schema_version` 4→5 so the migration dialog surfaces the new toggle for existing user configs instead of silently overwriting them.
- Replaces the setup dialog's fixed width (70) with a computed `setupDialogWidth()` that grows to fit the longest toggle label (floored at 70, capped to terminal width). This makes the long Chrome label render on one line and also repairs a **pre-existing wrap** of the "Dangerously skip permissions" label, which already overflowed the fixed width.

## Notes

- `--chrome` requires the Claude in Chrome extension (v1.0.36+) and `claude` ≥ 2.0.73; the flag only connects the CLI to the already-installed extension.
- Reviewed via `/code-review` (security / quality / rules / qa) — no Critical/High/Medium findings; actionable findings fixed in this branch (added `setupDialogWidth` unit test, renamed the toggle-parse test, comment polish). State recorded in `.claude/reviews/quil/claude-code-chrome-toggle.md`.

## Test Plan

- [x] `./scripts/dev.sh test` — full suite green (266 tui/plugin tests incl. new `TestSetupDialogWidth_FloorGrowthAndCap`)
- [x] `gofmt`/`go vet` clean on changed files
- [ ] Manual: Ctrl+N → AI → Claude Code → confirm the setup dialog is wider and the three toggle labels (incl. "Chrome support …") each render on one line; enabling Chrome support launches `claude --chrome`.
