### PR TITLE
fix(site): accurate MCP tool count, AI resume claim, SEO title

### DIFF
--- a/site/src/data/competitors.ts
+++ b/site/src/data/competitors.ts
@@ -36,7 +36,7 @@ export const competitorMatrix: CompareRow[] = [
     note: "Quil's defining capability. Everyone else loses the session on reboot.",
   },
   {
-    feature: "AI session auto-resume (Claude Code, Cursor)",
+    feature: "AI session auto-resume (Claude Code, OpenCode)",
     quil: "yes",
     tmux: "no",
     zellij: "no",

--- a/site/src/data/faq.ts
+++ b/site/src/data/faq.ts
@@ -20,7 +20,7 @@ export const homeFaq: FaqItem[] = [
   {
     question: "Which AI tools does Quil support today?",
     answer:
-      "Claude Code has first-class support via the built-in Claude Code pane type, with auto-resume on daemon restart, a setup dialog that pre-fills the active pane's working directory (so the project's `.claude/` context is preserved), and a one-click `Dangerously skip permissions` toggle for unattended runs. Quil also runs an MCP server (`quil mcp`) that exposes 17 tools so any MCP-capable client can read pane output, send keystrokes, snapshot a workspace, and query per-pane memory usage. Any other AI tool can be wrapped in a custom TOML plugin that defines its spawn command, resume strategy, and error patterns.",
+      "Claude Code has first-class support via the built-in Claude Code pane type, with auto-resume on daemon restart, a setup dialog that pre-fills the active pane's working directory (so the project's `.claude/` context is preserved), and a one-click `Dangerously skip permissions` toggle for unattended runs. Quil also runs an MCP server (`quil mcp`) that exposes 18 tools so any MCP-capable client can read pane output, send keystrokes, snapshot a workspace, and query per-pane memory usage. Any other AI tool can be wrapped in a custom TOML plugin that defines its spawn command, resume strategy, and error patterns.",
   },
   {
     question: "Can I paste a screenshot into Claude Code on Windows?",

--- a/site/src/data/features.ts
+++ b/site/src/data/features.ts
@@ -80,7 +80,7 @@ export const features: Feature[] = [
       "Run `quil mcp` and an AI agent can list panes, read output, send keystrokes, and snapshot your workspace.",
     category: "ai",
     detail: [
-      "17 tools exposed over the Model Context Protocol (Anthropic's open standard for AI tool use).",
+      "18 tools exposed over the Model Context Protocol (Anthropic's open standard for AI tool use).",
       "Tools include: list/create/destroy panes, read pane output, send keys, switch tabs, screenshot a pane, watch the notification queue, query memory usage per pane, and more.",
       "Lets any MCP-capable client (Claude Desktop, Claude Code, Cursor) reach directly into your running Quil session.",
     ],

--- a/site/src/pages/docs.astro
+++ b/site/src/pages/docs.astro
@@ -50,7 +50,7 @@ const sections: DocSection[] = [
       { name: "Features",          path: "docs/features.md",         tag: "← TOUR",         desc: "Capability tour grouped by area: persistence, layout, typed panes, clipboard, observability, pane notes." },
       { name: "Keybindings",       path: "docs/keybindings.md",      tag: "← KEYS",         desc: "Full keymap, customization syntax, what to bind and what to leave passing through to the PTY." },
       { name: "Configuration",     path: "docs/configuration.md",    tag: "← CONFIG",       desc: "~/.quil/config.toml reference — every section and every key with defaults and effects." },
-      { name: "MCP",               path: "docs/mcp.md",              tag: "← AI",           desc: "Let your AI assistant drive Quil. Client wiring for Claude / Cursor / VS Code, all 17 tools, redaction model." },
+      { name: "MCP",               path: "docs/mcp.md",              tag: "← AI",           desc: "Let your AI assistant drive Quil. Client wiring for Claude / Cursor / VS Code, all 18 tools, redaction model." },
     ],
   },
   {

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -20,7 +20,7 @@ import { softwareApplicationSchema, faqSchema } from "@/data/schemas";
 import { homeFaq } from "@/data/faq";
 
 const seo = {
-  title: "The workspace that doesn't forget",
+  title: "Reboot-proof terminal multiplexer for AI development",
   description:
     "Quil is a reboot-proof terminal multiplexer for AI-native developers. Typed panes, auto-resuming Claude Code sessions, an MCP server. One static binary per platform.",
   path: "/",
@@ -62,7 +62,7 @@ const topFeatures = [
     number: "◇ 04",
     title: "MCP server for agents",
     tag: "← AGENT LAYER",
-    body: `Run <span class="mono" style="color:var(--flame);">quil mcp</span> and any MCP-capable client — Claude Desktop, Cursor, Claude Code — can list panes, read output, send keystrokes, and snapshot your workspace. 17 tools. Your terminal becomes addressable by AI.`,
+    body: `Run <span class="mono" style="color:var(--flame);">quil mcp</span> and any MCP-capable client — Claude Desktop, Cursor, Claude Code — can list panes, read output, send keystrokes, and snapshot your workspace. 18 tools. Your terminal becomes addressable by AI.`,
   },
 ];
 


### PR DESCRIPTION
SEO / accuracy fixes for the marketing site, surfaced during an SEO audit.

## Changes
- **MCP tool count 17 → 18** across `faq.ts`, `features.ts`, `docs.astro`, and the home MCP card in `index.astro`. Matches `docs/mcp.md`, the authoritative count.
- **AI auto-resume claim: Cursor → OpenCode** (`competitors.ts`). The comparison matrix claimed Quil auto-resumes *Cursor* sessions — it doesn't. Quil resumes **Claude Code** and **OpenCode** by session id. Cursor remains listed only where accurate (as an MCP-capable client in the MCP card / docs).
- **Home `<title>` is now keyword-bearing**: "Reboot-proof terminal multiplexer for AI development". The SERP/OG title carries the primary keyword; the visual hero ("the workspace that doesn't forget") is unchanged.

## Why
- Two factual inaccuracies (tool count, Cursor resume) erode trust with a technical audience.
- The previous `<title>` ("The workspace that doesn't forget") contained no target keywords — the title tag is the strongest SERP signal.

## Notes
- Pure string edits, no logic changes. 5 files, 6 lines.
- Not yet build-verified locally (Astro toolchain not present in this environment); CI/preview build will confirm.