### PR TITLE
fix(ci): guarantee release notes and fix the Pages deploy race

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,21 +207,26 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set release notes
-        # No `if: hashFiles(...)` guard here. Earlier versions used
-        # `hashFiles('/tmp/release-notes.md') != ''` which always evaluated
-        # false because /tmp is outside GITHUB_WORKSPACE — the step was
-        # silently skipped on every release. The inner `[ -s ... ]` check
-        # is the real safety net.
+        # The release body must NEVER be empty. The CHANGELOG section is the
+        # preferred source, but when a PR ships without a `## [Unreleased]`
+        # entry that section is empty (this produced blank release pages on
+        # v1.29.0 and v1.31.0). In that case we fall back to GitHub's
+        # commit/PR-generated notes so every release has a description.
         env:
           VERSION: ${{ needs.release.outputs.version }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ -s release-notes.md ]; then
-            gh release edit "v${VERSION}" --notes-file release-notes.md
-            echo "::notice::Release notes applied to v${VERSION}"
-          else
-            echo "::warning::Release notes file is empty — skipping"
+          if [ ! -s release-notes.md ]; then
+            echo "::warning::CHANGELOG section for v${VERSION} is empty — generating notes from commits/PRs"
+            gh api --method POST "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+              -f tag_name="v${VERSION}" --jq .body > release-notes.md
           fi
+          if [ ! -s release-notes.md ]; then
+            echo "::error::Could not produce release notes for v${VERSION}"
+            exit 1
+          fi
+          gh release edit "v${VERSION}" --notes-file release-notes.md
+          echo "::notice::Release notes applied to v${VERSION}"
 
   # --- Site rebuild ---------------------------------------------------
   # Pushes made with GITHUB_TOKEN don't trigger other workflows, so
@@ -232,6 +237,16 @@ jobs:
     needs: release
     if: needs.release.outputs.skip != 'true' && needs.release.outputs.dry_run != 'true'
     runs-on: ubuntu-latest
+    # Share the "pages" concurrency group with site.yml. The same merge push
+    # triggers site.yml (which builds the PRE-bump commit → stale version pill)
+    # AND this job (which builds the tag → correct version). Without a shared
+    # group both deploy to github-pages and the stale one can win the race
+    # (v1.31.0 shipped but quil.cc kept showing 1.30.0). This job runs after the
+    # release job, so it enters the group last and supersedes/cancels site.yml's
+    # in-flight deploy — making the versioned deploy authoritative.
+    concurrency:
+      group: pages
+      cancel-in-progress: true
     permissions:
       contents: read
       pages: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.31.0] - 2026-06-18
 
+### Fixed
+
+- **Windows 10 input rendering** — typing in claude-code (and other TUIs) no
+  longer shows an extra space after the first character on Windows 10
+  (`Hello` → `H ello`). The Windows 10 inbox console host re-serializes
+  incremental screen updates incorrectly; Quil now bundles Microsoft's
+  OpenConsole (MIT) and hosts panes through it on Windows 10 only — Windows 11
+  keeps its built-in host, which is unaffected. Fail-safe: falls back to the
+  inbox host if the bundle is unavailable. See `docs/architecture.md` (ADR-25).
+
 ## [1.30.0] - 2026-06-17
 
 ### Added


### PR DESCRIPTION
## Summary

Two release-pipeline gaps caused **v1.31.0** to ship with an empty release page and left **quil.cc stuck on 1.30.0** even though the release succeeded. Both are fixed so it can't recur.

**1. Empty release notes** — when a PR merges without a `## [Unreleased]` CHANGELOG entry, the per-version section is empty, the extracted `release-notes.md` is empty, and the `Set release notes` step skipped → blank release body (also happened on v1.29.0). Now the step **falls back to GitHub's commit/PR-generated notes** when the CHANGELOG section is empty, and **fails the job** if it still can't produce a body. Releases can no longer be description-less.

**2. GitHub Pages deploy race** — the merge push triggers **both** `site.yml` (builds the *pre-bump* commit → stale version pill, 1.30.0) **and** the release's `deploy-site` job (builds the *tag* → correct 1.31.0). With no shared concurrency both deploy to the `github-pages` environment and the stale one was winning (verified: every Pages deployment was from a merge sha, never the `chore(release)` sha). `deploy-site` now joins `site.yml`'s **`pages` concurrency group** (`cancel-in-progress: true`); it runs after the release job, so it enters the group last and supersedes the in-flight stale deploy — the versioned deploy is authoritative.

Also backfills the empty `CHANGELOG [1.31.0]` section.

## Verification / context
- Root-caused from live evidence: `gh release view v1.31.0` body empty; `gh api .../deployments?environment=github-pages` all from merge shas; cache-busted `curl quil.cc` = 1.30.0; the Release run's `deploy-site` reported success yet didn't win.
- v1.31.0 was repaired out-of-band (notes set, clean site redeploy triggered); this PR prevents recurrence for **future** releases.

## Test Plan
- YAML is valid; the `Set release notes` fallback uses the `releases/generate-notes` API (always non-empty for a tagged release).
- Next release exercises both paths; a `workflow_dispatch` dry-run can validate the release job without publishing.