### PR TITLE
chore(site): add visible FAQ sections and blog SEO improvements

### DIFF
--- a/site/src/components/Faq.astro
+++ b/site/src/components/Faq.astro
@@ -1,0 +1,66 @@
+---
+/**
+ * Faq — a reusable FAQ accordion (the repeated, CSS-heavy part).
+ *
+ * Renders a list of <details> items from an array of {question, answer}.
+ * Callers supply their own surrounding <section> + heading so each page
+ * controls its own chrome; this component owns only the accordion so the
+ * markup + styling live in one place (home page, blog posts).
+ *
+ * The SAME array should also feed `faqSchema(...)` so the visible text
+ * and the FAQPage JSON-LD stay in sync — Google only honours FAQ
+ * structured data when the answer text is visible on the page.
+ *
+ * The /vs/* comparison pages keep their own mono-styled accordion
+ * (ComparePage.astro); Astro scopes these styles, so there's no clash.
+ */
+import type { FaqItem } from "@/data/faq";
+
+interface Props {
+  items: FaqItem[];
+}
+
+const { items } = Astro.props;
+---
+{items.length > 0 && (
+  <div class="faq-list">
+    {items.map((item) => (
+      <details class="faq-item">
+        <summary>{item.question}</summary>
+        <p>{item.answer}</p>
+      </details>
+    ))}
+  </div>
+)}
+
+<style>
+  .faq-item {
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+    padding: 0.9rem 0;
+  }
+  .faq-item summary {
+    cursor: pointer;
+    font-weight: 600;
+    font-size: 1.05rem;
+    line-height: 1.4;
+    list-style: none;
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+  .faq-item summary::-webkit-details-marker { display: none; }
+  .faq-item summary::after {
+    content: "+";
+    color: var(--flame, #ff6a2b);
+    font-weight: 400;
+    transition: transform 0.15s;
+  }
+  .faq-item[open] summary::after { content: "−"; }
+  .faq-item summary:hover { color: var(--flame, #ff6a2b); }
+  .faq-item p {
+    margin: 0.75rem 0 0.25rem;
+    font-size: 1.02rem;
+    line-height: 1.7;
+    opacity: 0.85;
+  }
+</style>

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -29,6 +29,16 @@ const blog = defineCollection({
     ogImage: z.string().optional(),
     /** Target + secondary keywords (Bing/Yandex meta; Google ignores). */
     keywords: z.array(z.string()).default([]),
+    /**
+     * Optional FAQ. Each entry renders BOTH a visible <details> accordion
+     * at the foot of the post AND a FAQPage JSON-LD block. Google only
+     * honours FAQ structured data when the same text is visible on the
+     * page, so both are driven from this one array — they can't drift.
+     * Answers must be plain prose (no Markdown), grounded in the post body.
+     */
+    faq: z
+      .array(z.object({ question: z.string(), answer: z.string() }))
+      .default([]),
     /** Hide from listing + sitemap until ready. */
     draft: z.boolean().default(false),
     /** Rare: point our copy's canonical at an external origin. */

--- a/site/src/content/blog/resume-claude-code-session-after-reboot.md
+++ b/site/src/content/blog/resume-claude-code-session-after-reboot.md
@@ -2,6 +2,7 @@
 title: "How to Resume Your Claude Code Session After a Reboot — Automatically"
 description: "Reboot your machine and your Claude Code conversation is gone. Here's the manual fix with claude --resume, why it doesn't scale, and how to make it automatic."
 pubDate: 2026-06-14
+updatedDate: 2026-07-24
 ogImage: "https://cdn.stukans.com/quil/screenshots/pane-restoration-og.png"
 keywords:
   - "resume claude code session after reboot"
@@ -9,6 +10,15 @@ keywords:
   - "claude code continue session"
   - "tmux that survives reboot"
   - "reboot-proof terminal"
+faq:
+  - question: "How do I resume a Claude Code session after a reboot?"
+    answer: "The conversation transcript survives a reboot as a JSONL file under ~/.claude/projects/, but the running claude process does not. From the project directory, run claude --continue to reattach to the latest session, or claude --resume to pick one from a list. To make this happen automatically for your whole workspace, use a reboot-proof multiplexer that records each pane's current session id and re-runs claude --resume for you."
+  - question: "What is the difference between claude --continue and claude --resume?"
+    answer: "claude --continue (short form claude -c) grabs the most recent session for the current working directory and drops you straight back in. claude --resume opens a picker of past sessions in that folder, and claude --resume followed by a session id jumps straight to a specific one."
+  - question: "Where are Claude Code sessions stored?"
+    answer: "On your local machine as JSONL files under ~/.claude/projects/. There is one directory per project, named after the project path, and one .jsonl file per session — the filename is the session id."
+  - question: "Why doesn't claude --continue work well with multiple agents in one repo?"
+    answer: "claude --continue only knows the most recent session for a folder, so it cannot tell apart two or three Claude Code sessions running against the same repo — you end up hunting for the right session id under ~/.claude/projects/. Compaction and /clear also rotate the id, so an id you noted earlier may already be stale."
 draft: false
 ---
 
@@ -75,7 +85,7 @@ What you actually want is for the machine to come back, you type one command, an
 
 ## Making it automatic
 
-This is the specific problem [Quil](/) was built to solve. Quil is an open-source terminal multiplexer (a tmux alternative) with one defining trait: it survives a full host reboot, and it treats an AI coding session as first-class state to be restored — not just a pane to respawn.
+This is the specific problem [Quil](/) was built to solve. Quil is an open-source terminal multiplexer (a [tmux alternative](/vs/tmux/)) with one defining trait: it survives a full host reboot, and it treats an AI coding session as first-class state to be restored — not just a pane to respawn.
 
 Here's the mechanism, because the "how" matters for trusting it:
 

--- a/site/src/pages/blog/[...slug].astro
+++ b/site/src/pages/blog/[...slug].astro
@@ -10,8 +10,9 @@
  */
 import { getCollection, render } from "astro:content";
 import Page from "@/layouts/Page.astro";
+import Faq from "@/components/Faq.astro";
 import { SITE, canonical } from "@/data/seo";
-import { breadcrumbSchema } from "@/data/schemas";
+import { breadcrumbSchema, faqSchema } from "@/data/schemas";
 
 export async function getStaticPaths() {
   const posts = await getCollection("blog", ({ data }) => !data.draft);
@@ -52,6 +53,9 @@ const blogPosting = {
 
 const schemas = [
   blogPosting,
+  // FAQPage only when the post ships an FAQ — the same entries render as
+  // a visible accordion below, satisfying Google's visible-content rule.
+  ...(post.data.faq.length > 0 ? [faqSchema(post.data.faq)] : []),
   breadcrumbSchema([
     { name: "Home", path: "/" },
     { name: "Blog", path: "/blog" },
@@ -92,6 +96,13 @@ const displayDate = post.data.pubDate.toLocaleDateString("en-US", {
     <div class="blog-body">
       <Content />
     </div>
+
+    {post.data.faq.length > 0 && (
+      <section class="blog-faq" aria-labelledby="faq-heading">
+        <h2 id="faq-heading">Frequently asked questions</h2>
+        <Faq items={post.data.faq} />
+      </section>
+    )}
 
     <footer class="blog-foot">
       <a href="/install/" class="btn btn-primary"><span>▸ install quil</span></a>
@@ -184,6 +195,21 @@ const displayDate = post.data.pubDate.toLocaleDateString("en-US", {
     margin: 1.5rem 0;
     font-size: 0.92rem;
     line-height: 1.6;
+  }
+
+  /* FAQ — accordion markup + styling live in the shared Faq.astro; here
+     we only style the section wrapper. Driven by the post's `faq`
+     frontmatter, mirrored in FAQPage JSON-LD so visible text and
+     structured data stay in sync. */
+  .blog-faq {
+    margin-top: 3.5rem;
+    padding-top: 2rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+  }
+  .blog-faq h2 {
+    font-size: 1.5rem;
+    line-height: 1.2;
+    margin: 0 0 1.25rem;
   }
 
   .blog-foot {

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -386,7 +386,7 @@ const revTimestamp = new Date().toISOString().slice(0, 10).replace(/-/g, "");
   </section>
 
   <!-- ================================ CTA ================================ -->
-  <section class="cta"
+  <section class="cta">
     <div class="container-ember stack">
       <div class="cta-inner">
         <div class="hr-ascii" style="text-align:center;">┗━━━ <b>§ 06 / 06</b> ━ TAKE IT HOME━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛</div>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -5,16 +5,18 @@
  * Sections: hero (with animated restore viz) → features grid →
  * interactive 4-pane demo → compare teaser → install CTA.
  *
- * SEO / JSON-LD is unchanged: SoftwareApplication + FAQPage schemas
- * still ship as part of the head. Visible FAQ block was dropped from
- * the previous iteration; schema-only stays to keep the Google rich
- * result eligible.
+ * SEO / JSON-LD: SoftwareApplication + FAQPage schemas ship in the
+ * head, and the FAQPage entries are ALSO rendered as a visible
+ * accordion (the §06 FAQ section) — Google only honours FAQ structured
+ * data when the same answer text is visible on the page, so both are
+ * driven from the one `homeFaq` array.
  *
  * Inline scripts are Astro-processed (bundled to a single `page.js`
  * chunk on build). No client hydration — the scripts just wire up
  * static DOM.
  */
 import Page from "@/layouts/Page.astro";
+import Faq from "@/components/Faq.astro";
 import { SITE } from "@/data/seo";
 import { softwareApplicationSchema, faqSchema } from "@/data/schemas";
 import { homeFaq } from "@/data/faq";
@@ -50,7 +52,7 @@ const topFeatures = [
     number: "◇ 02",
     title: "Claude Code resumes itself",
     tag: "← AI CONTINUITY",
-    body: `Each AI pane owns a UUID at spawn. On restart, Quil runs <span class="mono" style="color:var(--flame);">claude --resume &lt;id&gt;</span> automatically. No copy-paste, no context rebuild, no re-explaining what you were doing. Your conversation is where you left it.`,
+    body: `Each AI pane owns a UUID at spawn. On restart, Quil runs <span class="mono" style="color:var(--flame);">claude --resume &lt;id&gt;</span> automatically. No copy-paste, no context rebuild, no re-explaining what you were doing. Your conversation is where you left it. <a href="/blog/resume-claude-code-session-after-reboot/" style="color:var(--flame); white-space:nowrap;">How auto-resume works →</a>`,
   },
   {
     number: "◇ 03",
@@ -91,7 +93,7 @@ const revTimestamp = new Date().toISOString().slice(0, 10).replace(/-/g, "");
   <section class="hero">
     <div class="container-ember stack">
       <div class="hero-ruler">
-        <span>§ <b>01</b> / 05 · HERO</span>
+        <span>§ <b>01</b> / 06 · HERO</span>
         <span>LAT <b>48.8566° N</b></span>
         <span>LON <b>2.3522° E</b></span>
         <span>BUILD <b>{SITE.software.version}-release</b></span>
@@ -178,7 +180,7 @@ const revTimestamp = new Date().toISOString().slice(0, 10).replace(/-/g, "");
   <!-- ================================ FEATURES ================================ -->
   <section class="features">
     <div class="container-ember stack">
-      <div class="hr-ascii">┏━━━ <b>§ 02 / 05</b> ━ WHAT IT DOES ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓</div>
+      <div class="hr-ascii">┏━━━ <b>§ 02 / 06</b> ━ WHAT IT DOES━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓</div>
 
       <div class="features-head">
         <div>
@@ -220,7 +222,7 @@ const revTimestamp = new Date().toISOString().slice(0, 10).replace(/-/g, "");
   <!-- ================================ INTERACTIVE DEMO ================================ -->
   <section class="demo" id="demo">
     <div class="container-ember stack">
-      <div class="hr-ascii">┣━━━ <b>§ 03 / 05</b> ━ LIVE DEMO ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫</div>
+      <div class="hr-ascii">┣━━━ <b>§ 03 / 06</b> ━ LIVE DEMO━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫</div>
 
       <div class="demo-head">
         <div class="section-tag"><span class="dot"></span>CLICK ANY PANE · TRY A COMMAND</div>
@@ -289,7 +291,7 @@ const revTimestamp = new Date().toISOString().slice(0, 10).replace(/-/g, "");
   <!-- ================================ COMPARE TEASER ================================ -->
   <section class="compare">
     <div class="container-ember stack">
-      <div class="hr-ascii">┣━━━ <b>§ 04 / 05</b> ━ VS THE FIELD ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫</div>
+      <div class="hr-ascii">┣━━━ <b>§ 04 / 06</b> ━ VS THE FIELD━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫</div>
 
       <div class="compare-grid">
         <div>
@@ -356,11 +358,38 @@ const revTimestamp = new Date().toISOString().slice(0, 10).replace(/-/g, "");
     </div>
   </section>
 
+  <!-- ================================ FAQ ================================ -->
+  <section class="faq-section">
+    <div class="container-ember stack">
+      <div class="hr-ascii">┣━━━ <b>§ 05 / 06</b> ━ COMMON QUESTIONS ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫</div>
+
+      <div class="features-head">
+        <div>
+          <div class="section-tag"><span class="dot"></span>BEFORE YOU INSTALL</div>
+          <h2 class="h2" style="margin-top:18px;">
+            Questions, <span class="flame-text">answered.</span>
+          </h2>
+        </div>
+        <div>
+          <p>
+            The honest version — what Quil does, how the persistence
+            actually works, where it runs, and when you genuinely don't
+            need it. No marketing hedging.
+          </p>
+        </div>
+      </div>
+
+      <div class="faq-home">
+        <Faq items={homeFaq} />
+      </div>
+    </div>
+  </section>
+
   <!-- ================================ CTA ================================ -->
-  <section class="cta">
+  <section class="cta"
     <div class="container-ember stack">
       <div class="cta-inner">
-        <div class="hr-ascii" style="text-align:center;">┗━━━ <b>§ 05 / 05</b> ━ TAKE IT HOME ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛</div>
+        <div class="hr-ascii" style="text-align:center;">┗━━━ <b>§ 06 / 06</b> ━ TAKE IT HOME━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛</div>
 
         <pre class="cta-ascii" aria-hidden="true">
     ┌──────────────────────────────────────────────────┐
@@ -397,6 +426,18 @@ const revTimestamp = new Date().toISOString().slice(0, 10).replace(/-/g, "");
 </Page>
 
 <style>
+  /* FAQ section — mirrors the vertical rhythm of the other numbered
+     sections (features/demo/compare) which get their padding from
+     ember.css; this section has no ember class of its own. */
+  .faq-section {
+    padding: 96px 0;
+    border-top: 1px solid var(--line);
+  }
+  .faq-home {
+    margin-top: 40px;
+    max-width: 56rem;
+  }
+
   .mini-pane {
     border: 1px solid var(--line-2);
     padding: 8px 10px;


### PR DESCRIPTION
## Summary

Grounded, code-side SEO improvements to the marketing site (`site/`), driven by Google Search Console data for quil.cc. Foundation (meta, canonical, OG, Organization/WebSite/SoftwareApplication/BlogPosting schema, `trailingSlash: "always"`) was already solid — this closes the one real on-page gap (FAQ) and strengthens internal linking to the pages that are already ranking.

## Changes

| Change | Why |
|---|---|
| **Home visible FAQ** (new §05 section) rendering the existing 12-entry `homeFaq` | The page shipped `FAQPage` JSON-LD but no visible FAQ — Google only honours FAQ structured data when the answer text is on the page. Now 12 schema Questions ↔ 12 visible entries. |
| **Blog post FAQ** — 4 Q&As | Questions are the real GSC queries this page already gets impressions for (how to resume a session, `--continue` vs `--resume`, where sessions are stored, multiple agents). Answers grounded in the post body. |
| **Shared `Faq.astro` component** | Home + blog render the same accordion; extracting avoids a third copy of the markup. `/vs/*` pages keep their own mono-styled variant (Astro-scoped styles, no clash). |
| **Home → blog deep link** ("How auto-resume works →") | Passes home-page authority to the blog post that's already ranking for the Claude-resume cluster. |
| **Blog → `/vs/tmux/` contextual link** ("tmux alternative") | Feeds the weaker-ranking comparison page from the money page. |
| **`updatedDate: 2026-07-24`** | `BlogPosting.dateModified` now reflects today's real edit — an honest freshness signal. |

Both the visible accordion and the `FAQPage` schema are driven from a single `faq` array (blog frontmatter / `homeFaq`), so visible text and structured data can't drift.

## Notes

- **`/vs/*` pages intentionally untouched** — they already have visible FAQ + schema + matrix + migration notes. Their ranking is authority/depth, not a structural gap.
- **`chore(site):` not `feat:`** — the site lives in this repo and `release.yml` derives the binary version bump from commit types; a `feat` here would spuriously bump the app version for a website change.

## Verification

`npm run build` (`astro check && astro build`) passes; all 15 pages build. Confirmed in the built HTML:
- Home: 12 `Question` schema nodes ↔ 12 visible `<details>` items
- Blog: 4 ↔ 4
- `/vs/*`: unchanged (3 on herdr)
- Both internal links + `dateModified: 2026-07-24` present in output
