### PR TITLE
fix(ci): treat whitespace-only CHANGELOG section as empty

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -216,12 +216,16 @@ jobs:
           VERSION: ${{ needs.release.outputs.version }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ ! -s release-notes.md ]; then
+          # Treat a whitespace-only section as empty: the extract step emits a
+          # lone newline (1 byte) for an empty CHANGELOG section, which `[ -s ]`
+          # wrongly accepts as non-empty — that bug shipped v1.31.1 with a blank
+          # body. Strip whitespace and test for genuinely-empty content.
+          if [ -z "$(tr -d '[:space:]' < release-notes.md)" ]; then
             echo "::warning::CHANGELOG section for v${VERSION} is empty — generating notes from commits/PRs"
             gh api --method POST "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
               -f tag_name="v${VERSION}" --jq .body > release-notes.md
           fi
-          if [ ! -s release-notes.md ]; then
+          if [ -z "$(tr -d '[:space:]' < release-notes.md)" ]; then
             echo "::error::Could not produce release notes for v${VERSION}"
             exit 1
           fi


### PR DESCRIPTION
## Summary

Follow-up to #73. The empty-release-notes fallback guarded on `[ ! -s release-notes.md ]` (size 0), but the `Extract release notes` step emits a **lone newline (1 byte)** for an empty CHANGELOG section — so the guard never fired and **v1.31.1 still shipped a blank release body** (confirmed in the run log: `Release notes for v1.31.1 (1 bytes)`).

Fix: strip whitespace before testing emptiness, so the `generate-notes` fallback triggers for genuinely-empty sections (and the hard-fail guard also works).

The fallback **mechanism itself is proven** — v1.31.1's notes were repaired out-of-band using the exact `releases/generate-notes` API this step calls (now a 221-byte body listing #73).

## Test Plan
- Merging this cuts **v1.31.2** (its CHANGELOG section will be empty), which live-validates the corrected fallback: the release body should be auto-generated, non-empty notes.
- The deploy-race fix (#73) and site versioning are already validated (quil.cc serves 1.31.1).