### PR TITLE
feat(site): add blog + first post on Claude Code session resume

### DIFF
--- a/marketing/assets/screenshot-plan.md
+++ b/marketing/assets/screenshot-plan.md
@@ -1,0 +1,147 @@
+# Quil — Screenshot & Asset Plan
+
+Reproducible capture plan for marketing visuals: the article, the GitHub README
+hero, the OG/social-preview image, and the `/vs/*` pages.
+
+> **Why VHS:** Quil is a Bubble Tea (Charm) app, so [`charmbracelet/vhs`](https://github.com/charmbracelet/vhs)
+> is the right capture tool — a `.tape` script drives a real terminal headlessly
+> and renders a deterministic GIF/PNG. Same script → same frame every time, so
+> assets stay consistent as the UI evolves. Install: `go install github.com/charmbracelet/vhs@latest`
+> (needs `ttyd` + `ffmpeg`). For interactive shots VHS can't script cleanly, use a
+> manual terminal grab (see "Manual capture" below).
+
+> **⚠️ No fabricated data.** Every shot must show *real* Quil output from a real
+> session. Don't mock prices, fake a session id into a screenshot, or doctor a
+> count. Use a throwaway demo repo and real commands. Redact only personal paths
+> and secrets (see "Redaction").
+
+---
+
+## Global capture settings (keep all assets consistent)
+
+| Setting | Value | Why |
+|---|---|---|
+| Font | **JetBrains Mono** | Matches the quil.cc brand font |
+| Font size | 18–22 | Legible when scaled down on Medium / README |
+| Theme | Dark, warm — background `#080402` (the site `theme-color`), accent flame `#ff6a2b`-ish | Matches the site's "ember" palette |
+| Terminal width | ~110 cols | Wide enough for splits, not so wide text shrinks |
+| Output width | **1280px** (hero/README), **1200×630** (OG), ≤1400px (Medium inline) | Standard targets |
+| Format | **GIF** for motion (hero), **PNG** for static | Smaller static = faster pages |
+| Cursor | Block, blink off for stills | Cleaner frames |
+
+---
+
+## Shot list
+
+| # | Asset | Used by | Type | Content |
+|---|---|---|---|---|
+| 1 | **Hero restore** | Article top, README hero, OG image | GIF | Cold `quil` start restoring a real persisted workspace: layout rebuilds, panes drop into their dirs, a Claude Code pane shows a resume line |
+| 2 | **Typed panes** | Article (#2), /features | PNG | One tab: 2 Claude Code panes + a shell, each border showing its CWD; one pane border green (work-done indicator) |
+| 3 | **Quil resume close-up** | Article (#3) | PNG | A single Claude Code pane just after restore, showing the `claude --resume <id>` line / "resuming" state |
+| 4 | **Pane setup dialog** | /features, /plugins | PNG | `Ctrl+N` → Claude Code → setup dialog: directory browser + the permission-mode toggle |
+| 5 | **Notification sidebar** | /features | PNG | `Alt+N` open with a few real events (process exit, agent idle) |
+| 6 | **vs split** | /vs/tmux, /vs/zellij | PNG | Clean 2x2 split showing tmux-style nested layout |
+| 7 | **MCP in a client** | /features, article (optional) | PNG | Claude Desktop (or Claude Code) calling a Quil MCP tool, e.g. `list_panes` returning real panes |
+
+The **hero GIF (1) doubles as the OG/social image** — grab a clean single frame from
+it (1200×630) for `og/home.png` and the GitHub social-preview upload.
+
+---
+
+## VHS tapes (starting points — adjust paths/repo to your demo)
+
+### `tape/hero-restore.tape`  → Shot 1
+
+> This captures a **real** restore. Pre-seed a Quil workspace (open a couple of
+> panes + a Claude Code pane, let it persist), then this tape records a fresh
+> `quil` launch reattaching it. It is NOT a simulated/faked reboot — it shows the
+> genuine restore path. (A literal `reboot` can't run inside VHS; the cold `quil`
+> start is the honest stand-in and is what users actually type after a reboot.)
+
+```tape
+# hero-restore.tape
+Output marketing/assets/hero-reboot-restore.gif
+Set Theme { "name": "Quil", "background": "#080402", "foreground": "#e8e0d8" }
+Set FontFamily "JetBrains Mono"
+Set FontSize 20
+Set Width 1280
+Set Height 720
+Set Padding 24
+Set TypingSpeed 60ms
+
+# Show the "after reboot" cold prompt
+Type "# fresh boot — workspace is gone from memory, persisted on disk"
+Enter
+Sleep 1s
+Type "quil"
+Enter
+Sleep 4s        # let the layout rebuild + ghost buffers replay + claude --resume fire
+Sleep 3s        # hold on the restored workspace
+```
+
+### `tape/typed-panes.tape`  → Shot 2 (still)
+
+```tape
+# typed-panes.tape  — capture a still frame from an already-arranged workspace
+Output marketing/assets/typed-panes.png
+Set Theme { "name": "Quil", "background": "#080402", "foreground": "#e8e0d8" }
+Set FontFamily "JetBrains Mono"
+Set FontSize 20
+Set Width 1280
+Set Height 720
+Set Padding 24
+
+Type "quil"
+Enter
+Sleep 4s
+Screenshot marketing/assets/typed-panes.png
+```
+
+For the interactive dialogs (Shots 4–5) you *can* script the keypresses in VHS:
+
+```tape
+# e.g. inside a running quil, open the setup dialog
+Ctrl+N
+Sleep 800ms
+Screenshot marketing/assets/pane-setup-dialog.png
+```
+
+…but these are often easier to grab manually (below) since they depend on live
+state.
+
+---
+
+## Manual capture (Shots 4–7, or anything VHS can't script)
+
+1. Launch Quil in a clean terminal at the global settings above.
+2. Arrange the exact state you want (open the dialog, the sidebar, the splits).
+3. Grab the window:
+   - **Windows:** `Win+Shift+S` (region) → save PNG.
+   - **macOS:** `Cmd+Shift+4` then `Space` to grab the window.
+   - **Linux:** `flameshot gui` or `grim -g "$(slurp)"`.
+4. Crop to content, keep the dark background bleed for a framed look.
+
+For the **MCP shot (7)**: open Claude Desktop with Quil's MCP server wired up
+(`{"mcpServers":{"quil":{"command":"quil","args":["mcp"]}}}`), ask it to list
+panes, and screenshot the tool call + result. Real tool output only.
+
+---
+
+## Redaction (before publishing any shot)
+
+- Replace your real home path with a neutral one (demo user, e.g. `~/code/demo`).
+- Use a throwaway demo repo name — not a client/private project.
+- No real API keys, tokens, `.env` contents, or `stripe listen` secrets in frame.
+- Session ids are fine to show (they're random UUIDs, not secrets) — but double-check
+  nothing sensitive scrolled into the visible ghost buffer.
+
+---
+
+## Where each asset lands
+
+| Asset | Destination |
+|---|---|
+| Hero GIF | Article top + `README.md` (under the title) + a single frame → GitHub Settings → Social preview (1280×640) |
+| OG frame (1200×630) | `site/public/og/home.png` (replaces current) |
+| Article images | the `marketing/articles/.../assets/` refs, then upload into the Medium import / quil.cc blog |
+| /features, /plugins, /vs images | `site/public/` and reference from the relevant `.astro` pages |

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -79,6 +79,9 @@ const routeToFile = {
   "/features": "src/pages/features.astro",
   "/plugins": "src/pages/plugins.astro",
   "/docs": "src/pages/docs.astro",
+  "/blog": "src/pages/blog/index.astro",
+  "/blog/resume-claude-code-session-after-reboot":
+    "src/content/blog/resume-claude-code-session-after-reboot.md",
   "/legal": "src/pages/legal.astro",
   "/vs/tmux": "src/pages/vs/tmux.astro",
   "/vs/zellij": "src/pages/vs/zellij.astro",

--- a/site/src/components/Header.astro
+++ b/site/src/components/Header.astro
@@ -18,6 +18,7 @@ const navLinks = [
   { href: "/plugins",  label: "plugins"  },
   { href: "/install",  label: "install"  },
   { href: "/docs",     label: "docs"     },
+  { href: "/blog",     label: "blog"     },
 ];
 
 const compareLinks = [

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -1,0 +1,39 @@
+// Astro content collections.
+//
+// `blog` powers /blog and /blog/<slug>. Posts are plain Markdown under
+// src/content/blog/. The glob loader is the Astro 5 way (the old
+// `type: "content"` form is gone). Each post's id is its filename
+// without extension, which becomes the URL slug.
+//
+// SEO note: on quil.cc a post is self-canonical (BaseHead derives the
+// canonical from the path). The `canonicalOverride` field exists only
+// for the rare case where a post was first published elsewhere and we
+// want to point our copy at that origin — normally leave it unset, and
+// when syndicating to Medium/Dev.to set THEIR canonical to our URL.
+
+import { defineCollection, z } from "astro:content";
+import { glob } from "astro/loaders";
+
+const blog = defineCollection({
+  loader: glob({ pattern: "**/[^_]*.md", base: "./src/content/blog" }),
+  schema: z.object({
+    /** Post title — also the <h1>, the <title> stem, and og:title. */
+    title: z.string(),
+    /** 120–160 char meta description, unique per post. */
+    description: z.string(),
+    /** Publish date (ISO, e.g. 2026-06-14). Drives sort order + schema. */
+    pubDate: z.coerce.date(),
+    /** Optional last-updated date for the BlogPosting schema. */
+    updatedDate: z.coerce.date().optional(),
+    /** Per-post OG image under public/, e.g. /blog/img/foo.png. */
+    ogImage: z.string().optional(),
+    /** Target + secondary keywords (Bing/Yandex meta; Google ignores). */
+    keywords: z.array(z.string()).default([]),
+    /** Hide from listing + sitemap until ready. */
+    draft: z.boolean().default(false),
+    /** Rare: point our copy's canonical at an external origin. */
+    canonicalOverride: z.string().optional(),
+  }),
+});
+
+export const collections = { blog };

--- a/site/src/content/blog/resume-claude-code-session-after-reboot.md
+++ b/site/src/content/blog/resume-claude-code-session-after-reboot.md
@@ -1,0 +1,112 @@
+---
+title: "How to Resume Your Claude Code Session After a Reboot — Automatically"
+description: "Reboot your machine and your Claude Code conversation is gone. Here's the manual fix with claude --resume, why it doesn't scale, and how to make it automatic."
+pubDate: 2026-06-14
+ogImage: "/blog/img/hero-reboot-restore.png"
+keywords:
+  - "resume claude code session after reboot"
+  - "claude code session lost after restart"
+  - "claude code continue session"
+  - "tmux that survives reboot"
+  - "reboot-proof terminal"
+draft: false
+---
+
+*You rebooted. Claude Code forgot everything. Here's the manual fix, why it falls apart across a real project, and how to make session resume happen by itself.*
+
+![Cold boot, then `quil` restoring panes and a Claude Code session](/blog/img/hero-reboot-restore.gif)
+
+You were three hours into a refactor. Claude Code knew the whole plan — the files it had touched, the decisions you'd made together, the half-finished migration it was walking through. Then you installed an OS update, the machine rebooted, and you opened a fresh terminal to… nothing. Empty prompt. The conversation, and all of its context, gone.
+
+This is one of the most common papercuts of working with an AI coding agent day to day, and it has a real fix. Let's start with the manual one, then make it disappear.
+
+## Why the session vanishes
+
+Claude Code keeps each conversation as a session on your local machine. The transcript lives as a JSONL file under `~/.claude/projects/<your-project>/<session-id>.jsonl`. The session itself, though, is tied to the *running* `claude` process in your terminal.
+
+When you reboot:
+
+- Every terminal process dies, including `claude`.
+- Your terminal multiplexer (if you use one) dies too — `tmux` and `zellij` survive a disconnected SSH session, but **not** a full host reboot.
+- The transcript file survives on disk, but nothing reattaches to it automatically. You're staring at a clean shell.
+
+So the *data* is still there. The problem is reconnecting to it.
+
+## The manual fix: `claude --resume`
+
+Claude Code ships exactly the tool you need. From the project's directory:
+
+```bash
+# Continue the most recent session in this folder
+claude --continue          # or the short form: claude -c
+
+# Pick from a list of past sessions in this folder
+claude --resume
+
+# Jump straight to a specific session if you know its id
+claude --resume 8f2e1c4a-...
+```
+
+`claude --continue` is the fast path — it grabs the latest session for the current working directory and drops you back in mid-conversation. `claude --resume` opens a picker so you can choose an older one.
+
+If you ever need to find a session id by hand, they're right here:
+
+```bash
+ls ~/.claude/projects/
+# one directory per project, named after the project's path
+ls ~/.claude/projects/<your-project>/
+# *.jsonl — one file per session; the filename is the session id
+```
+
+For a single project on a single terminal, that's the whole story. `claude -c`, you're back, done.
+
+## Where it falls apart
+
+The manual fix is fine until your setup looks like an actual workday:
+
+- **Multiple projects.** You had Claude Code running in four repos across four tabs. After a reboot you have to `cd` into each one and `claude -c`, four times, in the right directories.
+- **Multiple agents in parallel.** Running two or three Claude Code panes against the same monorepo? `--continue` only knows "the most recent session for this folder." It can't tell your three concurrent sessions apart, so you're back to hunting session ids in `~/.claude/projects/`.
+- **Your whole workspace is gone too**, not just the AI. The split layout, the working directories, the scrollback, the `stripe listen` pane, the SSH session — all of it has to be rebuilt by hand before you even get to the `claude -c` step.
+- **Compaction and `/clear` rotate the id.** The session id you wrote down an hour ago may not be the current one anymore.
+
+People reach for `tmux-resurrect` or `tmux-continuum` here, and they help — but only with the *terminal* half. They restore your panes, layout, and working directories. They do **not** know anything about Claude Code, so they won't reattach the agent's session. You still land in each restored pane and run `claude -c` yourself. And again: those tools restore a tmux *server* that a reboot already killed, so you're relying on their save-and-respawn cycle, not true reboot survival.
+
+What you actually want is for the machine to come back, you type one command, and **everything** — panes, directories, *and* each Claude Code conversation — is already where you left it.
+
+## Making it automatic
+
+This is the specific problem [Quil](/) was built to solve. Quil is an open-source terminal multiplexer (a tmux alternative) with one defining trait: it survives a full host reboot, and it treats an AI coding session as first-class state to be restored — not just a pane to respawn.
+
+Here's the mechanism, because the "how" matters for trusting it:
+
+1. When you open a Claude Code pane, Quil registers a Claude Code **SessionStart hook** for that pane (via `claude --settings`, without touching your global `~/.claude/settings.json`).
+2. Every time Claude mints or rotates a session id — on launch, on `/clear`, on `/resume`, on compaction — the hook records the *current* id for that pane.
+3. Quil continuously snapshots your whole workspace: the tab and pane layout, each pane's working directory, scrollback, and the recorded session ids.
+4. After a reboot, you type `quil`. It rebuilds the layout, drops each pane back into its directory, and runs `claude --resume <the-recorded-id>` for every Claude Code pane — automatically, with the *post-rotation* id, not a stale one.
+
+![Two Claude Code panes mid-conversation plus a shell, each pane border labeled with its working directory](/blog/img/typed-panes.png)
+
+Because the id is captured by a hook rather than guessed, it works for the hard cases the manual path chokes on: several agents in one repo, sessions that compacted while you were away, projects spread across many tabs. OpenCode sessions are tracked the same way.
+
+The target boot-to-productive time is under 30 seconds, and ghost buffers replay the last 500 lines of each pane instantly while the shells re-initialise — so you're reading where you left off before everything has even finished spawning.
+
+## When you *don't* need this
+
+Honesty matters more than a pitch, so: if you run a single Claude Code session in a single project and a reboot is a rare event for you, `claude --continue` is genuinely all you need. Don't add a tool to solve a problem you don't have.
+
+Quil earns its place when **persistence across reboots and juggling multiple agents/projects** is a daily reality — when "rebuild my whole workspace and reattach every agent by hand" is a tax you pay often enough to want it gone.
+
+## TL;DR
+
+- Claude Code sessions live on disk (`~/.claude/projects/`) but the running process dies on reboot.
+- Manual fix: `claude --continue` (latest) or `claude --resume` (pick one) from the project directory.
+- It doesn't scale to multiple projects/agents, and it doesn't restore the rest of your workspace.
+- To make it automatic across reboots — layout, directories, *and* each AI session — use a reboot-proof multiplexer like [Quil](/install/).
+
+Install Quil (Linux/macOS):
+
+```bash
+curl -sSfL https://raw.githubusercontent.com/artyomsv/quil/master/scripts/install.sh | sh
+```
+
+*Quil is free and open source (MIT). [quil.cc](/) · [GitHub](https://github.com/artyomsv/quil)*

--- a/site/src/pages/blog/[...slug].astro
+++ b/site/src/pages/blog/[...slug].astro
@@ -1,0 +1,197 @@
+---
+/**
+ * Blog post page — renders one entry from the `blog` content
+ * collection. Wires per-post SEO (title/description/OG/keywords) plus
+ * BlogPosting + BreadcrumbList JSON-LD through the shared Page layout.
+ *
+ * On quil.cc each post is self-canonical (BaseHead derives it from the
+ * path). When syndicating to Medium / Dev.to / Hashnode, set THEIR
+ * canonical URL to this page's URL so we keep the ranking.
+ */
+import { getCollection, render } from "astro:content";
+import Page from "@/layouts/Page.astro";
+import { SITE, canonical } from "@/data/seo";
+import { breadcrumbSchema } from "@/data/schemas";
+
+export async function getStaticPaths() {
+  const posts = await getCollection("blog", ({ data }) => !data.draft);
+  return posts.map((post) => ({
+    params: { slug: post.id },
+    props: { post },
+  }));
+}
+
+const { post } = Astro.props;
+const { Content } = await render(post);
+
+const path = `/blog/${post.id}/`;
+const published = post.data.pubDate.toISOString();
+const modified = (post.data.updatedDate ?? post.data.pubDate).toISOString();
+
+const blogPosting = {
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "@id": canonical(path) + "#post",
+  headline: post.data.title,
+  description: post.data.description,
+  datePublished: published,
+  dateModified: modified,
+  author: {
+    "@type": "Person",
+    "@id": SITE.author.url,
+    name: SITE.author.name,
+    url: SITE.author.url,
+  },
+  publisher: { "@id": SITE.url + "/#organization" },
+  mainEntityOfPage: canonical(path),
+  url: canonical(path),
+  inLanguage: SITE.htmlLang,
+  keywords: post.data.keywords,
+  ...(post.data.ogImage ? { image: SITE.url + post.data.ogImage } : {}),
+};
+
+const schemas = [
+  blogPosting,
+  breadcrumbSchema([
+    { name: "Home", path: "/" },
+    { name: "Blog", path: "/blog" },
+    { name: post.data.title, path },
+  ]),
+];
+
+// Human-readable date for the byline.
+const displayDate = post.data.pubDate.toLocaleDateString("en-US", {
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+  timeZone: "UTC",
+});
+---
+<Page
+  title={post.data.title}
+  description={post.data.description}
+  path={path}
+  ogImage={post.data.ogImage}
+  keywords={post.data.keywords}
+  schemas={schemas}
+>
+  <article class="blog-article">
+    <nav class="blog-crumbs" aria-label="Breadcrumb">
+      <a href="/blog/">blog</a>
+      <span aria-hidden="true">/</span>
+      <span>{post.data.title}</span>
+    </nav>
+
+    <header class="blog-head">
+      <h1>{post.data.title}</h1>
+      <p class="blog-meta">
+        <time datetime={published}>{displayDate}</time>
+      </p>
+    </header>
+
+    <div class="blog-body">
+      <Content />
+    </div>
+
+    <footer class="blog-foot">
+      <a href="/install/" class="btn btn-primary"><span>▸ install quil</span></a>
+      <a href="/blog/" class="btn btn-ghost">← all posts</a>
+    </footer>
+  </article>
+</Page>
+
+<style>
+  .blog-article {
+    max-width: 46rem;
+    margin: 0 auto;
+    padding: 4rem 1.5rem 6rem;
+  }
+  .blog-crumbs {
+    font-size: 0.8rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    opacity: 0.6;
+    margin-bottom: 2rem;
+    display: flex;
+    gap: 0.6rem;
+  }
+  .blog-crumbs a { color: inherit; text-decoration: none; }
+  .blog-crumbs a:hover { color: var(--flame, #ff6a2b); }
+
+  .blog-head h1 {
+    font-size: clamp(1.9rem, 4vw, 2.8rem);
+    line-height: 1.1;
+    margin: 0 0 0.75rem;
+    letter-spacing: -0.01em;
+  }
+  .blog-meta {
+    font-size: 0.9rem;
+    opacity: 0.6;
+    margin: 0 0 2.5rem;
+  }
+
+  /* Rendered Markdown — scoped styles don't reach <Content/>, so target
+     the body via :global() under the wrapper. */
+  .blog-body :global(h2) {
+    font-size: 1.5rem;
+    margin: 2.5rem 0 0.9rem;
+    line-height: 1.2;
+  }
+  .blog-body :global(h3) {
+    font-size: 1.2rem;
+    margin: 2rem 0 0.7rem;
+  }
+  .blog-body :global(p),
+  .blog-body :global(ul),
+  .blog-body :global(ol) {
+    font-size: 1.05rem;
+    line-height: 1.75;
+    margin: 0 0 1.25rem;
+  }
+  .blog-body :global(ul),
+  .blog-body :global(ol) { padding-left: 1.4rem; }
+  .blog-body :global(li) { margin-bottom: 0.4rem; }
+  .blog-body :global(a) {
+    color: var(--flame, #ff6a2b);
+    text-underline-offset: 3px;
+  }
+  .blog-body :global(strong) { font-weight: 600; }
+  .blog-body :global(img) {
+    max-width: 100%;
+    height: auto;
+    border-radius: 10px;
+    margin: 2rem 0;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+  }
+  .blog-body :global(blockquote) {
+    border-left: 3px solid var(--flame, #ff6a2b);
+    padding-left: 1rem;
+    margin: 1.5rem 0;
+    opacity: 0.85;
+  }
+  /* Inline code; fenced blocks are themed by Shiki at build time. */
+  .blog-body :global(:not(pre) > code) {
+    font-family: "JetBrains Mono", ui-monospace, monospace;
+    font-size: 0.9em;
+    background: rgba(255, 255, 255, 0.07);
+    padding: 0.1em 0.35em;
+    border-radius: 4px;
+  }
+  .blog-body :global(pre) {
+    border-radius: 10px;
+    padding: 1rem 1.1rem;
+    overflow-x: auto;
+    margin: 1.5rem 0;
+    font-size: 0.92rem;
+    line-height: 1.6;
+  }
+
+  .blog-foot {
+    margin-top: 3.5rem;
+    padding-top: 2rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+  }
+</style>

--- a/site/src/pages/blog/index.astro
+++ b/site/src/pages/blog/index.astro
@@ -1,0 +1,99 @@
+---
+/**
+ * Blog index — lists published posts newest-first. Pure static list;
+ * the per-post pages live at /blog/<slug>/ via [...slug].astro.
+ */
+import { getCollection } from "astro:content";
+import Page from "@/layouts/Page.astro";
+
+const posts = (await getCollection("blog", ({ data }) => !data.draft)).sort(
+  (a, b) => b.data.pubDate.getTime() - a.data.pubDate.getTime(),
+);
+
+const seo = {
+  title: "Blog",
+  description:
+    "Guides and notes on reboot-proof terminal workflows, running Claude Code and OpenCode across restarts, and getting more out of Quil.",
+  path: "/blog",
+  keywords: [
+    "quil blog",
+    "claude code tips",
+    "terminal multiplexer guides",
+    "reboot-proof terminal",
+  ],
+};
+
+function fmt(date: Date): string {
+  return date.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+}
+---
+<Page {...seo}>
+  <section class="blog-index">
+    <header class="blog-index-head">
+      <h1>Blog</h1>
+      <p>Reboot-proof workflows, AI session continuity, and Quil deep-dives.</p>
+    </header>
+
+    {posts.length === 0 ? (
+      <p class="blog-empty">No posts yet — check back soon.</p>
+    ) : (
+      <ul class="blog-list">
+        {posts.map((post) => (
+          <li class="blog-card">
+            <a href={`/blog/${post.id}/`}>
+              <time datetime={post.data.pubDate.toISOString()}>
+                {fmt(post.data.pubDate)}
+              </time>
+              <h2>{post.data.title}</h2>
+              <p>{post.data.description}</p>
+              <span class="read">Read →</span>
+            </a>
+          </li>
+        ))}
+      </ul>
+    )}
+  </section>
+</Page>
+
+<style>
+  .blog-index {
+    max-width: 46rem;
+    margin: 0 auto;
+    padding: 4rem 1.5rem 6rem;
+  }
+  .blog-index-head h1 {
+    font-size: clamp(2rem, 5vw, 3rem);
+    margin: 0 0 0.5rem;
+  }
+  .blog-index-head p { opacity: 0.65; margin: 0 0 3rem; }
+
+  .blog-list { list-style: none; margin: 0; padding: 0; display: grid; gap: 1.25rem; }
+  .blog-card a {
+    display: block;
+    text-decoration: none;
+    color: inherit;
+    padding: 1.5rem;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 12px;
+    transition: border-color 0.15s ease, transform 0.15s ease;
+  }
+  .blog-card a:hover {
+    border-color: var(--flame, #ff6a2b);
+    transform: translateY(-2px);
+  }
+  .blog-card time {
+    font-size: 0.8rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    opacity: 0.55;
+  }
+  .blog-card h2 { font-size: 1.35rem; margin: 0.5rem 0 0.6rem; line-height: 1.25; }
+  .blog-card p { opacity: 0.75; margin: 0 0 0.9rem; line-height: 1.6; }
+  .blog-card .read { color: var(--flame, #ff6a2b); font-weight: 600; font-size: 0.9rem; }
+  .blog-empty { opacity: 0.6; }
+</style>


### PR DESCRIPTION
Adds a blog to quil.cc and the first article, as part of the SEO/content push.

## Why a blog (and why publish here first)
The keyword-gap analysis flagged **"resume claude code session after reboot"** as the single most winnable query — the SERP is just GitHub issues and personal blogs, and it maps exactly to Quil's headline feature. Publishing on `quil.cc/blog` first (then syndicating to Medium/Dev.to/Hashnode with `rel=canonical` back here) keeps the ranking on our domain instead of handing it to Medium.

## What's in here
- **`src/content.config.ts`** — `blog` content collection (Astro 5 `glob` loader) with a zod schema: `title`, `description`, `pubDate`, `keywords`, `ogImage`, `draft`.
- **`/blog`** index (newest-first) and **`/blog/<slug>`** post pages.
- Post page emits **BlogPosting + BreadcrumbList JSON-LD** and is self-canonical via the shared `Page` layout.
- **First post**: *How to Resume Your Claude Code Session After a Reboot — Automatically*. Honest-first structure (real `claude --resume` manual fix → where it breaks → Quil automates it → "when you don't need this").
- **Header**: new `blog` nav link (internal linking + crawl discovery).
- **astro.config**: mapped the two blog routes for accurate sitemap `lastmod`; `@astrojs/sitemap` auto-includes the new URLs.
- **`marketing/assets/screenshot-plan.md`**: reproducible VHS capture plan for the article images, README hero, and OG image.

## Before announcing
The post references 3 images under `/blog/img/` (`hero-reboot-restore.gif`, `hero-reboot-restore.png`, `typed-panes.png`) that still need capturing — see `screenshot-plan.md`. **The page builds and the text is publish-ready without them**; those slots just render as broken images until the assets land.

## Verification
Content-collection + new routes couldn't be built locally (no Astro toolchain in the authoring env) — relying on CI / the Pages preview build to confirm `astro check` + build pass.