### PR TITLE
feat(site): wire CDN screenshots into blog, README, and features

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,28 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Go](https://img.shields.io/badge/Go-1.25-00ADD8.svg)](https://go.dev)
 [![Platform](https://img.shields.io/badge/Platform-Linux%20%7C%20macOS%20%7C%20Windows-lightgrey.svg)](#install)
-[![MCP](https://img.shields.io/badge/MCP-17%20tools-orange.svg)](docs/mcp.md)
+[![MCP](https://img.shields.io/badge/MCP-18%20tools-orange.svg)](docs/mcp.md)
 
 ---
 
 A terminal multiplexer built for developers who orchestrate 5–10 sessions per project across AI assistants, build watchers, webhook tunnels, and SSH connections. Unlike tmux, Quil understands **projects** and **typed panes**: it persists your entire workspace across reboots, auto-resumes AI conversations by session id, and lets your AI assistant drive your terminal over [MCP](docs/mcp.md).
 
 Type `quil` after a reboot — every tab, pane, working directory, layout split, and AI conversation is right where you left it.
+
+<p align="center">
+  <img src="https://cdn.stukans.com/quil/screenshots/pane-restoration-1280.png"
+       alt="Quil restoring tabs, panes, and Claude Code sessions after a reboot" width="880">
+</p>
+
+## See it
+
+| Survives a full reboot | AI drives your terminal |
+|:---:|:---:|
+| <img src="https://cdn.stukans.com/quil/screenshots/pane-restoration-800.webp" alt="Panes and AI sessions restoring after reboot" width="420"> | <img src="https://cdn.stukans.com/quil/screenshots/claude-code-quil-mcp-800.webp" alt="Claude Code talking to the Quil MCP server" width="420"> |
+| Panes, working dirs, and AI sessions snap back in ~30s. | Expose Quil over MCP — agents list panes, read output, send keys. |
+| **Many projects, one window** | **Typed panes** |
+| <img src="https://cdn.stukans.com/quil/screenshots/focus-screen-800.webp" alt="Focus mode across a dozen project tabs" width="420"> | <img src="https://cdn.stukans.com/quil/screenshots/claude-code-setup-dialog-800.webp" alt="Claude Code pane setup dialog with directory browser and toggles" width="420"> |
+| Focus mode + a dozen project tabs. | Per-type setup: dir browser, resume strategy, permission toggles. |
 
 ## Install
 

--- a/site/src/components/BaseHead.astro
+++ b/site/src/components/BaseHead.astro
@@ -50,6 +50,11 @@ const ogImageURL = SITE.url + (ogImage ?? SITE.defaultOgImage);
 <meta http-equiv="X-Content-Type-Options" content="nosniff" />
 <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=(), interest-cohort=()" />
 
+<!-- CDN preconnect — screenshots/images are served from cdn.stukans.com.
+     Allowed by the CSP img-src 'self' data: https: rule; a preconnect is a
+     resource hint (not a fetch), so connect-src 'self' doesn't block it. -->
+<link rel="preconnect" href="https://cdn.stukans.com" crossorigin />
+
 <!-- Fonts: Inter for body, JetBrains Mono for code -->
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/site/src/content/blog/resume-claude-code-session-after-reboot.md
+++ b/site/src/content/blog/resume-claude-code-session-after-reboot.md
@@ -2,7 +2,7 @@
 title: "How to Resume Your Claude Code Session After a Reboot — Automatically"
 description: "Reboot your machine and your Claude Code conversation is gone. Here's the manual fix with claude --resume, why it doesn't scale, and how to make it automatic."
 pubDate: 2026-06-14
-ogImage: "/blog/img/hero-reboot-restore.png"
+ogImage: "https://cdn.stukans.com/quil/screenshots/pane-restoration-og.png"
 keywords:
   - "resume claude code session after reboot"
   - "claude code session lost after restart"
@@ -14,7 +14,7 @@ draft: false
 
 *You rebooted. Claude Code forgot everything. Here's the manual fix, why it falls apart across a real project, and how to make session resume happen by itself.*
 
-![Cold boot, then `quil` restoring panes and a Claude Code session](/blog/img/hero-reboot-restore.gif)
+![Quil restoring tabs, panes, and Claude Code sessions after a reboot](https://cdn.stukans.com/quil/screenshots/pane-restoration-1280.webp)
 
 You were three hours into a refactor. Claude Code knew the whole plan — the files it had touched, the decisions you'd made together, the half-finished migration it was walking through. Then you installed an OS update, the machine rebooted, and you opened a fresh terminal to… nothing. Empty prompt. The conversation, and all of its context, gone.
 
@@ -84,7 +84,7 @@ Here's the mechanism, because the "how" matters for trusting it:
 3. Quil continuously snapshots your whole workspace: the tab and pane layout, each pane's working directory, scrollback, and the recorded session ids.
 4. After a reboot, you type `quil`. It rebuilds the layout, drops each pane back into its directory, and runs `claude --resume <the-recorded-id>` for every Claude Code pane — automatically, with the *post-rotation* id, not a stale one.
 
-![Two Claude Code panes mid-conversation plus a shell, each pane border labeled with its working directory](/blog/img/typed-panes.png)
+![Quil in focus mode with a dozen project tabs — many AI sessions, one workspace](https://cdn.stukans.com/quil/screenshots/focus-screen-1280.webp)
 
 Because the id is captured by a hook rather than guessed, it works for the hard cases the manual path chokes on: several agents in one repo, sessions that compacted while you were away, projects spread across many tabs. OpenCode sessions are tracked the same way.
 

--- a/site/src/data/features.ts
+++ b/site/src/data/features.ts
@@ -26,12 +26,15 @@ export interface Feature {
   blurb: string;
   detail: string[];
   category: "persistence" | "interaction" | "ai" | "extensibility" | "observability";
+  /** Optional CDN screenshot (…-800.webp) rendered beside the feature on /features. */
+  image?: string;
 }
 
 export const features: Feature[] = [
   // --- Persistence ---------------------------------------------------
   {
     slug: "reboot-proof-sessions",
+    image: "https://cdn.stukans.com/quil/screenshots/pane-restoration-800.webp",
     icon: "refresh-ccw",
     title: "Reboot-proof sessions",
     blurb:
@@ -74,6 +77,7 @@ export const features: Feature[] = [
   },
   {
     slug: "mcp-server",
+    image: "https://cdn.stukans.com/quil/screenshots/claude-code-quil-mcp-800.webp",
     icon: "zap",
     title: "MCP server for AI agents",
     blurb:
@@ -120,6 +124,7 @@ export const features: Feature[] = [
   // --- Interaction ---------------------------------------------------
   {
     slug: "typed-panes",
+    image: "https://cdn.stukans.com/quil/screenshots/claude-code-setup-dialog-800.webp",
     icon: "layers",
     title: "Typed panes",
     blurb:
@@ -135,6 +140,7 @@ export const features: Feature[] = [
   },
   {
     slug: "tmux-splits",
+    image: "https://cdn.stukans.com/quil/screenshots/tui-panes-800.webp",
     icon: "layout-panel-left",
     title: "tmux-style splits with spatial navigation",
     blurb:
@@ -152,6 +158,7 @@ export const features: Feature[] = [
   },
   {
     slug: "pane-notes",
+    image: "https://cdn.stukans.com/quil/screenshots/focus-with-notes-800.webp",
     icon: "notebook-pen",
     title: "Pane notes",
     blurb:
@@ -194,6 +201,7 @@ export const features: Feature[] = [
   },
   {
     slug: "lazygit-overlay",
+    image: "https://cdn.stukans.com/quil/screenshots/lazygit-integration-800.webp",
     icon: "code",
     title: "Lazygit overlay",
     blurb:

--- a/site/src/pages/features.astro
+++ b/site/src/pages/features.astro
@@ -109,6 +109,15 @@ for (const feature of features) {
                       <li>{bullet}</li>
                     ))}
                   </ul>
+                  {feature.image && (
+                    <img
+                      class="feat-shot"
+                      src={feature.image}
+                      alt={`${feature.title} — Quil screenshot`}
+                      loading="lazy"
+                      decoding="async"
+                    />
+                  )}
                 </div>
               </div>
             ))}
@@ -134,3 +143,16 @@ for (const feature of features) {
     </div>
   </section>
 </Page>
+
+<style>
+  /* Feature screenshots (opt-in via the data layer's `image` field). */
+  .feat-shot {
+    display: block;
+    width: 100%;
+    max-width: 640px;
+    height: auto;
+    margin-top: 18px;
+    border-radius: 10px;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+  }
+</style>


### PR DESCRIPTION
Wires the cropped, CDN-hosted screenshots into the site/blog/README — the deferred half of the screenshot work.

## Changes
- **Blog post** — fixes the **broken placeholder images** that are live right now (`/blog/img/*` 404s). Hero → `pane-restoration-1280.webp`, second image → `focus-screen-1280.webp`, `og:image` → `pane-restoration-og.png`.
- **README** — adds a hero shot under the intro + a "See it" 2×2 highlights grid (restore · MCP · focus · setup), and fixes the **stale MCP badge** (17 → 18 tools).
- **/features** — new optional `image` field in `data/features.ts`, rendered as a `.feat-shot` beside the six headline features (reboot-proof sessions, MCP server, typed panes, lazygit overlay, pane notes, splits). Lazy-loaded.
- **BaseHead** — `preconnect` to `cdn.stukans.com` (kills the cross-origin handshake on first image; allowed by the existing `img-src 'self' data: https:` CSP).

All images are width-versioned WebP/PNG served from the DO Space behind `cdn.stukans.com` (cropped + exported by `tools/imgproc`).

## Verification
`npm run build` (astro check + build) passes — 13 pages. Confirmed in `dist/` that the blog, features, and OG tags reference the CDN URLs and that **no `/blog/img/` placeholder paths remain**.

## Note
The MCP screenshot currently shows "17 tools" (older local build); captions avoid a hard number so there's no contradiction. Swap the master + re-run `tools/imgproc` when convenient.