### PR TITLE
docs(site): drag-resize on quil.cc features + roadmap Pages correction

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -249,11 +249,11 @@ The entire pitch in one visual. Goes on README, Hacker News, r/programming, Twit
 
 GitHub repo as registry, `quil plugin install/search/update` CLI. High-value plugins: Aider, lazygit, k9s, Docker Compose, ngrok, pgcli. Every plugin makes Quil useful to a new audience.
 
-### GitHub Pages Documentation Site
+### Native Docs on quil.cc
 
-> Publish the `docs/` tree as a browsable site with a landing page.
+> Render the `docs/` markdown tree as first-class pages on the existing site.
 
-The documentation is already structured as a navigable tree (`docs/README.md` index, per-topic pages). A GitHub Pages deployment (static site generator over the existing Markdown — e.g. MkDocs Material or GitHub's built-in Jekyll — via a `pages.yml` workflow) turns it into a linkable, searchable site: install one-liner above the fold, quick-start, feature catalog, keybindings, plugin reference, MCP guide. Pairs with the demo GIF as the landing target for README / HN / social links. Custom domain optional later.
+[quil.cc](https://quil.cc) (Astro under `site/`, deployed to GitHub Pages by `site.yml` on master pushes touching `site/**`) already covers marketing: landing, features catalog, install, plugins, blog, comparisons. Its `/docs` page is a **link hub** that points back to the markdown on GitHub. The gap: render `docs/*.md` natively on the site (Astro content collections over the existing tree) so keybindings, configuration, plugin reference, and MCP guide are searchable, linkable pages with site navigation — no GitHub round-trip. Requires keeping `docs/` as the single source of truth (site consumes, never forks, the markdown). Also add a docs-freshness check: site deploys only trigger on `site/**`, so feature PRs that touch `docs/` or the feature catalog data layer must remember quil.cc (this PR added the drag-resize entry to `site/src/data/features.ts` by hand — content collections would make `docs/` changes flow automatically).
 
 ### tmux Migration Path — [PRD](roadmap/tmux-migration.md)
 
@@ -408,7 +408,7 @@ section above.
 | 15 | Session sharing | Large | Medium | Advanced |
 | 16 | **[gap]** Web dashboard + remote phone access (M18) | Large | Medium | Advanced |
 | 17 | **[gap]** Container sandboxing | Large | Medium | Advanced |
-| 18 | GitHub Pages documentation site | Small | Medium | Growth |
+| 18 | Native docs rendering on quil.cc | Small | Medium | Growth |
 | 19 | Terminal reflow-on-resize | Large | Medium | Polish |
 
 ## Strategic Notes

--- a/site/src/data/features.ts
+++ b/site/src/data/features.ts
@@ -173,6 +173,22 @@ export const features: Feature[] = [
     ],
   },
   {
+    slug: "mouse-pane-resize",
+    icon: "layout-panel-left",
+    title: "Mouse drag-resize splits",
+    blurb:
+      "Grab any border between panes and drag — the split follows your mouse, every nested pane keeps its minimum size, and the child processes see exactly one resize when you let go.",
+    category: "interaction",
+    detail: [
+      "Click-and-drag any split border; the affected panes show a highlight while the drag is active.",
+      "Works on arbitrarily nested layouts: the drag is clamped so every pane in both subtrees keeps the 10×4 minimum — not just the two panes touching the border.",
+      "The grab zone is wider than the drawn line, and the drawn line always wins over the scrollbar where they overlap — no pixel hunting.",
+      "PTY resize and layout persistence fire once, on mouse release — mid-drag the borders move locally, so TUI apps (claude-code, vim, htop) never see resize churn and never repaint mid-drag.",
+      "The new ratios ride the existing workspace snapshot, so a drag-resized layout survives daemon restarts and reboots.",
+      "Companion pane type — Terminal (keeps content on squeeze): the same shell on an AI-pane-style window-sized canvas, for log tails and watch loops where content survival matters more than width-perfect formatting.",
+    ],
+  },
+  {
     slug: "pane-notes",
     image: "https://cdn.stukans.com/quil/screenshots/focus-with-notes-800.webp",
     icon: "notebook-pen",


### PR DESCRIPTION
## Summary

Two docs commits that were pushed to the `feat/mouse-pane-resize` branch after PR #93 had already been squash-merged, rescued onto a fresh branch:

- **quil.cc features catalog** (`site/src/data/features.ts`): new interaction entry "Mouse drag-resize splits" covering the split-border drag shipped in #93 — live highlight, nested 10×4 minimum clamping, widened grab zone with border-over-scrollbar priority, single on-release PTY resize, ratios persisting across restarts, and the "Terminal (keeps content on squeeze)" companion pane type. Full Astro build verified (15 pages).
- **Roadmap correction** (`docs/roadmap.md`): the "GitHub Pages documentation site" item written in #93 was stale — quil.cc already deploys via Pages (`site.yml`). Reframed as "Native Docs on quil.cc": render `docs/*.md` as first-class site pages via Astro content collections, with `docs/` staying the single source of truth.

Merging this triggers the site deploy (`site.yml` watches `site/**` on master), which puts the drag-resize entry live on quil.cc/features.