### PR TITLE
fix: keep work-in-progress spinner accurate across pane mute/unmute

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2347,6 +2347,19 @@ func (d *Daemon) emitEvent(e PaneEvent) {
 			muted := pane.Muted
 			pane.PluginMu.Unlock()
 			if muted {
+				// Muting suppresses the visible notification (sidebar card,
+				// MCP get_notifications), but a work-state transition
+				// (turn start/stop/abort) must still reach live clients —
+				// otherwise the TUI's per-pane `working` flag (and its
+				// spinner) goes stale for the whole mute window and never
+				// resyncs on unmute, since no later event exists to correct
+				// it against. Bypass the persisted queue, still broadcast.
+				if hookevents.ClassifyWorkEvent(e.Type) == hookevents.WorkEventNone {
+					return
+				}
+				payload := toPaneEventPayload(e)
+				msg, _ := ipc.NewMessage(ipc.MsgPaneEvent, payload)
+				d.broadcast(msg)
 				return
 			}
 		}

--- a/internal/daemon/event_mute_test.go
+++ b/internal/daemon/event_mute_test.go
@@ -45,6 +45,28 @@ func TestEmitEvent_MutedPaneDropsEvent(t *testing.T) {
 	}
 }
 
+// TestEmitEvent_MutedPaneWorkStateEventBypassesQueue verifies that a
+// work-state hook event (turn start/stop/abort) from a muted pane still
+// bypasses the persisted/notification queue — mute must still mean "no
+// visible notification" (sidebar card, MCP get_notifications) — even though
+// daemon.emitEvent now broadcasts it live so the TUI's working flag doesn't
+// go stale for the duration of the mute (see workstate.go syncPaneMeta).
+func TestEmitEvent_MutedPaneWorkStateEventBypassesQueue(t *testing.T) {
+	d := New(config.Default())
+	tab := &Tab{ID: "tab-1", Name: "test", Panes: []string{"pane-quiet"}}
+	panes := []*Pane{
+		{ID: "pane-quiet", TabID: "tab-1", Type: "terminal", Muted: true},
+	}
+	d.session.RestoreTab(tab, panes)
+
+	d.emitEvent(PaneEvent{ID: "evt-1", PaneID: "pane-quiet", Type: "hook.claude.UserPromptSubmit", Title: "Working"})
+	d.emitEvent(PaneEvent{ID: "evt-2", PaneID: "pane-quiet", Type: "hook.claude.Stop", Title: "Done"})
+
+	if d.events.Count() != 0 {
+		t.Errorf("work-state events from a muted pane must not enter the notification queue: got %d", d.events.Count())
+	}
+}
+
 // TestEmitEvent_UnknownPaneStillEmits guards against an over-aggressive filter
 // — events whose PaneID does not resolve to a live pane (e.g. a synthetic
 // daemon-level event) must still be queued.

--- a/internal/hookevents/workstate.go
+++ b/internal/hookevents/workstate.go
@@ -1,0 +1,47 @@
+package hookevents
+
+// WorkEventKind classifies how a composed PaneEvent Type (the daemon encodes
+// hook events as "hook.<src>.<event>") affects a pane's mid-turn "working"
+// state. Shared by the daemon — which must keep delivering these specific
+// event types to live TUI clients even for a muted pane, so the spinner
+// doesn't go stale for the duration of the mute and never resync on unmute —
+// and the TUI, which drives the work-in-progress spinner from them. This is
+// the single source of truth for the work indicator — keep it in sync with
+// the producers in internal/claudehook and internal/opencodehook.
+type WorkEventKind int
+
+const (
+	WorkEventNone  WorkEventKind = iota // no effect
+	WorkEventStart                      // a turn began
+	WorkEventStop                       // turn completed OR parked for user input → mark pane unseen
+	WorkEventAbort                      // process exited → clear working, no mark
+)
+
+// ClassifyWorkEvent maps a composed PaneEvent Type to a work-state transition.
+func ClassifyWorkEvent(eventType string) WorkEventKind {
+	switch eventType {
+	case "hook.claude.UserPromptSubmit", "hook.opencode.chat.message":
+		return WorkEventStart
+	// Resume edge: the user answered an interactive-prompt tool (AskUserQuestion
+	// / ExitPlanMode) and the agent is working again. The hook registers
+	// PostToolUse only for those tools, so this re-arms the spinner after a park
+	// without tracking ordinary tool completions.
+	case "hook.claude.PostToolUse":
+		return WorkEventStart
+	case "hook.claude.Stop", "hook.claude.SessionEnd",
+		"hook.opencode.session.idle", "hook.opencode.session.error":
+		return WorkEventStop
+	// Park-for-input edges: the agent is blocked waiting on the user (permission
+	// prompt, option select, idle-input nudge). There is no "resumed after
+	// approval" hook, so we treat the park as a turn boundary — stop the spinner
+	// and mark the pane unseen to pull attention. Both Claude (Notification fires
+	// for permission + idle-wait; PermissionRequest when available) and opencode
+	// (permission.ask) are covered.
+	case "hook.claude.Notification", "hook.claude.PermissionRequest",
+		"hook.opencode.permission.ask":
+		return WorkEventStop
+	case "process_exit":
+		return WorkEventAbort
+	}
+	return WorkEventNone
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -955,8 +955,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		//
 		// hook.claude.PostToolUse is a work-state-only signal (re-arms the
 		// spinner after a prompt is answered) — never a user-facing card.
+		//
+		// A muted pane's daemon still forwards work-state hook events live
+		// (see emitEvent) so `working` tracks reality across mute/unmute —
+		// but muting must still mean "no visible notification", so suppress
+		// the sidebar card for any event sourced from a muted pane.
+		eventPane, _ := m.findPaneAndTab(msg.PaneID)
+		muted := eventPane != nil && eventPane.Muted
 		workStateOnly := msg.Type == "hook.claude.PostToolUse"
-		if !workStateOnly && !(msg.Type == "output_idle" && m.isActivePane(msg.PaneID)) {
+		if !muted && !workStateOnly && !(msg.Type == "output_idle" && m.isActivePane(msg.PaneID)) {
 			m.notifications.AddEvent(ipc.PaneEventPayload(msg))
 		}
 		cmds := []tea.Cmd{m.listenForMessages()}

--- a/internal/tui/workstate.go
+++ b/internal/tui/workstate.go
@@ -4,6 +4,8 @@ import (
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+
+	"github.com/artyomsv/quil/internal/hookevents"
 )
 
 // workSpinnerInterval is the animation cadence for the work-in-progress
@@ -11,45 +13,21 @@ import (
 const workSpinnerInterval = 100 * time.Millisecond
 
 // workTransition classifies a pane event's effect on a pane's working state.
-type workTransition int
+// Alias of hookevents.WorkEventKind — that package is the single source of
+// truth (shared with the daemon's mute-bypass logic in emitEvent).
+type workTransition = hookevents.WorkEventKind
 
 const (
-	workNone  workTransition = iota // no effect
-	workStart                       // a turn began
-	workStop                        // turn completed OR parked for user input → mark pane unseen
-	workAbort                       // process exited → clear working, no mark
+	workNone  = hookevents.WorkEventNone  // no effect
+	workStart = hookevents.WorkEventStart // a turn began
+	workStop  = hookevents.WorkEventStop  // turn completed OR parked for user input → mark pane unseen
+	workAbort = hookevents.WorkEventAbort // process exited → clear working, no mark
 )
 
 // workEventKind maps a PaneEvent Type (the daemon encodes hook events as
-// "hook.<src>.<event>") to a working-state transition. This is the single
-// source of truth for the work indicator — keep it in sync with the
-// producers in internal/claudehook and internal/opencodehook.
+// "hook.<src>.<event>") to a working-state transition.
 func workEventKind(eventType string) workTransition {
-	switch eventType {
-	case "hook.claude.UserPromptSubmit", "hook.opencode.chat.message":
-		return workStart
-	// Resume edge: the user answered an interactive-prompt tool (AskUserQuestion
-	// / ExitPlanMode) and the agent is working again. The hook registers
-	// PostToolUse only for those tools, so this re-arms the spinner after a park
-	// without tracking ordinary tool completions.
-	case "hook.claude.PostToolUse":
-		return workStart
-	case "hook.claude.Stop", "hook.claude.SessionEnd",
-		"hook.opencode.session.idle", "hook.opencode.session.error":
-		return workStop
-	// Park-for-input edges: the agent is blocked waiting on the user (permission
-	// prompt, option select, idle-input nudge). There is no "resumed after
-	// approval" hook, so we treat the park as a turn boundary — stop the spinner
-	// and mark the pane unseen to pull attention. Both Claude (Notification fires
-	// for permission + idle-wait; PermissionRequest when available) and opencode
-	// (permission.ask) are covered.
-	case "hook.claude.Notification", "hook.claude.PermissionRequest",
-		"hook.opencode.permission.ask":
-		return workStop
-	case "process_exit":
-		return workAbort
-	}
-	return workNone
+	return hookevents.ClassifyWorkEvent(eventType)
 }
 
 // findPaneAndTab locates a pane by ID and the index of its containing tab.
@@ -185,11 +163,11 @@ func (m Model) workSpinnerTick() tea.Cmd {
 // syncPaneMeta copies daemon-authoritative metadata from a PaneInfo onto the
 // local PaneModel during workspace-state reconciliation.
 //
-// Muting a pane clears any in-progress work indicator: the daemon drops a
-// muted pane's hook events at the source, so the completion edge that would
-// normally clear `working` never reaches the TUI. Without this, muting a pane
-// mid-turn would strand its spinner — and keep the 100ms animation tick alive
-// — indefinitely.
+// Muting a pane does NOT clear `working` here: the daemon still delivers
+// work-state hook events (start/stop/abort) live for a muted pane — it only
+// suppresses the visible notification card (see emitEvent) — so the normal
+// completion edge keeps `working` accurate across the whole mute/unmute
+// window instead of going stale the instant the pane is muted.
 func syncPaneMeta(pane *PaneModel, info *PaneInfo) {
 	pane.Name = info.Name
 	pane.CWD = info.CWD
@@ -201,7 +179,4 @@ func syncPaneMeta(pane *PaneModel, info *PaneInfo) {
 	pane.HistoryLines = info.HistoryLines
 	pane.daemonMouseTracking = info.MouseTracking
 	pane.daemonMouseSGR = info.MouseSGR
-	if info.Muted {
-		pane.working = false
-	}
 }

--- a/internal/tui/workstate_test.go
+++ b/internal/tui/workstate_test.go
@@ -286,6 +286,39 @@ func TestTabStyle_UnseenOverridesInactive(t *testing.T) {
 	}
 }
 
+func TestUpdate_PaneEvent_MutedPaneTracksWorkingWithoutCard(t *testing.T) {
+	t.Parallel()
+	// A muted pane's daemon still forwards work-state hook events live (see
+	// daemon.emitEvent) so `working` stays accurate across mute/unmute — but
+	// muting must still suppress the visible sidebar card.
+	m := modelForWorkTest()
+	m.tabs[0].Root.Leaves()[0].Muted = true
+
+	start := paneEventMsg(ipc.PaneEventPayload{
+		ID: "e1", PaneID: "p1", Type: "hook.claude.UserPromptSubmit", Title: "Working on: x",
+	})
+	next, _ := m.Update(start)
+	nm := next.(Model)
+	if !nm.tabs[0].Root.Leaves()[0].working {
+		t.Fatal("muted pane should still track working=true from a live work-state event")
+	}
+	if nm.notifications.Count() != 0 {
+		t.Errorf("muted pane must not produce a sidebar card: got %d events", nm.notifications.Count())
+	}
+
+	stop := paneEventMsg(ipc.PaneEventPayload{
+		ID: "e2", PaneID: "p1", Type: "hook.claude.Stop", Title: "Done",
+	})
+	next2, _ := nm.Update(stop)
+	nm2 := next2.(Model)
+	if nm2.tabs[0].Root.Leaves()[0].working {
+		t.Error("muted pane should still clear working=false from a live Stop event")
+	}
+	if nm2.notifications.Count() != 0 {
+		t.Errorf("muted pane must not produce a sidebar card on stop: got %d events", nm2.notifications.Count())
+	}
+}
+
 func TestUpdate_PaneEvent_StartBeginsTicking(t *testing.T) {
 	t.Parallel()
 	m := modelForWorkTest()
@@ -354,19 +387,20 @@ func TestTabLabel_ShowsSpinnerWhenWorking(t *testing.T) {
 	}
 }
 
-func TestSyncPaneMeta_MuteClearsWorking(t *testing.T) {
+func TestSyncPaneMeta_MuteDoesNotDisturbWorking(t *testing.T) {
 	t.Parallel()
-	// Muting a pane mid-turn must clear `working`: the daemon drops a muted
-	// pane's hook events, so the completion edge that would clear it never
-	// arrives — otherwise the spinner (and the 100ms tick) would run forever.
+	// The daemon still delivers work-state hook events live for a muted pane
+	// (see daemon.emitEvent), so a metadata sync must NOT clobber `working`
+	// just because the pane is muted — otherwise a real completion event
+	// racing a workspace-state broadcast would get its effect reverted, and
+	// the spinner would never reappear after unmuting a still-working pane.
 	pane := NewPaneModel("p1", 1024)
 	pane.working = true
 	syncPaneMeta(pane, &PaneInfo{Muted: true})
-	if pane.working {
-		t.Error("muting a pane must clear its working indicator")
+	if !pane.working {
+		t.Error("a mute metadata sync must not clear working")
 	}
 
-	// An unmuted metadata sync must not disturb working.
 	pane2 := NewPaneModel("p2", 1024)
 	pane2.working = true
 	syncPaneMeta(pane2, &PaneInfo{Muted: false})


### PR DESCRIPTION
## Summary
- Muting a pane instantly killed the tab/pane work-in-progress spinner, and unmuting never restored it — even if the pane was still actively working — because the daemon dropped *all* hook events for a muted pane and the TUI force-cleared `working` on every mute sync.
- `daemon.emitEvent` now still forwards work-state hook events (turn start/stop/abort) live to connected clients for a muted pane, bypassing only the persisted notification queue (so mute still suppresses the sidebar card / MCP `get_notifications`).
- `internal/tui/workstate.go`'s `syncPaneMeta` no longer force-clears `working` on mute, since the live event stream now keeps it accurate across the whole mute/unmute window.
- Extracted the hook-event → work-state classification into `internal/hookevents.ClassifyWorkEvent` as the single shared source of truth for both the daemon (mute bypass) and the TUI (spinner derivation).

## Test Plan
- [x] `./scripts/dev.sh test` — full suite passes, including updated/new tests in `internal/daemon` and `internal/tui`
- [x] `./scripts/dev.sh vet` — clean
- [x] `./scripts/dev.sh build` — builds successfully
- [ ] Manual: mute a working pane, confirm spinner stops; unmute, confirm spinner reappears immediately without waiting for the next turn; confirm no sidebar card appears for the muted pane's hook events