### PR TITLE
chore(site): target head terms and expand FAQ on comparison pages

### DIFF
--- a/site/src/components/ComparePage.astro
+++ b/site/src/components/ComparePage.astro
@@ -26,9 +26,14 @@ interface Props {
 const { slug } = Astro.props;
 const info = competitors[slug];
 
+// "a" vs "an" for the "<name> alternative" head term in the meta
+// description — only "Agent of Empires" is vowel-initial today, but the
+// check keeps any future competitor grammatical.
+const article = /^[aeiou]/i.test(info.name) ? "an" : "a";
+
 const seo = {
   title: `Quil vs ${info.name}`,
-  description: `How Quil compares to ${info.name}: side-by-side feature matrix, where each tool wins, and what ${info.name} can't do that Quil can. Reboot-proof persistence, AI session resume, typed panes, MCP server.`,
+  description: `Looking for ${article} ${info.name} alternative? Quil is a reboot-proof terminal multiplexer with AI session resume, typed panes, and an MCP server — see how it compares to ${info.name}.`,
   path: `/vs/${slug}`,
   ogImage: `/og/vs-${slug}.png`,
   keywords: [

--- a/site/src/data/competitors.ts
+++ b/site/src/data/competitors.ts
@@ -180,6 +180,16 @@ export const competitors: Record<CompetitorInfo["slug"], CompetitorInfo> = {
         answer:
           "It depends on what you use tmux for. If you need reboot persistence + AI session continuity, yes. If you need a headless multiplexer for classical server administration, tmux remains the right tool.",
       },
+      {
+        question: "Is Quil a good tmux alternative for AI coding agents?",
+        answer:
+          "For AI-heavy work, yes. tmux keeps sessions alive while its server runs, but it loses everything on a host reboot and has no concept of an AI session. Quil survives a full reboot, auto-resumes Claude Code and OpenCode sessions with the current (post-rotation) session id, and exposes an MCP server so an AI assistant can read and drive the panes directly. For classic headless server administration, tmux is still the better fit.",
+      },
+      {
+        question: "What is the best tmux alternative that survives a reboot?",
+        answer:
+          "tmux, Zellij, WezTerm and GNU Screen all lose their sessions when the host reboots — their persistence only lasts while the server process is alive. Quil was built specifically for this gap: its daemon snapshots the whole workspace to disk continuously, so after a reboot you type one command and the layout, working directories, scrollback, and AI sessions come back in under 30 seconds.",
+      },
     ],
   },
 
@@ -275,6 +285,16 @@ export const competitors: Record<CompetitorInfo["slug"], CompetitorInfo> = {
         question: "Is screen actively maintained?",
         answer:
           "Yes, but slowly. Version 5.0 shipped in 2024 — the first major release since 2014.",
+      },
+      {
+        question: "What is a modern alternative to GNU Screen?",
+        answer:
+          "Any current multiplexer — tmux, Zellij, or Quil — is a straight upgrade from Screen's 1987-era UX, mouse-less defaults, and dated config syntax. Quil goes further than the others by surviving a full host reboot and auto-resuming AI coding sessions, which even tmux doesn't do. If you only need detach-and-reattach on a headless server, tmux is the closest like-for-like replacement.",
+      },
+      {
+        question: "Does Quil run on Windows, unlike GNU Screen?",
+        answer:
+          "Yes. GNU Screen is Unix-only. Quil ships a native Windows binary using ConPTY — no WSL required — alongside its Linux and macOS builds, so it's a cross-platform alternative to Screen for developers who also work on Windows.",
       },
     ],
   },


### PR DESCRIPTION
## Summary

SEO tuning for the `/vs/*` comparison pages, targeting the evergreen head terms they already rank for weakly (GSC: "tmux alternative", "gnu screen alternative" at position ~24–33). Content-depth/authority is the real limiter, so this focuses on the two grounded, code-side levers: exact-phrase targeting + more topical FAQ.

## Changes

**`ComparePage.astro` — meta description (all 6 vs pages):**
- Now leads with the exact query: `Looking for a <name> alternative? Quil is a reboot-proof terminal multiplexer…`
- Added an `a`/`an` article helper so vowel-initial names read correctly (`an Agent of Empires alternative`).

**`competitors.ts` — +2 FAQ each on tmux and GNU Screen:**
- tmux: *"Is Quil a good tmux alternative for AI coding agents?"*, *"What is the best tmux alternative that survives a reboot?"*
- screen: *"What is a modern alternative to GNU Screen?"*, *"Does Quil run on Windows, unlike GNU Screen?"*
- Answers are grounded in existing, documented capabilities (reboot survival, AI session auto-resume, MCP server, native Windows/ConPTY). No new claims.
- Each page's `FAQPage` schema grows from 3 → 5 Questions (visible accordion + schema are driven from the same `info.faq` array, so they stay in sync).

## Not done (deliberately)
- No rewrite of the existing descriptions/positioning/migration copy — it's already solid; a needless rewrite risks degrading good, truthful content.
- Zellij/WezTerm/herdr/aoe FAQ unchanged (only tmux + screen target the high-value evergreen terms).

## Verification
`npm run build` (`astro check && astro build`) passes; all 15 pages build. Confirmed in output:
- Correct `a`/`an` head-term meta on all 6 vs pages
- tmux + screen `FAQPage` at 5 Questions each
