### PR TITLE
ci: auto-terminate hung runs with timeouts and concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,19 @@ on:
         type: boolean
         default: true
 
+# Auto-supersede: a new push to a PR cancels the in-flight run for the previous
+# commit instead of piling up (or waiting for a human to cancel it). Grouped
+# per-branch so different PRs never cancel each other.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    # Hard cap so a hung step — historically an intermittent test-suite
+    # deadlock — auto-fails here instead of running until someone cancels it.
+    timeout-minutes: 15
     steps:
       - name: Dry run notice
         if: inputs.dry_run == true
@@ -25,7 +35,11 @@ jobs:
           go-version: '1.25'
 
       - run: go vet ./...
-      - run: go test ./...
+      # -race targets the concurrency-bug class behind the intermittent hangs
+      # (the project's go-testing rule requires CI to run with -race). -timeout
+      # makes a deadlocked test fail fast WITH a full goroutine dump naming the
+      # culprit, instead of hanging until the job timeout.
+      - run: go test -race -timeout 300s ./...
       - run: go build ./cmd/quil && go build ./cmd/quild
 
       - name: shellcheck

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,7 +213,14 @@ jobs:
           git add VERSION CHANGELOG.md site/src/data/seo.ts
           git commit -m "chore(release): v${VERSION}"
           git tag "v${VERSION}"
-          git push origin master --tags
+          # --atomic: land the release commit and its tag together or not at
+          # all. If this push is interrupted (e.g. the job timeout-minutes cap
+          # firing, or a network stall), the server applies both refs or
+          # neither — never the commit without the tag (or vice versa), which
+          # would otherwise leave a half-released state needing manual cleanup.
+          # Push the specific tag rather than --tags so only this release's tag
+          # is part of the atomic unit.
+          git push --atomic origin master "v${VERSION}"
           echo "::notice::Tagged v${VERSION}"
 
   goreleaser:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,10 @@ on:
         description: 'Dry run — compute version but skip commit, tag, and release'
         type: boolean
         default: true
+      publish_tag:
+        description: 'Recovery: publish an existing tag (e.g. v1.35.0) whose Release never went public. Skips the version bump/commit; (re)runs GoReleaser + publish for that tag.'
+        type: string
+        default: ''
 
 env:
   DRY_RUN: ${{ inputs.dry_run || false }}
@@ -47,7 +51,9 @@ jobs:
     outputs:
       version: ${{ steps.bump.outputs.version }}
       skip: ${{ steps.bump.outputs.skip }}
-      dry_run: ${{ env.DRY_RUN }}
+      # Sourced from the bump step (not env) so recovery mode can force it false
+      # even when the workflow_dispatch dry_run box is left at its default.
+      dry_run: ${{ steps.bump.outputs.dry_run }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
@@ -64,7 +70,7 @@ jobs:
           HAS_PAT: ${{ secrets.RELEASE_PAT != '' }}
         run: |
           if [ "$HAS_PAT" != "true" ]; then
-            echo "::warning::RELEASE_PAT secret is not set. The release push will run as github-actions[bot], which is NOT a ruleset bypass actor — 'git push origin master --tags' below will be rejected by the master branch ruleset. Add the RELEASE_PAT secret (see release.yml header)."
+            echo "::warning::RELEASE_PAT secret is not set. The release push will run as github-actions[bot], which is NOT a ruleset bypass actor — the 'git push --atomic origin master' below will be rejected by the master branch ruleset. Add the RELEASE_PAT secret (see release.yml header)."
           fi
 
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5
@@ -73,7 +79,26 @@ jobs:
 
       - name: Determine version bump
         id: bump
+        # PUBLISH_TAG via env (not inline ${{ }}) so the user-supplied input
+        # can't be interpolated into the shell — no script-injection surface.
+        env:
+          PUBLISH_TAG: ${{ inputs.publish_tag }}
         run: |
+          # Recovery: publish an existing tag without cutting a new version.
+          # Triggered via workflow_dispatch with publish_tag=vX.Y.Z when a prior
+          # run pushed the tag but its GitHub Release never went public. Skips
+          # bump/commit/tag; goreleaser then (re)publishes that tag.
+          if [ -n "$PUBLISH_TAG" ]; then
+            V="${PUBLISH_TAG#v}"
+            echo "version=${V}" >> $GITHUB_OUTPUT
+            echo "skip=false" >> $GITHUB_OUTPUT
+            echo "dry_run=false" >> $GITHUB_OUTPUT
+            echo "::notice::Recovery publish for v${V} — skipping bump/commit/tag"
+            exit 0
+          fi
+          # Normal mode: this run's dry_run flag flows to the goreleaser gate.
+          echo "dry_run=${DRY_RUN}" >> $GITHUB_OUTPUT
+
           CURRENT=$(cat VERSION)
           LAST_TAG="v${CURRENT}"
           echo "current=${CURRENT}" >> $GITHUB_OUTPUT
@@ -147,7 +172,7 @@ jobs:
           echo "::notice::Version bump: ${CURRENT} → ${NEW_VERSION} (${BUMP})"
 
       - name: Update version files
-        if: steps.bump.outputs.skip != 'true'
+        if: steps.bump.outputs.skip != 'true' && inputs.publish_tag == ''
         env:
           VERSION: ${{ steps.bump.outputs.version }}
         run: |
@@ -172,7 +197,7 @@ jobs:
           echo "::notice::Updated VERSION to ${VERSION}, CHANGELOG.md, and site/src/data/seo.ts"
 
       - name: Run tests
-        if: steps.bump.outputs.skip != 'true'
+        if: steps.bump.outputs.skip != 'true' && inputs.publish_tag == ''
         run: |
           go vet ./...
           # -race + bounded -timeout: a deadlocked test fails fast with a
@@ -180,7 +205,7 @@ jobs:
           go test -race -timeout 300s ./...
 
       - name: Dry run summary
-        if: steps.bump.outputs.skip != 'true' && env.DRY_RUN == 'true'
+        if: steps.bump.outputs.skip != 'true' && env.DRY_RUN == 'true' && inputs.publish_tag == ''
         env:
           VERSION: ${{ steps.bump.outputs.version }}
           BUMP: ${{ steps.bump.outputs.bump }}
@@ -204,7 +229,7 @@ jobs:
         # removed this job (see its description for the concrete failure).
         # Exactly one deploy pathway, from a commit that is always correct,
         # beats two deploy pathways arbitrated by a concurrency group.
-        if: steps.bump.outputs.skip != 'true' && env.DRY_RUN != 'true'
+        if: steps.bump.outputs.skip != 'true' && env.DRY_RUN != 'true' && inputs.publish_tag == ''
         env:
           VERSION: ${{ steps.bump.outputs.version }}
         run: |
@@ -265,6 +290,21 @@ jobs:
           echo "::notice::Release notes for v${VERSION} ($(wc -c < release-notes.md) bytes):"
           cat release-notes.md
 
+      - name: Clear any leftover draft for this tag
+        # Recovery-safe idempotency: if a prior interrupted run left a DRAFT
+        # release for this tag, delete it so GoReleaser can recreate it cleanly
+        # (GoReleaser errors on a pre-existing release). ONLY a draft is removed
+        # — an already-published release is never touched — and the tag itself
+        # is kept (--cleanup-tag=false). No-op on a normal first release.
+        env:
+          VERSION: ${{ needs.release.outputs.version }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "$(gh release view "v${VERSION}" --json isDraft --jq .isDraft 2>/dev/null)" = "true" ]; then
+            gh release delete "v${VERSION}" --yes --cleanup-tag=false
+            echo "::notice::Removed leftover draft for v${VERSION} before re-publish"
+          fi
+
       - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a  # v6
         with:
           distribution: goreleaser
@@ -298,6 +338,18 @@ jobs:
           fi
           gh release edit "v${VERSION}" --notes-file release-notes.md
           echo "::notice::Release notes applied to v${VERSION}"
+
+      - name: Publish release
+        # Final, atomic step: flip the draft to public ONLY after every asset is
+        # uploaded (GoReleaser) and the notes are set. Any earlier interruption
+        # leaves a hidden draft — never a partial PUBLIC release. Recovery is to
+        # re-run this job, or dispatch the workflow with publish_tag=v${VERSION}.
+        env:
+          VERSION: ${{ needs.release.outputs.version }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release edit "v${VERSION}" --draft=false
+          echo "::notice::Published v${VERSION}"
 
   # --- Site deploy ------------------------------------------------------
   # There is deliberately no site-deploy job here. site.yml (path-filtered on

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,9 +26,20 @@ on:
 env:
   DRY_RUN: ${{ inputs.dry_run || false }}
 
+# Serialize releases: if two pushes to master land close together, queue the
+# second run rather than let two release jobs race on the tag/commit. Never
+# cancel-in-progress — a release must not be interrupted mid tag-and-push.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 jobs:
   release:
     runs-on: ubuntu-latest
+    # Hard cap so a hung step (e.g. an intermittent test-suite deadlock) auto-
+    # fails instead of running for 15+ min until someone cancels it — the exact
+    # toil this workflow kept causing.
+    timeout-minutes: 15
     permissions:
       contents: write  # commit + tag version bump
     # Skip release commits to prevent infinite loop
@@ -164,7 +175,9 @@ jobs:
         if: steps.bump.outputs.skip != 'true'
         run: |
           go vet ./...
-          go test ./...
+          # -race + bounded -timeout: a deadlocked test fails fast with a
+          # goroutine dump instead of hanging the release job to its timeout.
+          go test -race -timeout 300s ./...
 
       - name: Dry run summary
         if: steps.bump.outputs.skip != 'true' && env.DRY_RUN == 'true'
@@ -207,6 +220,9 @@ jobs:
     needs: release
     if: needs.release.outputs.skip != 'true' && needs.release.outputs.dry_run != 'true'
     runs-on: ubuntu-latest
+    # Cross-compiles 5 platforms + publishes assets — give it more room than the
+    # release job, but still bounded so a stuck upload can't hang indefinitely.
+    timeout-minutes: 30
     permissions:
       contents: write  # publish GitHub release assets
     steps:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -73,6 +73,10 @@ release:
   github:
     owner: artyomsv
     name: quil
-  draft: false
+  # Upload assets to a HIDDEN draft. The release becomes public only when the
+  # workflow's final "Publish" step flips the draft — so an interruption during
+  # asset upload leaves an invisible draft, never a partial PUBLIC release. See
+  # release.yml (goreleaser job) for the flip + the recovery path.
+  draft: true
   prerelease: auto
   name_template: "v{{.Version}}"


### PR DESCRIPTION
## Problem

CI and Release runs periodically "fail" — but they're **cancelled**, not code errors. Neither `ci.yml` nor `release.yml` had `timeout-minutes` or a `concurrency` block, so when a step intermittently hangs (the shared suspect is `go test ./...` — this daemon has known deadlock/wedge classes), the run executes **until someone manually cancels it**. Concretely: the release job for the #91 merge ran **16 minutes then was cancelled, producing no release**.

## Fix — hangs terminate themselves, no human involvement

- **`timeout-minutes` on every job** (CI test 15, release 15, goreleaser 30). A hung step now auto-fails at the cap instead of waiting for a manual cancel — this removes the toil regardless of *where* it hangs.
- **`go test -race -timeout 300s ./...`** in both CI and release. A deadlocked test fails fast with a full goroutine dump naming the culprit, so the next occurrence self-diagnoses. `-race` also directly targets the concurrency-bug class — and the project's `go-testing` rule already requires CI to run with `-race` (it wasn't).
- **`concurrency` groups**: CI cancels superseded PR runs cleanly (`cancel-in-progress: true`, grouped per-branch); Release serializes on a shared group with `cancel-in-progress: false` so two close merges queue and a release is **never** interrupted mid tag-and-push.

## Why this is the right shape

The #91 release re-ran successfully on the *same commit* — the hang was a transient flake, not a deterministic error. The correct response to a rare flake is to make the pipeline **self-terminating and self-diagnosing**, not to chase a repro that only appears a few times a week. When it next fires, the `-timeout` dump will finally identify the hanging test for a real fix.

## Validation

- `actionlint` clean on both files (only pre-existing shellcheck info notes in the untouched version-bump script).
- Full suite green locally under `-race -count=3` across daemon/pty/tui/ipc/cmd.
