### PR TITLE
fix: publish merged pane render artifact fixes (v1.33.1)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,11 +70,13 @@ chore/update-deps
 ## Pull requests
 
 - One logical concern per PR — bundling unrelated changes makes review painful
-- Title follows Conventional Commits
+- Title follows Conventional Commits — this is release-critical, not cosmetic (see below)
 - Description has a **Summary** (1–3 bullets) and a **Test plan** (how to verify)
 - Aim for under 400 lines of diff. If you must go bigger, split into stacked PRs with a clear sequence.
 
-PRs get squash-merged to `master` for a clean history. The release pipeline picks up the squash commit, computes the version bump from conventional commit types, updates `VERSION` + `CHANGELOG.md`, tags, and publishes via GoReleaser.
+PRs get squash-merged to `master` for a clean history. GitHub uses the **PR title** as the squash-commit subject, and the release pipeline classifies that subject by conventional-commit type to compute the version bump, update `VERSION` + `CHANGELOG.md`, tag, and publish via GoReleaser.
+
+> **A non-conventional PR title silently skips the release.** The bump regex requires the type followed by `:`, `(`, or `/` (e.g. `fix:`, `fix(tui):`, `fix/…`). A title like `Fix the pane bug` matches nothing, so the release job logs `No version-bumping commits found` and exits without tagging — the merge lands on `master` but never ships. If a merged change didn't produce a release, check the PR title first.
 
 ## Documentation maintenance
 


### PR DESCRIPTION
## Summary

- PR #84 (pane render artifacts: sidebar overlay, wide canvas, resize guard, session resume) merged to `master` at `cc953ca`, but **no release was cut** — it's been unreleased since v1.33.0.
- Cause: the squash subject `Fix claude-code pane render artifacts…` is **not** a conventional commit. The release job's bump regex needs `fix:` / `fix(scope):` / `fix/…`; a bare `Fix ` matched nothing, so it logged `No version-bumping commits found` and skipped tagging.
- This PR lands one conventional `fix:` commit so the release pipeline bumps `v1.33.0 → v1.33.1` and GoReleaser publishes the already-merged pane fixes.
- Also hardens `CONTRIBUTING.md` to document the silent-skip failure mode so a non-conventional PR title can't swallow a release again.

## Test plan

- On squash-merge, confirm the **Release** workflow's *Determine version bump* step classifies `fix:` as `patch` and proceeds (does not skip).
- Confirm a `v1.33.1` tag + GitHub Release is created with all 5 platform archives.
- Confirm the published binaries contain the PR #84 pane render fixes.