### PR TITLE
fix(site): don't double-prefix absolute ogImage URLs

### DIFF
--- a/site/src/components/BaseHead.astro
+++ b/site/src/components/BaseHead.astro
@@ -22,7 +22,13 @@ const { title, description, path, ogImage, keywords } = Astro.props;
 
 const fullTitle = `${title} · ${SITE.name}`;
 const canonicalURL = canonical(path);
-const ogImageURL = SITE.url + (ogImage ?? SITE.defaultOgImage);
+// ogImage may be a site-relative path ("/og/home.png") or an absolute
+// URL (a CDN-hosted card). Only prefix the origin for relative paths,
+// otherwise an absolute URL gets double-prefixed (https://quil.cchttps://…).
+const ogImageURL =
+  ogImage && /^https?:\/\//.test(ogImage)
+    ? ogImage
+    : SITE.url + (ogImage ?? SITE.defaultOgImage);
 ---
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
The blog post's social card is broken on the live site:

```
og:image = "https://quil.cc​https://cdn.stukans.com/quil/screenshots/pane-restoration-og.png"
```

`BaseHead` unconditionally prefixed `SITE.url` onto `ogImage`, which is right for site-relative paths (`/og/home.png`) but double-prefixes the blog post's absolute CDN card URL. Affects `og:image` and `twitter:image`.

**Fix:** only prefix the origin when `ogImage` is relative; pass absolute `http(s)` URLs through unchanged. Backward-compatible — every existing page uses a relative `ogImage` and is unaffected.

**Verified** (local build): blog `og:image` → `https://cdn.stukans.com/quil/screenshots/pane-restoration-og.png`; home `og:image` → `https://quil.cc/og/home.png`. `astro check` + build pass.