### PR TITLE
ci(release): remove redundant deploy-site job, let site.yml deploy alone

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,8 +149,12 @@ jobs:
           # Bump the marketing site's version pill so quil.cc reflects the
           # release. seo.ts is the single source of truth for the home page
           # hero pill — without this update the site keeps showing the old
-          # version even though the binary moved on. The deploy-site job
-          # below rebuilds the site from the tagged commit after release.
+          # version even though the binary moved on. This file is included in
+          # the release commit below, so the push that follows triggers
+          # site.yml (path-filtered on site/**) with the correct version
+          # already baked in — that is the ONLY thing that deploys the site;
+          # see the "Commit version bump and tag" step for why there is no
+          # separate deploy job here.
           sed -i -E "s/(version: )\"[0-9]+\\.[0-9]+\\.[0-9]+\"/\\1\"${VERSION}\"/" site/src/data/seo.ts
           sed -i -E "s/(releaseDate: )\"[0-9]{4}-[0-9]{2}-[0-9]{2}\"/\\1\"${DATE}\"/" site/src/data/seo.ts
 
@@ -173,6 +177,20 @@ jobs:
           echo "Bump type: ${BUMP}"
 
       - name: Commit version bump and tag
+        # This push (via RELEASE_PAT, not the loop-prevention-exempt
+        # GITHUB_TOKEN) touches site/src/data/seo.ts, so it triggers a fresh
+        # site.yml run on its own — from a commit that already has the
+        # correct version baked in. That is deliberately the ONLY thing that
+        # deploys quil.cc: release.yml used to ALSO rebuild+deploy the site
+        # itself in a dedicated job after goreleaser, to force an
+        # "authoritative" redeploy over a stale in-flight site.yml build.
+        # That guard against a rare ordering race introduced a much more
+        # common one — the two deploys landing back-to-back made GitHub
+        # Pages' API reject the second attempt outright ("Deployment failed,
+        # try again later"), which is what actually happened on the PR that
+        # removed this job (see its description for the concrete failure).
+        # Exactly one deploy pathway, from a commit that is always correct,
+        # beats two deploy pathways arbitrated by a concurrency group.
         if: steps.bump.outputs.skip != 'true' && env.DRY_RUN != 'true'
         env:
           VERSION: ${{ steps.bump.outputs.version }}
@@ -258,62 +276,18 @@ jobs:
           gh release edit "v${VERSION}" --notes-file release-notes.md
           echo "::notice::Release notes applied to v${VERSION}"
 
-  # --- Site rebuild ---------------------------------------------------
-  # A push made with RELEASE_PAT triggers site.yml (unlike GITHUB_TOKEN, which
-  # is exempt from workflow loop-prevention). However, site.yml fires on the
-  # *pre-bump* push that started this run — not the release commit — so it
-  # would deploy a stale version pill. The shared "pages" concurrency group
-  # below cancels that stale build and makes this job the authoritative
-  # deploy. This job rebuilds and deploys the site directly from the tagged
-  # commit (which has the updated seo.ts version pill).
-  deploy-site:
-    needs: [release, goreleaser]
-    if: needs.release.outputs.skip != 'true' && needs.release.outputs.dry_run != 'true'
-    runs-on: ubuntu-latest
-    # Share the "pages" concurrency group with site.yml. The same push
-    # triggers site.yml (which builds the PRE-bump commit → stale version pill)
-    # AND this job (which builds the tag → correct version). Without a shared
-    # group both deploy to github-pages and the stale one can win the race
-    # (v1.31.0 shipped but quil.cc kept showing 1.30.0). This job runs after the
-    # release job, so it enters the group last and supersedes/cancels site.yml's
-    # in-flight deploy — making the versioned deploy authoritative.
-    concurrency:
-      group: pages
-      cancel-in-progress: true
-    permissions:
-      contents: read
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    defaults:
-      run:
-        working-directory: site
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
-        with:
-          ref: v${{ needs.release.outputs.version }}
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-          cache: npm
-          cache-dependency-path: site/package-lock.json
-
-      - name: Install dependencies
-        run: npm ci --no-audit --no-fund
-
-      - name: Build site
-        run: npm run build
-        env:
-          NODE_ENV: production
-
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: site/dist
-
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+  # --- Site deploy ------------------------------------------------------
+  # There is deliberately no site-deploy job here. site.yml (path-filtered on
+  # site/**) is the ONLY thing that ever deploys quil.cc, triggered by the
+  # "Commit version bump and tag" push above (it touches site/src/data/seo.ts
+  # with the version already bumped). site.yml carries its own top-level
+  # `concurrency: {group: pages, cancel-in-progress: true}`, so if the
+  # original merge push ALSO happened to touch site/** (a docs/site PR bundled
+  # with the release-worthy commit), that earlier, stale-content site.yml run
+  # is a run of the very same workflow/group and is guaranteed to be
+  # cancelled-or-superseded by this strictly-later, correct-content run —
+  # no separate job or shared concurrency group needed to arbitrate between
+  # two different workflows. See CHANGELOG / git history for why a redundant
+  # deploy-site job briefly existed here and why it was removed (it made two
+  # independent deploys of the SAME correct content race each other, and
+  # GitHub Pages' API rejected the second one outright).


### PR DESCRIPTION
## Summary
- The v1.32.2 release just failed a `Deploy to GitHub Pages` step with "Deployment failed, try again later" — root cause: `release.yml`'s own `deploy-site` job and `site.yml` were both deploying the *same, already-correct* version-bump commit to GitHub Pages back-to-back. Their shared `pages` concurrency group only helps when one run is still in-flight when the other starts; by the time `deploy-site` runs (after `goreleaser`, ~2 minutes later), `site.yml`'s own run has usually already finished, so there's nothing to cancel — the second deployment just gets rejected by GitHub's Pages API.
- Removed the `deploy-site` job entirely. `site.yml` (path-filtered on `site/**`) is now the *only* thing that deploys quil.cc, triggered by the same version-bump commit push (it always touches `site/src/data/seo.ts` with the version already bumped).
- This matches the single-deployer design used in the `marauder` project: exactly one workflow ever calls `actions/deploy-pages`, so there's no arbitration race to get wrong.
- Checked this doesn't reintroduce the historical "v1.31.0 shipped, quil.cc stuck on 1.30.0" bug that the removed job was originally added to fix: that bug happened when the release push (at the time, made with `GITHUB_TOKEN`) did **not** trigger `site.yml` at all, and a separate `deploy-site` job with no shared concurrency group raced an unrelated stale `site.yml` run with no ordering guarantee. Today, `site.yml` already carries its own top-level `concurrency: {group: pages, cancel-in-progress: true}` — so even if an original merge push happens to also touch `site/**` (triggering a stale `site.yml` run), the strictly-later version-bump-commit push triggers another run of the *same* workflow/group, which GitHub guarantees supersedes the earlier one. No second job or shared group needed.

## Test Plan
- [x] YAML validated (`python -c "import yaml; yaml.safe_load(...)"` via Docker)
- [ ] Next release (patch/minor/major merge to master) exercises this path end-to-end — confirm exactly one "Deploy site (quil.cc)" run per release and quil.cc shows the correct version afterward