### PR TITLE
fix(mcp): exit bridge when parent AI client dies, ending orphan leak

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -90,6 +90,8 @@ IPC request-response: `Message.ID` field (omitempty, backward compatible) correl
 
 Key files: `cmd/quil/mcp.go` (bridge + daemon connection), `cmd/quil/mcp_tools.go` (18 tool implementations), `cmd/quil/mcp_keys.go` (key name → escape sequence map), `cmd/quil/mcp_log.go` (per-pane interaction logging + two-layer redaction).
 
+Bridge lifetime: `watchParentExit()` (`cmd/quil/parentwatch_windows.go` / `parentwatch_unix.go`, armed first thing in `runMCP`) ties the bridge to the AI client that spawned it. Stdin EOF is NOT a reliable termination signal on Windows — the MCP client spawns stdio servers concurrently and same-second siblings inherit each other's pipe handles, so after the client dies a sibling still holds the bridge's stdin write end and `server.Run` blocks forever (observed: 20 orphaned bridges accumulated over a week, in same-second spawn pairs, each holding a live IPC conn to the production daemon). Windows: `OpenProcess(SYNCHRONIZE)` on the parent + `WaitForSingleObject` in a goroutine → `os.Exit(0)` when the parent exits, with a PID-reuse guard (`parentHandleTrustworthy` — a real parent's creation time is ≤ the child's; an impostor wearing a reused PID is treated as parent-already-dead). Unix: 2 s `Getppid()` reparent poll as belt-and-suspenders (EOF is reliable there). Covers pane kill, pane restart, session restart, and client crash with zero daemon coupling — the pane's claude process IS the bridge's parent.
+
 AI tool configuration:
 ```json
 {"mcpServers": {"quil": {"command": "quil", "args": ["mcp"]}}}

--- a/.claude/agent-memory/rules-compliance/MEMORY.md
+++ b/.claude/agent-memory/rules-compliance/MEMORY.md
@@ -1,0 +1,3 @@
+# Memory Index — rules-compliance (quil)
+
+- [Goroutine shutdown-path convention](goroutine-shutdown-convention.md) — quil's daemon/CLI goroutines use done-channels or os.Exit, not context.Context; treat as satisfying go-conventions.md's goroutine rule, not a violation.

--- a/.claude/agent-memory/rules-compliance/goroutine-shutdown-convention.md
+++ b/.claude/agent-memory/rules-compliance/goroutine-shutdown-convention.md
@@ -1,0 +1,36 @@
+---
+name: goroutine-shutdown-convention
+description: quil's established goroutine shutdown pattern (done-channel or os.Exit) is an accepted alternative to context.Context under go-conventions.md
+metadata:
+  type: project
+---
+
+quil's codebase never uses `context.Context` for its long-running background
+goroutines. Instead it uses two patterns, both already established before the
+2026-07 parentwatch feature:
+
+1. **Daemon-side long-lived goroutines** (`internal/daemon/daemon.go`:
+   `idleChecker`, `hookEventsWatcher`, the notification watcher loop, etc.)
+   select on a shared `d.shutdown` channel, closed once via `sync.Once` in
+   `Daemon.Stop()`. This is the "done channel" alternative go-conventions.md
+   explicitly allows alongside `context.Context`.
+2. **Single-purpose CLI helper processes** (e.g. `cmd/quil/parentwatch_windows.go`
+   / `parentwatch_unix.go` — the MCP bridge's parent-death watchdog) launch a
+   goroutine whose entire job is to call `os.Exit(0)` when a condition is met.
+   There is no coordinating parent structure to hand a context or done-channel
+   to, because the goroutine's own shutdown act ends the whole process. This
+   is a stronger shutdown guarantee than a context cancel, not a weaker one.
+
+**Why this matters for review:** go-conventions.md says goroutines must
+"always" pair with `context.Context`. Reviewers should NOT flag pattern (2) as
+a HIGH violation — it's a deliberate, repo-consistent exception for
+process-lifetime helper goroutines in short-lived `cmd/*` binaries, mirroring
+the done-channel pattern already accepted for daemon-side goroutines. Do flag
+it (LOW, informational) only if the goroutine lacks any comment explaining why
+no context/channel is used — code should self-document the exception.
+
+**How to apply:** When reviewing new `cmd/quil` or `cmd/quild` goroutines that
+terminate via `os.Exit` or process death rather than context cancellation,
+check for (a) a clear comment justifying the process-exit-as-shutdown design,
+and (b) consistency with this precedent, rather than treating the missing
+`context.Context` as a rule violation by itself.

--- a/.claude/reviews/quil/mcp-parentwatch.md
+++ b/.claude/reviews/quil/mcp-parentwatch.md
@@ -1,0 +1,15 @@
+# Code Review State: quil / mcp-parentwatch
+
+Last reviewed: 2026-07-17
+Rounds completed: 1
+
+## Resolved (fixed in code; do not re-raise)
+- [code-quality/M1] GetProcessTimes-failure path skipped the impostor guard but still waited on the unverified handle (erred toward the leak) — now abandons the watchdog on unverifiable identity and lets stdin EOF govern (round 1)
+- [rules/M1] CloseHandle error discarded without justification comment — both discard sites now carry explicit deliberately-ignored comments per go-conventions error-handling rule (round 1)
+- [security/L1 + code-quality/L1] OpenProcess failure conflated parent-gone with access-denied — now branches: ERROR_INVALID_PARAMETER → exit(0); any other error → return, stdin EOF governs (a permission quirk can no longer kill a healthy bridge) (round 1)
+- [code-quality/L2] Unix watchdog's "direct parent == owner" assumption implicit — documented (MCP stdio spawn model; wrapper launches would self-terminate) (round 1)
+- [qa/R1] Unix reparent path had no test despite the parentWatchInterval seam — added TestWatchParentExit_OrphanExitsOnReparent (Linux-only helper-process integration test; sh intermediary spawns the re-exec'd test binary, exits after 1 s, asserts the orphan dies within the poll budget; zombie-aware liveness check) (round 1)
+
+## Dismissed (acknowledged, will not fix; agents may escalate with explicit justification)
+- [code-quality/nit] TestParentHandleTrustworthy name lacks _Scenario_Expected suffix — reviewer's own verdict: subtest names carry the scenarios, matches the go-testing rule's table-driven example; not worth changing (round 1)
+- [qa/2] Windows watchdog runtime path has zero CI coverage — structural (no Windows runner, mirrors the existing PTY testing gap); substituted by the scripted host e2e: parent killed with stdin write handle held open, bridge exited in 0.5 s via the watchdog log line, re-run after round-1 fixes (round 1)

--- a/cmd/quil/mcp.go
+++ b/cmd/quil/mcp.go
@@ -129,6 +129,13 @@ func runMCP() {
 	// MCP uses stdout for JSON-RPC — redirect logs to stderr early
 	log.SetOutput(os.Stderr)
 
+	// Tie this bridge's lifetime to the AI client that spawned it. Stdin
+	// EOF alone is not a reliable termination signal on Windows (sibling
+	// processes inherit the pipe's write handle and keep it open past the
+	// parent's death), which leaked orphaned bridges for days. See
+	// parentwatch_windows.go for the full mechanism.
+	watchParentExit()
+
 	cfg := config.Default()
 	if cfgPath := config.ConfigPath(); fileExists(cfgPath) {
 		if loaded, loadErr := config.Load(cfgPath); loadErr == nil {

--- a/cmd/quil/parentwatch.go
+++ b/cmd/quil/parentwatch.go
@@ -1,0 +1,13 @@
+package main
+
+import "time"
+
+// parentHandleTrustworthy reports whether a process opened via the recorded
+// parent PID is plausibly the ORIGINAL parent rather than a PID-reuse
+// impostor: a real parent was created no later than the child it spawned
+// (equal timestamps are possible at coarse clock resolution). When this
+// returns false the original parent is already gone — the watchdog must
+// treat the parent as dead instead of waiting on a stranger.
+func parentHandleTrustworthy(parentCreated, selfCreated time.Time) bool {
+	return !parentCreated.After(selfCreated)
+}

--- a/cmd/quil/parentwatch_orphan_linux_test.go
+++ b/cmd/quil/parentwatch_orphan_linux_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestParentWatchOrphanHelper is NOT a test in the normal suite (it skips
+// unless the env gate is set). It is the CHILD half of the orphan
+// integration test below: re-executed via the test binary, it arms the
+// watchdog with a tiny poll interval and then blocks. If the watchdog
+// works, the process exits 0 long before the sleep elapses; exit code 2
+// means the watchdog never fired.
+func TestParentWatchOrphanHelper(t *testing.T) {
+	if os.Getenv("QUIL_PW_HELPER") != "1" {
+		t.Skip("helper process for TestWatchParentExit_OrphanExitsOnReparent")
+	}
+	parentWatchInterval = 5 * time.Millisecond
+	watchParentExit()
+	time.Sleep(30 * time.Second)
+	os.Exit(2)
+}
+
+// TestWatchParentExit_OrphanExitsOnReparent exercises the real reparent
+// path: an intermediate sh spawns the helper (so sh is its parent), keeps
+// living for 1 s while the helper arms the watchdog, then exits — the
+// helper is reparented to the init/reaper and must self-terminate within a
+// few poll intervals. This is the Linux-container-reachable counterpart of
+// the Windows e2e (which needs a real host).
+func TestWatchParentExit_OrphanExitsOnReparent(t *testing.T) {
+	t.Parallel()
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("resolve test binary: %v", err)
+	}
+	// Helper stdout/stderr go to /dev/null so the backgrounded process
+	// doesn't hold our stdout pipe open past sh's exit.
+	script := fmt.Sprintf(
+		"QUIL_PW_HELPER=1 %q -test.run '^TestParentWatchOrphanHelper$' >/dev/null 2>&1 & echo $!; sleep 1",
+		self)
+	out, err := exec.Command("sh", "-c", script).Output()
+	if err != nil {
+		t.Fatalf("spawn helper via sh: %v", err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	if err != nil || pid <= 1 {
+		t.Fatalf("helper pid parse: %q (%v)", out, err)
+	}
+
+	// sh has exited (Output returned) → helper is reparented. It must die
+	// within a few 5 ms polls; 10 s is a generous CI bound. An orphan that
+	// is reaped shows ENOENT; one whose new parent never reaps it stays
+	// visible as a zombie — both count as exited.
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if helperExited(pid) {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	_ = syscall.Kill(pid, syscall.SIGKILL) // don't leak the helper on failure
+	t.Fatal("orphaned helper still running 10s after reparent — unix watchdog did not fire")
+}
+
+// helperExited reports whether pid is gone or a zombie (exited but not yet
+// reaped by its adoptive parent — /proc state 'Z').
+func helperExited(pid int) bool {
+	stat, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if err != nil {
+		return true // ENOENT: fully gone
+	}
+	// Field 3 (state) follows the last ')' — comm may contain spaces.
+	rest := string(stat)
+	if i := strings.LastIndexByte(rest, ')'); i >= 0 && i+2 < len(rest) {
+		return rest[i+2] == 'Z'
+	}
+	return false
+}

--- a/cmd/quil/parentwatch_test.go
+++ b/cmd/quil/parentwatch_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParentHandleTrustworthy(t *testing.T) {
+	t.Parallel()
+	base := time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name          string
+		parentCreated time.Time
+		selfCreated   time.Time
+		want          bool
+	}{
+		// The original parent necessarily existed before (or at the same
+		// coarse-clock tick as) the child it spawned.
+		{"parent older than child", base.Add(-time.Minute), base, true},
+		{"same creation tick", base, base, true},
+		// A process created AFTER us that wears our recorded parent PID is
+		// a PID-reuse impostor: the real parent is gone, so the watchdog
+		// must treat the parent as already dead instead of waiting on a
+		// stranger that may never exit.
+		{"parent newer than child (PID reuse)", base.Add(time.Second), base, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := parentHandleTrustworthy(tt.parentCreated, tt.selfCreated); got != tt.want {
+				t.Errorf("parentHandleTrustworthy(%v, %v) = %v, want %v",
+					tt.parentCreated, tt.selfCreated, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/quil/parentwatch_unix.go
+++ b/cmd/quil/parentwatch_unix.go
@@ -35,8 +35,10 @@ func watchParentExit() {
 		return
 	}
 	go func() {
+		// No ticker.Stop: this goroutine is a one-way exit — it only ever
+		// leaves via os.Exit(0) below, which bypasses defers anyway. The
+		// timer is reclaimed when the process exits.
 		ticker := time.NewTicker(parentWatchInterval)
-		defer ticker.Stop()
 		for range ticker.C {
 			if os.Getppid() != initial {
 				log.Printf("mcp: parent %d exited (reparented), shutting down", initial)

--- a/cmd/quil/parentwatch_unix.go
+++ b/cmd/quil/parentwatch_unix.go
@@ -1,0 +1,47 @@
+//go:build !windows
+
+package main
+
+import (
+	"log"
+	"os"
+	"time"
+)
+
+// parentWatchInterval paces the orphan poll. Package var so a future test
+// harness can shrink it; 2 s keeps the check effectively free while still
+// reaping an orphaned bridge promptly.
+var parentWatchInterval = 2 * time.Second
+
+// watchParentExit arms the MCP bridge's parent-death watchdog: when the
+// process that spawned `quil mcp` exits, the bridge exits too.
+//
+// On Unix stdin EOF usually terminates the bridge already (server.Run
+// returns when the pipe breaks), so this is belt-and-suspenders for the
+// case where a leaked descendant still holds the pipe's write end. Orphan
+// detection is a ppid poll: when the parent dies the bridge is reparented
+// (to init/subreaper) and getppid changes.
+//
+// Assumption: the DIRECT parent is the bridge's owner. That holds for the
+// MCP stdio spawn model — the AI client execs `quil mcp` itself, because
+// it must own the stdio pipe ends. A launch behind an intermediate
+// wrapper that exits by design would self-terminate here; don't do that.
+func watchParentExit() {
+	initial := os.Getppid()
+	if initial <= 1 {
+		// Already orphaned (or spawned by init): no live parent to watch.
+		// Don't exit here — a deliberate detached launch stays governed by
+		// stdin EOF, which is reliable on Unix.
+		return
+	}
+	go func() {
+		ticker := time.NewTicker(parentWatchInterval)
+		defer ticker.Stop()
+		for range ticker.C {
+			if os.Getppid() != initial {
+				log.Printf("mcp: parent %d exited (reparented), shutting down", initial)
+				os.Exit(0)
+			}
+		}
+	}()
+}

--- a/cmd/quil/parentwatch_windows.go
+++ b/cmd/quil/parentwatch_windows.go
@@ -1,0 +1,93 @@
+//go:build windows
+
+package main
+
+import (
+	"errors"
+	"log"
+	"os"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+// watchParentExit arms the MCP bridge's parent-death watchdog: when the
+// process that spawned `quil mcp` (the AI client — claude.exe or an IDE)
+// exits for ANY reason, the bridge exits too.
+//
+// Why stdin EOF is not enough on Windows: the MCP client spawns several
+// stdio servers concurrently, and concurrently-spawned siblings inherit
+// each other's pipe handles (spawn-time handle inheritance races). When the
+// client dies — pane killed, session restarted, crash — a sibling still
+// holds the write end of this bridge's stdin pipe, so the blocking read
+// inside server.Run never sees EOF and the process leaks forever (observed
+// in production: 20 bridges accumulated over a week, in same-second spawn
+// pairs). The parent process HANDLE is signaled on exit regardless of who
+// holds which pipe, so waiting on it is the reliable lifetime signal.
+func watchParentExit() {
+	ppid := os.Getppid()
+	if ppid <= 0 {
+		return // no recorded parent — nothing to watch, rely on stdin EOF
+	}
+	h, err := windows.OpenProcess(
+		windows.SYNCHRONIZE|windows.PROCESS_QUERY_LIMITED_INFORMATION,
+		false, uint32(ppid))
+	if err != nil {
+		if errors.Is(err, windows.ERROR_INVALID_PARAMETER) {
+			// The PID no longer exists: the recorded parent died before we
+			// could open it — this bridge was orphaned at birth. Exit
+			// before serving anything.
+			log.Printf("mcp: parent %d already gone at startup, exiting", ppid)
+			os.Exit(0)
+		}
+		// Access denied or another open failure: the parent may well be
+		// alive. Exiting would kill a healthy bridge, and there is no
+		// handle to wait on — abandon the watchdog and leave lifetime to
+		// stdin EOF (the pre-watchdog behavior).
+		log.Printf("mcp: cannot open parent %d (%v) — stdin EOF governs lifetime", ppid, err)
+		return
+	}
+
+	// PID-reuse guard: os.Getppid returns the PID recorded at creation. If
+	// the original parent died before OpenProcess above, the PID may now
+	// belong to an unrelated process that could run for weeks — exactly the
+	// leak this watchdog exists to prevent. The impostor is detectable by
+	// its creation time: a real parent cannot be younger than its child.
+	var pCreate, pExit, pKernel, pUser windows.Filetime
+	var sCreate, sExit, sKernel, sUser windows.Filetime
+	errParent := windows.GetProcessTimes(h, &pCreate, &pExit, &pKernel, &pUser)
+	errSelf := windows.GetProcessTimes(windows.CurrentProcess(), &sCreate, &sExit, &sKernel, &sUser)
+	if errParent != nil || errSelf != nil {
+		// Identity unverifiable: waiting on an unverified handle risks the
+		// exact leak this watchdog prevents (an impostor may never exit),
+		// while exiting risks killing a bridge whose parent is alive.
+		// Abandon the watchdog — stdin EOF governs, as before the feature.
+		// CloseHandle error deliberately ignored: we are leaving the
+		// watchdog path and the OS reclaims the handle at process exit.
+		_ = windows.CloseHandle(h)
+		log.Printf("mcp: cannot verify parent %d identity (parent times: %v, self times: %v) — stdin EOF governs lifetime",
+			ppid, errParent, errSelf)
+		return
+	}
+	parentCreated := time.Unix(0, pCreate.Nanoseconds())
+	selfCreated := time.Unix(0, sCreate.Nanoseconds())
+	if !parentHandleTrustworthy(parentCreated, selfCreated) {
+		// CloseHandle error deliberately ignored: os.Exit follows
+		// immediately and the OS reclaims the handle either way.
+		_ = windows.CloseHandle(h)
+		log.Printf("mcp: parent pid %d was reused by a newer process, original parent is gone — exiting", ppid)
+		os.Exit(0)
+	}
+
+	go func() {
+		// Blocks until the parent's process object is signaled (it exited).
+		// The wait result is deliberately ignored: after a verified-parent
+		// INFINITE wait the outcomes are "signaled" or "wait failed", and
+		// for a helper process whose only purpose is to serve its parent,
+		// both mean the same thing — stop serving. Erring toward exit is
+		// the safe direction.
+		windows.WaitForSingleObject(h, windows.INFINITE)
+		log.Printf("mcp: parent %d exited, shutting down", ppid)
+		os.Exit(0)
+	}()
+}


### PR DESCRIPTION
## Problem

`quil mcp` stdio bridges never exited after their parent AI client died. Over one week a single machine accumulated **20 orphaned bridges** — each a full process holding a live IPC connection to the production daemon.

Root cause: the bridge's only lifetime signal was stdin EOF, and stdin EOF is unreliable on Windows. MCP clients spawn several stdio servers concurrently, and concurrently-spawned siblings inherit each other's pipe handles (the leaked bridges cluster in same-second spawn pairs — the fingerprint of that inheritance race). When the client dies — pane killed, session restarted, crash — a sibling still holds the bridge's stdin write end, the blocking read inside `server.Run` never breaks, and nothing else keeps a Go `main` from exiting, so the process leaks forever.

## Fix

`watchParentExit()`, armed first thing in `runMCP` (before the up-to-30 s daemon auto-start window, and after logs are redirected to stderr so the JSON-RPC stdout stream stays clean):

- **Windows** (`parentwatch_windows.go`): open the parent with `SYNCHRONIZE|PROCESS_QUERY_LIMITED_INFORMATION`, verify identity via creation times (PID-reuse guard: a real parent cannot be younger than its child), then `WaitForSingleObject` in a goroutine → exit 0 when the parent exits. Failure handling is direction-aware: provably-dead PID at startup → exit immediately; unverifiable handle (access denied, `GetProcessTimes` failure) → abandon the watchdog and let stdin EOF govern, so a permission quirk can't kill a healthy bridge and an impostor handle is never waited on.
- **Unix** (`parentwatch_unix.go`): 2 s `getppid()` reparent poll as belt-and-suspenders (EOF is reliable there). The direct-parent-is-owner assumption of the MCP stdio spawn model is documented.

This covers pane kill, tab kill, `restart_pane`, in-pane session restart, and client crash with zero daemon coupling — the pane's AI process *is* the bridge's parent. No new dependencies (`golang.org/x/sys` already direct).

## Review

Four-agent round (security / code-quality / rules / qa); state in `.claude/reviews/quil/mcp-parentwatch.md`. All findings fixed in this PR: the unverifiable-handle path no longer errs toward the leak, `OpenProcess` errors branch on parent-gone vs access-denied, discarded syscall returns carry justification comments, and the Unix reparent path gained a real integration test.

## Testing

- `TestParentHandleTrustworthy` — comparator table (older / same-tick / PID-reuse)
- `TestWatchParentExit_OrphanExitsOnReparent` — Linux helper-process integration test: an `sh` intermediary spawns the re-exec'd test binary and exits; the orphan must die within the poll budget (zombie-aware liveness check); runs in the standard Docker test container
- Scripted Windows e2e on a real host: bridge spawned under `cmd.exe` with its stdin write handle deliberately held open the whole time (EOF suppressed, exactly like the production leak), parent killed → bridge exited in **0.5 s** logging `mcp: parent <pid> exited, shutting down`; re-run after review fixes
- Full suite: 21 packages pass; `go vet` clean on Linux and `GOOS=windows`