### PR TITLE
docs: backfill changelog, sync roadmap, and gate future entries

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -207,7 +207,7 @@ Project docs are now organized as a navigable tree under `docs/` (with the index
 - `docs/mcp.md` — User-facing MCP guide (client wiring, all 18 tools, redaction model)
 - `docs/plugin-reference.md` — TOML plugin schema (every field, every strategy, examples)
 - `docs/troubleshooting.md` — Daemon won't start, MCP not detected, log file locations, reset
-- `docs/architecture.md` — 24 ADRs (moved from root `ARCHITECTURE.md`)
+- `docs/architecture.md` — 25 ADRs (moved from root `ARCHITECTURE.md`)
 - `docs/vision.md` — Project vision (moved from root `VISION.md`)
 - `docs/prd.md` — Original v1 PRD, historical reference (moved from root `PRD.md`)
 - `docs/roadmap.md` — Milestone status + planned work (moved from root `ROADMAP.md`)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,45 @@ jobs:
 
       - name: installer regression test
         run: sh scripts/test-install.sh
+
+  # The release workflow only inserts a version header above whatever is under
+  # `## [Unreleased]` — it never writes prose. So an entry that is not written
+  # HERE, while the author still has the context, is never written at all: the
+  # version section ships empty and stays empty. Catching it at release time
+  # (release.yml has that gate too, as a backstop) means blocking a release on
+  # a changelog nobody remembers the details for.
+  changelog:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          fetch-depth: 0
+
+      - name: Require a CHANGELOG entry for user-facing changes
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          CHANGED=$(git diff --name-only "$(git merge-base "$BASE" "$HEAD")" "$HEAD")
+          echo "--- changed files ---"
+          echo "$CHANGED"
+          echo "---"
+
+          # Production Go code only. Test-only, docs-only, site-only, workflow-
+          # only, and plugin-TOML-only PRs are exempt — they can't change what a
+          # user sees in the binary.
+          CODE=$(echo "$CHANGED" | grep -E '^(cmd|internal)/.*\.go$' | grep -v '_test\.go$' || true)
+          if [ -z "$CODE" ]; then
+            echo "::notice::No production Go changes — changelog entry not required"
+            exit 0
+          fi
+
+          if echo "$CHANGED" | grep -qx 'CHANGELOG.md'; then
+            echo "::notice::CHANGELOG.md updated"
+            exit 0
+          fi
+
+          echo "::error file=CHANGELOG.md::This PR changes production code but does not touch CHANGELOG.md. Add an entry under '## [Unreleased]' describing the change from a user's point of view — the release workflow copies that section verbatim and cannot write it for you. If the change is genuinely invisible to users (pure refactor, internal cleanup), add the literal line '_No user-facing changes._' under '## [Unreleased]' to say so explicitly."
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,6 +171,45 @@ jobs:
           echo "skip=false" >> $GITHUB_OUTPUT
           echo "::notice::Version bump: ${CURRENT} → ${NEW_VERSION} (${BUMP})"
 
+      - name: Require a non-empty [Unreleased] section
+        # The release "generator" does NOT write changelog prose — it only
+        # inserts a `## [X.Y.Z] - DATE` header above whatever is already under
+        # `## [Unreleased]`. So a PR that ships without an Unreleased entry
+        # produces a version section that is permanently empty in CHANGELOG.md.
+        # That silently happened 42 times (v0.10.2 through v1.40.0), including
+        # feature releases: quil status, split-border drag, auto-update, the
+        # pane context menu, and the command palette's content search all
+        # shipped with no changelog entry at all.
+        #
+        # The goreleaser job's fallback (generate notes from commits) only
+        # rescues the GitHub Release *page* — CHANGELOG.md itself stays blank
+        # forever, and backfilling it later is archaeology. Fail here instead,
+        # BEFORE the version bump is committed and tagged, so the fix is a
+        # one-line commit rather than a released-with-no-notes version.
+        #
+        # Escape hatch for a release with genuinely nothing to tell users
+        # (CI-only, refactor-only): put the sentinel line below in
+        # `## [Unreleased]`. It is deliberately an explicit, greppable
+        # statement — "nothing to say" and "forgot to write it" must not look
+        # identical to this check.
+        #
+        # One failure here is NOT the author's fault: when two PRs merge
+        # back-to-back, this job checks out master at trigger time, so run #1
+        # can sweep BOTH entries into version #1 and leave run #2 with an empty
+        # section. That is how v1.32.1's macOS fixes ended up filed under
+        # v1.32.0, and v1.40.0's palette content search under v1.39.0. If this
+        # gate fires immediately after another release, check whether the
+        # previous version's section is holding this one's entry, and move it
+        # down rather than writing a new one.
+        if: steps.bump.outputs.skip != 'true' && inputs.publish_tag == ''
+        run: |
+          UNRELEASED=$(sed -n '/^## \[Unreleased\]/,/^## \[/{ /^## \[Unreleased\]/d; /^## \[/d; p; }' CHANGELOG.md)
+          if [ -z "$(printf '%s' "$UNRELEASED" | tr -d '[:space:]')" ]; then
+            echo "::error file=CHANGELOG.md::The [Unreleased] section is empty — refusing to cut a release with no changelog entry. Add one under '## [Unreleased]' describing the change from a user's point of view, or, if this release genuinely has nothing user-facing, add the literal line '_No user-facing changes._' there."
+            exit 1
+          fi
+          echo "::notice::[Unreleased] section present ($(printf '%s\n' "$UNRELEASED" | wc -l) lines)"
+
       - name: Update version files
         if: steps.bump.outputs.skip != 'true' && inputs.publish_tag == ''
         env:
@@ -327,6 +366,15 @@ jobs:
           # lone newline (1 byte) for an empty CHANGELOG section, which `[ -s ]`
           # wrongly accepts as non-empty — that bug shipped v1.31.1 with a blank
           # body. Strip whitespace and test for genuinely-empty content.
+          #
+          # The "_No user-facing changes._" sentinel (see the release job's
+          # [Unreleased] gate) counts as empty HERE on purpose: it is an honest
+          # thing to keep in CHANGELOG.md, but a useless release page. Falling
+          # through to the generated notes gives readers the commits instead.
+          if grep -qx '_No user-facing changes\._' release-notes.md; then
+            echo "::notice::CHANGELOG section for v${VERSION} is the no-user-facing-changes sentinel — generating notes from commits/PRs"
+            : > release-notes.md
+          fi
           if [ -z "$(tr -d '[:space:]' < release-notes.md)" ]; then
             echo "::warning::CHANGELOG section for v${VERSION} is empty — generating notes from commits/PRs"
             gh api --method POST "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   only on the focused field, so tabbing from **Working directory** on to the
   toggles erased every trace of the directory you had picked — and the field was
   equally blank while still focused if the cursor sat on the trailing "Browse…"
-  row, which never becomes the answer. The committed row now carries a `•`
+  row, which never becomes the answer. The committed row now carries a `▸`
   marker whenever the cursor is not already on it, so the directory that will
   actually be used stays on screen for the whole dialog. The kube-context list
   had the same gap and gets the same marker.
@@ -110,28 +110,118 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.40.0] - 2026-07-24
 
-## [1.39.0] - 2026-07-23
-
 ### Added
-- Command palette (`Alt+Shift+P`) — a modal, keyboard-first fuzzy-find launcher for every action plus jump-to-tab and jump-to-pane across the workspace. Entries are grouped under section headers (Pane / Go to pane / Tabs / System) with actions first; headers disappear when you type. Type to filter, `Enter` to run, `Esc` to close; each row shows its keybinding. Dispatches into the same handlers the keybindings use. Configurable via `command_palette` (`Ctrl+Shift+P` is opt-in — many terminals intercept it).
 - Command palette content search: as you type, the palette also searches every
   pane's scrollback and lists matching panes in a "Found in panes" section below
   the filtered commands (match count + preview) — one query narrows commands and
   finds content at once, no separate mode. Enter on a match jumps to that pane.
+  Background and muted panes are searched too; a search that never comes back
+  shows a timed-out row instead of an endless "Searching…".
+
+## [1.39.0] - 2026-07-23
+
+### Added
+- Command palette (`Alt+Shift+P`) — a modal, keyboard-first fuzzy-find launcher for every action plus jump-to-tab and jump-to-pane across the workspace. Entries are grouped under section headers (Pane / Go to pane / Tabs / System) with actions first; headers disappear when you type. Type to filter, `Enter` to run, `Esc` to close; each row shows its keybinding. Dispatches into the same handlers the keybindings use. Configurable via `command_palette` (`Ctrl+Shift+P` is opt-in — many terminals intercept it).
 
 ## [1.38.0] - 2026-07-19
 
+### Added
+- **Pane context menu** — right-click a pane (or press `Alt+A`) for a popup of
+  everything you can do to it: split, focus, rename, notes, input history,
+  lazygit, mute, always-resume, restart, close. The menu targets the pane under
+  the cursor and highlights it, so it works on any pane without focusing it
+  first. Rows that don't apply are greyed with the reason (input history on a
+  pane type that doesn't record it, lazygit when the binary isn't installed).
+- **Mark attention** — a context-menu action that pins the green attention
+  border to a pane and keeps it there until you clear it. Unlike the automatic
+  unseen mark, focusing the pane does not remove it, so you can flag a pane to
+  come back to.
+
+### Changed
+- Right-clicking a pane that has an active text selection still copies the
+  selection, as before — the menu only opens when there is nothing selected.
+
 ## [1.37.0] - 2026-07-18
+
+### Added
+- **Automatic updates** — Quil now notices new releases, downloads them in the
+  background, and can install one without you leaving the app. The status bar
+  shows `↑ v1.37.0 [ready]` when an update is staged, and F1 → "Check for
+  updates" runs a real check on demand. Applying swaps both binaries and
+  restarts Quil; your panes come back from the workspace snapshot as they do
+  after any restart.
+- Two settings under `[update]` in `~/.quil/config.toml`, both editable in the
+  F1 → Settings dialog: `check` (look for new releases; on by default) and
+  `auto` (download them in the background so applying is instant).
+
+### Fixed
+- Downloads are verified against the release checksums before anything is
+  swapped, and the previous binaries are kept as a backup that is restored if
+  the swap fails halfway.
+
+### Changed
+- Dev and debug builds have the whole update pipeline compiled out. Applying a
+  release build over `quil-dev` would strip its dev-mode wiring and silently
+  point the next launch at your production `~/.quil` data.
 
 ## [1.36.2] - 2026-07-17
 
+### Fixed
+- **Orphaned MCP bridges on Windows** — `quil mcp` processes no longer pile up
+  after the AI client that spawned them exits. Stdin EOF is not a reliable
+  end-of-life signal on Windows: clients spawn stdio servers concurrently, and a
+  sibling process inherits the pipe handle, so the bridge kept waiting on a
+  stdin that would never close. Observed as 20 abandoned bridges accumulating
+  over a week, each holding a live connection to the daemon. The bridge now
+  watches the process that started it and exits when that process does, with a
+  guard against a recycled process id being mistaken for a live parent. Covers
+  pane kill, pane restart, session restart, and client crash.
+
 ## [1.36.1] - 2026-07-16
+
+### Fixed
+- **Work spinner going dark while subagents are still running** — Claude Code
+  runs subagents detached, so the main turn reports "stop" while the subagents
+  are still grinding. The spinner treated that as end-of-work and the pane went
+  quiet with a green "done" mark exactly during the heaviest phase. Outstanding
+  subagents are now counted: the spinner keeps running until the last one
+  finishes, and only then does the pane get its unseen mark. A session ending
+  clears the count, so a lost subagent event can't leave the spinner stuck on.
 
 ## [1.36.0] - 2026-07-15
 
+### Added
+- **Drag a split border to resize panes** — click and drag any border between
+  two panes to move the split, like every other tiling terminal. The panes on
+  each side of the dragged line highlight while you drag. The size is clamped so
+  no pane can be squeezed below a usable minimum, including through nested
+  splits. The PTY resize and the layout save happen once when you release the
+  mouse, not continuously during the drag — mid-drag resizes are what garble a
+  running program's output. Disabled in focus mode, notes mode, and on
+  single-pane tabs; the scrollbar keeps priority over its own column.
+
 ## [1.35.0] - 2026-07-09
 
+### Added
+- **`quil status`** — a scriptable health check for the daemon (alias
+  `quil daemon status`). Reports whether the daemon is running, its pid,
+  version, environment (production or dev), roughly how long it has been up,
+  and a per-tab/pane breakdown with each pane's state and memory use. `--json`
+  emits the same data for scripts. Exit codes distinguish a healthy daemon from
+  one that isn't running from one that is wedged, so it works in a monitoring
+  loop.
+
 ## [1.34.2] - 2026-07-08
+
+### Fixed
+- **Input history filled with machine-generated turns** — the `Alt+Shift+I`
+  history for Claude Code panes listed `<task-notification>` blocks (task ids,
+  tool-use ids, usage stats) alongside your actual prompts. Claude Code fires
+  the same prompt-submitted hook for synthetic turns, which is how the harness
+  resumes the loop when a background task finishes. Those turns are now skipped
+  when recording, filtered when the list is displayed (so history recorded
+  before this release is clean too), and dropped when the file is trimmed. A
+  prompt of yours that merely quotes the tag is preserved.
 
 ## [1.34.1] - 2026-07-08
 
@@ -155,27 +245,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.34.0] - 2026-07-06
 
+### Added
+- **AI panes render at their real size when they're wide enough** — a Claude
+  Code or OpenCode pane used to always render on a window-wide canvas and show a
+  cropped view of it, which protected the program from constant resizes but cost
+  you selection and made the crop visible. Once a pane is at least 80 columns
+  wide (`[display] min_native_cols`) it now renders natively at its own size,
+  which brings back mouse and keyboard text selection. Below the threshold it
+  falls back to the canvas as before — and even then, mouse selection now works
+  on the cropped view.
+
 ## [1.33.1] - 2026-07-05
+
+### Fixed
+- **Garbled claude-code panes after working in a multi-pane tab** — mixed-width
+  line wraps and duplicated chunks of transcript accumulated over a session.
+  Claude Code hard-wraps its transcript at the width it streamed at and
+  re-renders its tail on every resize, and Quil resized panes far more often
+  than a real terminal does: toggling the notification sidebar, entering focus
+  mode, splitting, and every state broadcast each triggered one. The
+  notification sidebar is now drawn as an overlay that reserves no layout width,
+  so `Alt+N` no longer resizes anything, and same-size resizes are dropped
+  before they reach the PTY.
+- **Session resume after a pane restart** — restarting a Claude Code pane could
+  reattach to the session chosen when the pane was created rather than the
+  conversation it is actually in now.
 
 ## [1.33.0] - 2026-07-03
 
+### Added
+- **Model and context usage in the status bar** — AI panes show the model and
+  the context-window token count from the last completed turn, e.g.
+  `opus-4.8 · 612k ctx`. The number is the real total (input plus cached
+  tokens), deliberately shown as tokens and not a percentage, because the window
+  size isn't recorded in either tool's data and a Claude session may run at 200k
+  or 1M. Right after a compaction the pane shows `· compacting` until the next
+  turn reports the reduced size, rather than displaying a stale pre-compaction
+  count.
+
 ## [1.32.2] - 2026-07-03
 
+### Fixed
+- **Work spinner broken by muting a pane** — muting a pane instantly killed its
+  work-in-progress spinner and unmuting never brought it back, even while the
+  pane was still working. Mute is meant to silence the notification sidebar, not
+  to blind the spinner; work-state events now keep flowing to the TUI for a
+  muted pane while its notification cards stay suppressed.
+
 ## [1.32.1] - 2026-07-03
-
-## [1.32.0] - 2026-07-02
-
-### Added
-
-- **Mouse-wheel scrolling in AI/TUI panes** — scrolling the wheel over a pane
-  running an app that handles its own mouse input (opencode, claude-code, vim,
-  htop, lazygit, …) now scrolls that app's viewport instead of doing nothing.
-  These apps run on the alternate screen, which never fills Quil's local
-  scrollback, so the wheel is forwarded straight to the program. The daemon
-  detects when a pane's program enables mouse tracking — reliable even when you
-  reattach to an already-running session — and the client forwards each wheel
-  notch as the matching mouse sequence. Plain terminal/shell panes keep
-  scrolling Quil's own scrollback as before.
 
 ### Fixed
 
@@ -193,9 +310,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   keys, so claude-code and shell readline word navigation work with no extra
   configuration. `Ctrl+Arrow` word-jump on Windows/Linux is unchanged.
 
+## [1.32.0] - 2026-07-02
+
+### Added
+
+- **Mouse-wheel scrolling in AI/TUI panes** — scrolling the wheel over a pane
+  running an app that handles its own mouse input (opencode, claude-code, vim,
+  htop, lazygit, …) now scrolls that app's viewport instead of doing nothing.
+  These apps run on the alternate screen, which never fills Quil's local
+  scrollback, so the wheel is forwarded straight to the program. The daemon
+  detects when a pane's program enables mouse tracking — reliable even when you
+  reattach to an already-running session — and the client forwards each wheel
+  notch as the matching mouse sequence. Plain terminal/shell panes keep
+  scrolling Quil's own scrollback as before.
+
 ## [1.31.2] - 2026-06-18
 
+### Fixed
+- Releases whose changelog section contained only whitespace were published with
+  a blank description instead of falling back to generated notes — the check
+  treated a lone newline as real content. This shipped v1.31.1 with an empty
+  release page.
+
 ## [1.31.1] - 2026-06-18
+
+### Fixed
+- Every release now gets a description: when a release ships without a changelog
+  entry, the release page falls back to notes generated from its commits and
+  pull requests instead of publishing empty (as v1.29.0 and v1.31.0 did).
+- Fixed a race that made quil.cc deployments fail with "Deployment failed, try
+  again later" when a release and a site change landed together. The release
+  workflow no longer deploys the site itself; the version bump it pushes
+  triggers the site workflow, which is now the only thing that deploys.
 
 ## [1.31.0] - 2026-06-18
 
@@ -233,6 +379,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.29.0] - 2026-06-17
 
+### Changed
+- **Stop daemon moved to the F1 root menu** — it now sits alongside Settings,
+  Shortcuts, Plugins, Memory, and the log viewers instead of being buried in the
+  Settings list. Confirming still requires `y` rather than Enter, so a reflexive
+  Enter can't take down every pane, and Esc returns to the menu with the cursor
+  where you left it.
+- **Wider lazygit repository picker** — the picker shown when a pane's directory
+  contains several git repositories grew from 60 to 90 columns, so long paths
+  keep the tail that tells them apart instead of being truncated to a common
+  prefix.
+
 ## [1.28.0] - 2026-06-15
 
 ### Added
@@ -267,13 +424,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.26.0] - 2026-06-15
 
+### Added
+- **Restore progress for panes that are coming back** — a restored or
+  slow-starting pane now shows a centered checklist instead of an empty box that
+  looks frozen: session loaded → history restored (with the line count) or
+  restored via the tool's own resume, or none saved → resuming the tool →
+  waiting for first output, with a spinner on the current step. It stays up
+  through a multi-second boot (claude-code clears the screen before it paints)
+  and disappears the moment real output arrives. Panes on other tabs that are
+  restored lazily show it when they actually start, not at the original restart.
+
 ## [1.25.1] - 2026-06-15
+
+### Fixed
+- Website: social preview images on pages with an absolute image URL were
+  double-prefixed and failed to load.
 
 ## [1.25.0] - 2026-06-15
 
+### Changed
+- Website: real product screenshots on quil.cc and in the README, served from a
+  CDN, replacing the placeholder imagery on the landing page, feature catalog,
+  and blog.
+
 ## [1.24.0] - 2026-06-15
 
+### Added
+- Website: a blog at [quil.cc/blog](https://quil.cc/blog), starting with a post
+  on how Claude Code session resume works in Quil.
+
 ## [1.23.1] - 2026-06-14
+
+### Fixed
+- Website: corrected the advertised MCP tool count and the AI-resume claim on
+  quil.cc, which had drifted behind the shipped feature set, plus an SEO title
+  fix.
 
 ## [1.23.0] - 2026-06-13
 
@@ -289,17 +474,84 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.21.1] - 2026-06-12
 
+### Fixed
+- **Daemon freeze whenever Claude Code rang the terminal bell** — the whole
+  daemon (every pane, every tab) could stop responding, most often right when
+  Claude asked for your attention or finished compacting. The bell handler held
+  a per-pane lock while raising the notification event, and raising the event
+  needed the same lock to check whether the pane was muted — so the first
+  un-cooled-down bell deadlocked the pane's output goroutine, and the snapshot
+  loop, idle checker, memory report, and pane input all piled up behind it. This
+  was the root cause of the remaining production freezes, caught by the
+  goroutine dump added in v1.20.3.
+
 ## [1.21.0] - 2026-06-12
+
+### Added
+- **Restart a pane from the keyboard** — `Alt+R` restarts the active pane behind
+  a confirmation dialog, using the same kill-and-respawn path as the MCP
+  `restart_pane` tool, so session resume and pane settings are preserved.
+  Configurable via the `restart_pane` keybinding.
 
 ## [1.20.3] - 2026-06-12
 
+### Fixed
+- **Daemon freeze caused by a pane that stops reading input** — a child process
+  that stalls (observed with Claude Code after context compaction) filled its
+  input buffer, and the daemon blocked forever trying to write to it. Because
+  that write happened on the connection's shared dispatch path, *every* pane's
+  keyboard input died with it. Input is now handed to a per-pane writer with a
+  bounded queue; a stalled pane drops its own keystrokes and posts a "Pane not
+  accepting input" notification instead of freezing the app.
+- **Daemon freeze when closing a pane or tab whose child won't exit** — closing
+  waited for the child to be reaped while holding the lock that every other
+  operation needs, so the snapshot loop, attach, tab switch, and memory
+  reporting all died behind it. Panes are now detached under the lock and closed
+  outside it.
+- Added a watchdog that dumps all goroutine stacks to the log when no workspace
+  snapshot completes for two minutes, so a future freeze names its own culprit.
+
 ## [1.20.2] - 2026-06-12
+
+### Fixed
+- Made an internal connection-teardown test deterministic; it intermittently
+  failed CI and blocked releases.
 
 ## [1.20.1] - 2026-06-12
 
+### Fixed
+- **Tab color cycle stuck on the last color** — cycling a tab's color with
+  `Alt+C` wrapped back to "no color" in the client, but the daemon read the
+  empty color as "leave it unchanged" and the next state broadcast snapped the
+  tab back to orange. Clearing a color is now sent explicitly, so the cycle
+  completes.
+
 ## [1.20.0] - 2026-06-11
 
+### Added
+- **`quil restart`** — stops the daemon and starts a fresh one with the TUI in a
+  single command, plus `quil daemon stop` / `quil daemon restart` for the daemon
+  alone. Stopping escalates: a graceful shutdown request, then a terminate
+  signal, then a kill, each with its own bounded wait, so it also works against
+  a daemon that has stopped responding. Stale socket and pid files are cleaned
+  up afterwards, and the command prints which environment (production or dev) it
+  acted on before doing anything.
+
+### Fixed
+- `quil daemon stop` no longer intermittently does nothing. The shutdown request
+  was queued on a connection that the command then closed, discarding it.
+
 ## [1.19.1] - 2026-06-11
+
+### Fixed
+- **macOS: `zsh: killed quil` after upgrading** — the installer overwrote
+  binaries in place, reusing the file's identity on disk. macOS caches code
+  signatures per file, so the kernel killed the newly installed binary at launch
+  as an invalid signature, and reinstalling never fixed it. The installer now
+  writes each binary to a temporary file and moves it into place, which both
+  prevents the problem and repairs machines already stuck in that state — just
+  re-run the normal install command. Added a troubleshooting entry with the
+  diagnosis and the manual fallback for anyone on an old copy of the installer.
 
 ## [1.19.0] - 2026-06-11
 
@@ -357,9 +609,60 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.18.0] - 2026-06-09
 
+### Added
+- **Work-in-progress indicators for AI panes** — a spinner appears on the pane
+  border and its tab label while a Claude Code or OpenCode pane is working, and
+  clears when the turn ends. It is driven by the agent's own lifecycle hooks
+  rather than by guessing from screen output, so it is accurate through long
+  turns with no output. A pane that is waiting on you — a permission prompt or
+  an option prompt — stops spinning and flags for attention, then resumes when
+  you answer.
+- **Native Claude Code hook** — Quil's hook is now a built-in subcommand instead
+  of a generated shell/PowerShell script. It starts in tens of milliseconds
+  rather than seconds, and it removes an entire class of encoding bugs that
+  broke the old scripts on non-UTF-8 Windows code pages. Quil still registers
+  its hooks per pane at launch and never modifies your `~/.claude/settings.json`.
+
 ## [1.17.0] - 2026-06-09
 
+### Added
+- **Always resume** (`Alt+Shift+E`) — mark a pane to be started immediately on
+  daemon restart instead of when you first visit it. Tabs containing such a pane
+  show a `●` marker.
+
+### Changed
+- **Restarting with a large workspace no longer disconnects the TUI.** With many
+  tabs and AI panes, the daemon restored everything at once and force-closed the
+  busy client mid-restore (observed: 13 tabs / 12 Claude panes, TUI closing
+  itself about a minute after launch). Two changes fix it: on restart the daemon
+  now starts only the active tab's panes plus any marked "always resume", and
+  defers the rest until you switch to them; and a client that falls behind now
+  sheds live output frames instead of being disconnected — only a genuinely
+  wedged client is dropped.
+
+### Fixed
+- **Log files grow without bound** — `quild.log` and `quil.log` now rotate at
+  `[logging] max_size_mb` (default 5 MB), keeping `max_files` timestamped
+  archives (default 10) and pruning the rest. These settings existed but were
+  never honored; production logs had reached 74 MB and 182 MB.
+
 ## [1.16.1] - 2026-06-08
+
+### Fixed
+Windows rendering and pane-sizing fixes, all seen in the legacy console host:
+- **No visible caret** in interactive panes (claude-code, opencode). Every pane
+  type now draws its own caret into the frame.
+- **Column drift after emoji or CJK characters** — a phantom space was emitted
+  for the second half of a double-width character, pushing everything after it
+  one cell to the right.
+- **Panes stuck at 80×24 after starting or restoring** — the Windows console
+  drops resize events sent before the child starts reading input and never
+  replays them. The size is now re-applied on the pane's first output, and pane
+  dimensions are saved so restored panes start at the right size.
+- **Window resize not picked up** — maximizing or restoring the window could
+  leave Quil rendering at the old size. A one-second size poll recovers it, and
+  the new `redraw` keybinding (`Alt+Shift+L`) forces a full repaint plus a size
+  re-query.
 
 ## [1.16.0] - 2026-06-08
 
@@ -415,6 +718,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.13.0] - 2026-06-05
 
+### Changed
+- Documentation restructured into a navigable `docs/` tree with an index, and a
+  new user-facing MCP guide covering client setup, every tool, and the
+  redaction model. Only `README.md`, `CHANGELOG.md`, `CONTRIBUTING.md`, and
+  `LICENSE` remain at the repository root.
+
 ## [1.12.0] - 2026-05-22
 
 ### Added
@@ -447,6 +756,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Notes editor focus indicator is now non-subtle** — when the pane-notes editor (Alt+E) is open, the header carries a persistent reverse-video badge: `INPUT` on bright blue when keystrokes route to the editor, `PANE` on orange when they route to the bound PTY. Border colour alone was easy to miss in peripheral vision, leaving a defence-in-depth gap against synthesised mouse-click focus redirection. At narrow widths the badge degrades to single-letter form (`I` / `P`) before falling back to an empty header — never to a corrupted partial that would give the same visual on both sides. Implementation uses explicit `Background`+`Foreground` rather than `Reverse(true)` so the fill colour is stable across terminal themes.
 
 ## [1.10.1] - 2026-04-25
+
+### Changed
+- Documentation caught up with v1.8.0–v1.9.x: the version handshake, the VT
+  drain fix, and the Claude Code session hook are now described in the README,
+  roadmap, and architecture docs.
 
 ## [1.10.0] - 2026-04-24
 
@@ -520,7 +834,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Pane CWD ignored on creation** — selecting a working directory in the pane setup dialog (Ctrl+N → CWD browser) had no effect; the spawned process always started in the daemon's own working directory. `spawnPane()` now calls `ptySession.SetCWD(pane.CWD)` before `Start()`. The redundant `SetCWD` calls in `respawnPanes()` were removed — `spawnPane` is now the single source of truth for CWD application.
 
 ## [1.4.2] - 2026-04-14
+
+### Fixed
+- The release workflow now deploys quil.cc, so the website no longer lags a
+  release.
 ## [1.4.1] - 2026-04-14
+
+### Fixed
+- Website: a FAQ entry was missing its question text.
 
 ## [1.4.0] - 2026-04-14
 
@@ -546,6 +867,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`quild` background mode** — stdout/stderr prints gated on `!background` instead of redirecting to `/dev/null` (eliminates a file descriptor leak).
 
 ## [1.3.1] - 2026-04-09
+
+### Fixed
+- Release notes were not being applied to published releases, and the version
+  pill on quil.cc stayed at 1.2.1 regardless of the release.
 
 ## [1.3.0] - 2026-04-08
 
@@ -586,11 +911,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.2.1] - 2026-04-07
 
+### Changed
+- Website redesign: ember palette, monospace hero, matte-black cards.
+
+### Fixed
+- Website: sitemap entries and canonical URLs now match how GitHub Pages
+  actually serves the site, so search engines see one URL per page instead of
+  two.
+
 ## [1.2.0] - 2026-04-07
+
+### Added
+- Website: per-page social preview images, richer structured data, and a web app
+  manifest; page freshness dates now come from git history.
 
 ## [1.1.0] - 2026-04-07
 
+### Added
+- The marketing site at [quil.cc](https://quil.cc) — landing page, feature
+  catalog, install instructions, and plugin overview.
+
 ## [1.0.0] - 2026-04-07
+
+### Changed
+- **Renamed the project from Aethel to Quil.** The binaries are now `quil` and
+  `quild`, the data directory is `~/.quil/`, the config file is
+  `~/.quil/config.toml`, and the environment override is `QUIL_HOME`. There is
+  no automatic migration: move `~/.aethel/` to `~/.quil/` to keep an existing
+  workspace, and update any MCP client configuration that referenced the old
+  binary name.
 
 ## [0.13.0] - 2026-04-07
 
@@ -617,6 +966,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `cmd/quil/main.go` calls `Model.FlushNotes()` on TUI exit as a safety net for unsaved notes
 
 ## [0.12.1] - 2026-04-05
+
+### Fixed
+- Release notes are now applied to published GitHub releases.
 
 ## [0.12.0] - 2026-04-05
 
@@ -664,6 +1016,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Notification center PRD update** — added MCP integration section: `watch_notifications` blocking tool, event hub architecture, AI as event consumer
 
 ## [0.10.2] - 2026-03-24
+
+### Fixed
+- Fixed the release build, which was failing to produce binaries.
 
 ## [0.10.1] - 2026-03-24
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,11 +78,13 @@ PRs get squash-merged to `master` for a clean history. GitHub uses the **PR titl
 
 > **A non-conventional PR title silently skips the release.** The bump regex requires the type followed by `:`, `(`, or `/` (e.g. `fix:`, `fix(tui):`, `fix/…`). A title like `Fix the pane bug` matches nothing, so the release job logs `No version-bumping commits found` and exits without tagging — the merge lands on `master` but never ships. If a merged change didn't produce a release, check the PR title first.
 
+> **A PR that touches `cmd/` or `internal/` must also touch `CHANGELOG.md`.** CI enforces this. The release pipeline only inserts a `## [X.Y.Z]` header above whatever is already under `## [Unreleased]` — it never writes prose — so an entry you don't write in the PR is never written at all, and the released version ships with a permanently empty section. If the change genuinely has nothing to tell users (pure refactor, internal cleanup), say so explicitly with the literal line `_No user-facing changes._` under `## [Unreleased]`. Test-only, docs-only, and site-only PRs are exempt.
+
 ## Documentation maintenance
 
 When your change adds a new feature, configuration knob, or significant architectural decision:
 
-- Update [CHANGELOG.md](CHANGELOG.md) — add a line under `[Unreleased]`. The release pipeline rotates it into a dated section on the next bump.
+- Update [CHANGELOG.md](CHANGELOG.md) — add an entry under `[Unreleased]`, written for a user rather than a reviewer: what changed for them, and what was wrong before if it's a fix. The release pipeline rotates it into a dated section on the next bump and copies it verbatim to the GitHub release page.
 - Update the matching doc in [docs/](docs/):
   - New feature → [features.md](docs/features.md)
   - New config key → [configuration.md](docs/configuration.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,7 @@
 
 | Doc | What's in it |
 |---|---|
-| [Architecture](architecture.md) | All 24 ADRs — client-daemon split, IPC protocol, PTY cross-platform, persistence model, plugin system |
+| [Architecture](architecture.md) | All 25 ADRs — client-daemon split, IPC protocol, PTY cross-platform, persistence model, plugin system |
 | [Vision](vision.md) | The project's why — what problem Quil solves and how |
 | [Product requirements](prd.md) | Original PRD (historical reference) |
 | [Roadmap](roadmap.md) | Milestone summary + planned work — see also [roadmap/](roadmap/) for per-feature PRDs |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,6 +2,13 @@
 
 Detailed progress tracker and future plans for Quil.
 
+**Reflects shipped state as of v1.42.1.** Completed entries are ordered roughly
+chronologically and tagged with the release that shipped them; anything below the
+`In Progress` divider is unimplemented unless it says otherwise. When a feature
+ships, update this file in the same PR — the `Completed` section is the answer to
+"what does Quil actually do today", and it drifts fast when features ship straight
+from a plan in `docs/superpowers/plans/` with no PRD in `docs/roadmap/`.
+
 ---
 
 ## Completed
@@ -24,14 +31,21 @@ Session resume infrastructure is complete. The `preassign_id` strategy generates
 ### M4: Plugin System
 > Typed panes with TOML plugins, plugin registry, pane creation dialog.
 
-The plugin system is fully operational. 4 built-in plugins ship with Quil:
+The plugin system is fully operational. 9 built-in plugins ship with Quil — two Go
+built-ins plus seven embedded TOML defaults written to `~/.quil/plugins/` on first
+run (user copies override them):
 
-| Plugin | Status | Persistence |
-|--------|--------|-------------|
-| **Terminal** | Production | `cwd_only` — restore working directory |
-| **Claude Code** | Production | `preassign_id` — UUID-based session resume |
-| **SSH** | POC | `rerun` — reconnect with same args |
-| **Stripe** | POC | `rerun` — re-listen with same webhook URL |
+| Plugin | Status | Persistence | Shipped |
+|--------|--------|-------------|---------|
+| **Terminal** | Production | `cwd_only` — restore working directory | M4 |
+| **Terminal (wide canvas)** | Production | `cwd_only` — keeps content on squeeze | v1.34.0 |
+| **Claude Code** | Production | `preassign_id` / `--resume` — session resume | M4 |
+| **OpenCode** | Production | `session_scrape` via JS plugin hook | v1.12.0 |
+| **SSH** | POC | `rerun` — reconnect with same args | M4 |
+| **Stripe** | POC | `rerun` — re-listen with same webhook URL | M4 |
+| **lazygit** | Tool | `rerun` — plus per-tab `Alt+G` overlay | v1.22.0 |
+| **k9s** | Tool | `rerun` — kube-context pick via `discover = "kube"` | v1.27.0 |
+| **lazysql** | Tool | `rerun` — connections stay in lazysql's manager | v1.28.0 |
 
 Key capabilities:
 - **TOML plugin format** — user-created plugins in `~/.quil/plugins/*.toml`
@@ -90,7 +104,7 @@ Key capabilities:
 `quil mcp` subcommand bridges MCP JSON-RPC (stdio) to daemon IPC (socket). AI assistants can read pane output, send commands, take screenshots, navigate tabs, restart panes, and control the TUI. No other terminal multiplexer offers this.
 
 Key capabilities:
-- **17 MCP tools** — Phase A (workspace control): `list_panes`, `read_pane_output`, `send_to_pane`, `get_pane_status`, `create_pane`. Phase B (interaction + introspection): `send_keys`, `restart_pane`, `screenshot_pane`, `switch_tab`, `list_tabs`, `destroy_pane`, `set_active_pane`, `close_tui`. Notification Center (M12): `get_notifications`, `watch_notifications`. Memory Reporting (M13): `get_memory_report`, `get_pane_memory`
+- **18 MCP tools** — Phase A (workspace control): `list_panes`, `read_pane_output`, `send_to_pane`, `get_pane_status`, `create_pane`. Phase B (interaction + introspection): `send_keys`, `restart_pane`, `screenshot_pane`, `switch_tab`, `list_tabs`, `destroy_pane`, `set_active_pane`, `close_tui`. Notification Center (M12): `get_notifications`, `watch_notifications`, `dismiss_notifications`. Memory Reporting (M13): `get_memory_report`, `get_pane_memory`
 - **Official MCP SDK** — `modelcontextprotocol/go-sdk` v1.4+, typed tool handlers with struct-based input schemas
 - **Request-response IPC** — backward-compatible `Message.ID` field for correlation; daemon responds to specific connection
 - **VT-emulated screenshots** — `charmbracelet/x/vt` renders ring buffer into text grid showing actual screen state
@@ -179,6 +193,97 @@ Key capabilities:
 - **Notes outlive the pane** — closing or destroying a pane does not delete its notes file; browser ships in Phase 2
 - **TextEditor reuse** — the existing rune-aware editor (selection, clipboard, multi-line paste, word jumps) gained a `Highlight` field so it can render plain text with no TOML colouring
 
+### v1.17.0: Robust Restart — Lazy Restore, Log Rotation, IPC Backpressure
+> Daemon restart survives a large workspace instead of stalling on it.
+
+`respawnPanes` now spawns only the active tab's panes plus panes flagged **always resume** (`Alt+Shift+E`, `●` in the tab bar) before it starts listening; everything else is marked pending and spawned on first access. IPC gained a dual-queue design per connection — a must-deliver critical queue and a droppable live-output queue — so one wedged client can no longer block broadcast to the others. Log rotation (`max_size_mb` / `max_files`) landed in the same release.
+
+Follow-ups: **v1.34.1** raised the client-side readiness wait from 2 s to 30 s (crash-aware, aborts early if the spawned daemon actually dies) and added a single-instance guard so a redundant `quild --background` defers to the healthy daemon instead of stealing its socket and orphaning it.
+
+### v1.18.0–v1.19.0, v1.33.0: Agent Work-State Indicators & Hook-Events Pipeline
+> The TUI knows when an agent is working, blocked, or done — from the agent's own hooks, not from screen scraping.
+
+Quil registers hooks into Claude Code (native `quild claude-hook` subcommand, 12 events, inline `--settings`) and OpenCode (embedded JS plugin, `OPENCODE_CONFIG_CONTENT`) at every spawn, never touching the user's own config. Events land in a per-pane JSONL spool, are rate-limited and debounce-coalesced by `internal/hookevents`, and flow through the existing notification pipeline.
+
+Key capabilities:
+- **Working spinner** — braille spinner on the tab label and the pane's top border while a turn or any background subagent is running. Subagents are counted, so a parallel 3-subagent spawn does not undercount to 1
+- **Persistent unseen mark** (v1.19.0) — a completed turn leaves a green pane border and green tab label until you focus the pane. Replaced the old 5 s tab flash, which you missed if you were looking elsewhere
+- **Blocked-for-input edges** — permission prompts and option prompts park the spinner and raise the unseen mark, then resume when you answer
+- **Model + context segment** (v1.33.0) — AI panes show the last completed turn's model id and context-window token count in the status bar (`opus-4.8 · 612k ctx`), riding the same hook events with no new IPC. Compaction renders `· compacting` until the next turn reports the true reduced size
+- **Hook health fallback** — if hooks never load, the legacy idle-pattern analysis still fires, so notification coverage degrades rather than disappearing
+
+### v1.20.0–v1.21.0: Daemon Lifecycle CLI + Pane Restart
+> `quil restart`, `quil daemon stop|restart`, and `Alt+R` to restart a single pane.
+
+Bounded escalation for stopping a daemon — IPC `MsgShutdown` (5 s) → SIGTERM (3 s, Unix) → SIGKILL (2 s) — shared by the CLI and the upgrade path, with a PID-reuse guard that refuses to signal a PID whose image name is not `quild*`. `Alt+R` restarts the active pane through the same daemon-side kill+respawn the MCP `restart_pane` tool uses, behind a confirm dialog.
+
+### v1.22.0–v1.29.0: Tool Plugins & Discoverability
+> lazygit, k9s, and lazysql as first-class pane types; uninstalled tools stay visible.
+
+- **lazygit** (v1.22.0) — built-in plugin plus a per-tab `Alt+G` overlay that drops into a git UI for whatever repo the active pane is in. Overlays are ephemeral: one per tab, excluded from snapshots, auto-destroyed when you quit lazygit. New `discover = "git"` plugin field lists repos near the pane's CWD in the setup dialog
+- **k9s** (v1.27.0) — Kubernetes TUI with a kube-context picker backed by the new `discover = "kube"` field, reading context names only from `KUBECONFIG` / `~/.kube/config`, never credentials
+- **lazysql** (v1.28.0) — database TUI; connection selection and credentials stay inside lazysql's own manager, deliberately with no Quil-side DSN picker
+- **Greyed-not-hidden plugins** (v1.27.0) — plugins whose binary is not on `PATH` now appear greyed in `Ctrl+N` with a `homepage` link instead of vanishing, so the feature is discoverable before the tool is installed
+
+### v1.30.0: Per-Pane Input History
+> `Alt+Shift+I` lists every prompt you submitted to an AI pane.
+
+Recorded by the Claude Code `UserPromptSubmit` hook (opt-in per plugin via `[command] record_history = true`), stored at `~/.quil/history/<pane>.jsonl`, ring-trimmed to the last 200 entries, and removed when the pane is destroyed. `Enter` opens the full text in the read-only viewer. Machine-injected turns (background-task notifications) are filtered on write, on read, and on compaction so they never pollute the list. OpenCode support is still pending — its message handler does not yet extract prompt text.
+
+### v1.31.0: Bundled OpenConsole for Windows 10 — [ADR-25](architecture.md)
+> Fixes the `Hello` → `H ello` caret gap when typing in AI panes on Windows 10.
+
+The Windows 10 inbox console host re-serializes claude-code's incremental input render incorrectly. Quil now bundles Microsoft's OpenConsole (MIT) and routes the three pseudoconsole syscalls through it — on Windows 10 and older only, detected via `RtlGetVersion().BuildNumber < 22000`. Windows 11 keeps its unaffected inbox host. Falls back to the inbox host if the bundle is missing. Binaries are fetched at build time, not committed.
+
+### v1.32.0: Mouse-Wheel Forwarding + macOS Render Fixes
+> The wheel scrolls the app's own viewport in AI/TUI panes; claude-code no longer corrupts on Terminal.app.
+
+Apps that enable DEC mouse tracking run on the alternate screen and never fill Quil's scrollback, so the wheel had nothing to scroll. The daemon is the authority on tracking state — it is the only component that sees the mode-enable burst on every attach, including reattach to an already-running session — and the client forwards each notch as the matching SGR or X10 sequence.
+
+Same release fixed two macOS-only defects: the bundled emulator terminated OSC strings on a raw `0x9C` byte even mid-UTF-8, so claude-code's `✳` title spilled into the visible grid (doubled logo, `AAA` → `AAAude Code`); Quil now filters window-title OSCs before the emulator. And `Alt+<printable>` is forwarded as Meta so Option-based readline word navigation works.
+
+### v1.34.0: Wide-Canvas Panes with a Native Threshold
+> AI panes stop reformatting themselves every time the layout changes.
+
+AI panes render on a window-sized canvas so grid, zoom, and sidebar changes never resize their PTY. v1.34.0 added the inverse: once a pane's inner width reaches `[display] min_native_cols` (default 80) it renders **natively** at its real size, which restores mouse and keyboard selection for free. Below the threshold it falls back to the canvas plus a preview crop, with mouse selection mapped through the inverse layout. The `terminal-wide` built-in exposes the same behaviour for shells.
+
+### v1.35.0: `quil status`
+> Scriptable daemon and session introspection.
+
+Top-level command (alias `quil daemon status`) reporting daemon liveness, pid, version, environment, approximate uptime, and per-tab/pane session metrics with state and memory. `--json` for scripting; exit codes distinguish healthy / not-running / wedged.
+
+### v1.37.0: Automatic Updates — [plan](superpowers/plans/2026-07-18-auto-update.md)
+> Detect, stage, and apply a new release without leaving Quil.
+
+The daemon checks GitHub releases 1 min after startup then every 24 h, publishes the result on the workspace broadcast, and can stage the download in the background. Staging is sha256-verified and extracts to `$QUIL_HOME/update/staged/<ver>/` with `manifest.json` written last as the atomic completion marker. Applying does a rename-aside binary swap with pair rollback, then respawns itself.
+
+Key capabilities:
+- **Status-bar segment** — `↑ vX [ready]`, plus an About-menu row that triggers a real check rather than repeating stale broadcast state
+- **Two config knobs** — `[update] check` / `auto`, both exposed in the Settings dialog
+- **Compiled out of dev/debug builds** — applying a release binary over `quil-dev.exe` would strip its baked-in dev-mode ldflag and silently attach the next launch to production `~/.quil`
+- **Backup-slot fallback** — a backup file still held open by an orphaned process cannot be deleted or replaced on Windows, so the swap falls back to `.old.1`, `.old.2`, … instead of wedging every future update
+
+### v1.38.0: Pane Context Menu — [plan](superpowers/plans/2026-07-19-pane-context-menu.md)
+> Right-click a pane (or `Alt+A`) for its actions.
+
+A compositor overlay, not a modal — it targets the pane under the cursor, highlights it, and dispatches into the same handler methods the keybindings use. Rows are grouped (view actions / pane settings / destructive) and greyed when unavailable (history without `record_history`, lazygit without the binary). Adds **Mark attention**, a pinned green border that survives focus, unlike the automatic unseen mark. Right-click with an active selection still copies.
+
+### M11: Command Palette — [PRD](roadmap/command-palette.md), [plan](superpowers/plans/2026-07-23-command-palette.md)
+> `Alt+Shift+P` fuzzy-find launcher — commands, tabs, panes, and pane content in one query. Shipped v1.39.0–v1.40.0.
+
+A modal, centered, keyboard-first launcher. Entries are grouped under section headers with navigation first (Go to pane / Tabs / Pane / System); headers disappear as soon as you type. A greedy subsequence scorer rewards consecutive runs and word boundaries. Each row shows its keybinding, so the palette teaches the shortcuts as you use it. Default `alt+shift+p` only — `ctrl+shift+p` is intercepted by Windows Terminal and VS Code before Quil ever sees it, so it stays opt-in.
+
+**Content search is unified into the same query** (v1.40.0), not a separate `/` mode as originally specced: every keystroke both filters the command list and fires a debounced search across every pane's buffered scrollback — all tabs, including background and muted panes. Matches appear under a `Found in panes` header with a match count and a preview line, and `Enter` jumps to the pane. Because hits are stored as ordinary jump-to-pane commands, cursor navigation, dispatch, and rendering all reuse the command machinery. A local timeout turns an unanswered request into a diagnosable row instead of an endless `Searching…`.
+
+**Deferred to Phase 2:** per-plugin/instance quick-create, `:` direct-command mode, MRU ordering.
+
+### v1.41.0–v1.42.1: Pane Setup Dialog — Recent Locations & Session Picker
+> Two fewer keystrokes between `Ctrl+N` and a working AI pane.
+
+- **Recent locations** (v1.41.0) — the last 5 committed working directories are offered as a one-keystroke quick pick, persisted to `~/.quil/recent-cwds.json`, with deleted folders filtered out. Git-repo discovery keeps priority; **Browse…** still opens the full picker
+- **Claude resume-session picker** (v1.42.0) — see M5 below
+- **Committed-value marker** (v1.42.1) — the chosen directory (and kube context) stays visible with a `▸` marker once the cursor moves off it or the field loses focus. Previously the selection highlight was drawn only on the focused field's cursor row, so the answer disappeared from the dialog exactly while you configured the rest of it
+
 ---
 
 ## In Progress
@@ -211,6 +316,11 @@ Key capabilities:
 - **Mouse split-border drag-resize** ([PR #93](https://github.com/artyomsv/quil/pull/93)) — click and drag any border between panes to move the split. Ratio clamped in cells against subtree minimums (10×4 floor, nested splits included); adjacent panes show a transient highlight; PTY resize + layout persistence fire once on release (mid-drag only rects move — unpaired emulator resizes garble content). Border hit zone widened and given priority over the scrollbar's overlap cells. Disabled in focus/notes modes.
 - **Claude Code resume-session picker** ([PR #105](https://github.com/artyomsv/quil/pull/105)) — the pane setup dialog gains a **Session** field (opt-in per plugin via `[command] sessions = "claude"`) listing the transcripts recorded for the selected folder, newest first, each row titled with the first prompt typed in that session. Picking one spawns `claude --resume <id>` in place of the `preassign_id` strategy's `--session-id <new>`; toggles still compose, and the pane joins the normal restore machinery from the first instant. New `internal/claudesessions` package owns Claude's `~/.claude/projects/<escaped-cwd>` naming rule (moved out of the daemon, so the rule that silently breaks restore when wrong exists once). Sessions held by a live pane are listed but blocked — the guarantee is enforced daemon-side under a claim mutex, not just greyed in the UI, since any IPC client can send an id directly. Press `i` on a row for details: start/last-used timestamps, typed-prompt count, transcript size, and the first and last prompts — read on demand per session, streaming the whole transcript but rejecting each line by byte-compare before any JSON parsing (88 MB in ~1 s).
 - **Setup-dialog width accounting fix** (shipped with the above) — every content budget in the pane setup dialog reserved the box's padding but not its border, which lipgloss counts inside `Style.Width`; rows that filled their budget sat two cells past the wrap limit and reflow dropped the last word onto its own line. Session rows, the working-directory pick list, and the footer hints now all derive from one `setupTextWidth()`, pinned to lipgloss's actual behaviour by a two-sided test.
+- **Client CWD propagation** (v1.11.0) — the TUI sends `os.Getwd()` on attach so new panes and tabs spawn in the client's directory, not the daemon's frozen-at-spawn-time one.
+- **Tab drag-to-reorder, scrollbar drag, multi-binding keys** (v1.15.0) — drag a tab along the bar to reorder it (daemon stays authoritative, so a stale client never has to race for an accurate tab count); click-and-drag the scrollbar thumb with a 3-cell hit zone; any keybinding accepts comma-separated alternatives (`rename_pane = "alt+f2,alt+shift+r"` — F2 is eaten by macOS by default).
+- **Notification broadcast hardening** (v1.16.0) — events carry the triggering output lines as an excerpt; per-pane mute (`Alt+M`) drops events at the source.
+- **Per-pane restore activity indicator** (v1.26.0) — a checklist shows what the daemon is doing while a restored pane comes back, instead of an opaque wait.
+- **Stop daemon moved to the About root menu** (v1.29.0) — behind a `y`-only confirm, deliberately not `Enter`, so finger memory cannot kill every pane child.
 - **Wide-canvas terminal variant** — `terminal-wide` built-in ("Terminal (keeps content on squeeze)"): same shell auto-detection as the native terminal, but the pane keeps its PTY/emulator on the window-sized canvas below `min_native_cols` (like AI panes), so pane squeezes never cut content — at the cost of window-width output formatting while narrow. Native terminal remains the default for interactive work; proper reflow-on-resize is tracked below.
 
 **Remaining:**
@@ -229,22 +339,7 @@ Key capabilities:
 
 Define workspace blueprints committed to git: tabs, panes, plugins, CWDs, commands. `cd my-project && quil` materializes the entire dev environment. Every team member gets the exact same setup. **Network effect within teams.**
 
-### M11: Command Palette — [PRD](roadmap/command-palette.md)
-
-> `Alt+Shift+P` fuzzy-find overlay for everything. **Implemented (v1).**
-
-Search commands, switch tabs, jump to any pane, create panes — all from a single
-keyboard shortcut. Fuzzy string matching makes every feature instantly
-discoverable, and each row shows its keybinding so the palette teaches the
-shortcuts as you use it.
-
-v1 ships a modal, centered, keyboard-first launcher (`dialogCommandPalette`)
-with section-grouped entries (Go to pane / Tabs / Pane / System, navigation first), cross-tab
-navigation, a greedy subsequence fuzzy scorer, and the `command_palette`
-keybinding (default `alt+shift+p`; `ctrl+shift+p` is intercepted by many
-terminals' own palette, so it is opt-in). **Deferred to Phase 2:**
-per-plugin/instance quick-create, `/` content search across pane buffers, `:`
-direct-command mode, and MRU ordering.
+> M11 (Command Palette) shipped in v1.39.0–v1.40.0 — see **Completed** above.
 
 ---
 
@@ -260,7 +355,7 @@ The entire pitch in one visual. Goes on README, Hacker News, r/programming, Twit
 
 > `quil plugin install aider` — community TOML plugins via GitHub.
 
-GitHub repo as registry, `quil plugin install/search/update` CLI. High-value plugins: Aider, lazygit, k9s, Docker Compose, ngrok, pgcli. Every plugin makes Quil useful to a new audience.
+GitHub repo as registry, `quil plugin install/search/update` CLI. lazygit, k9s, and lazysql now ship as built-ins (v1.22.0–v1.28.0), which is exactly the argument for a registry: each one cost a PR, and the queue behind them — Aider, Docker Compose, ngrok, pgcli, and whatever ships next month — should not. Every plugin makes Quil useful to a new audience.
 
 ### Native Docs on quil.cc
 
@@ -315,9 +410,10 @@ Remote workspace viewing and collaboration over TCP+TLS. Read-only by default, c
 
 Both competitors are agent-orchestrators like Quil, but each is broader in one
 axis: herdr on **agent breadth + scriptable extensibility**, AoE on **web/remote
-access + sandboxing**. Quil already leads on **native Windows**, the **MCP
-server**, **pane notes**, and **memory reporting** — those are moats to defend,
-not gaps to close.
+access + sandboxing**. Quil already leads on **native Windows** (including the
+bundled OpenConsole fix for Windows 10), the **MCP server**, **pane notes**,
+**memory reporting**, **per-pane input history**, and **in-app auto-update** —
+those are moats to defend, not gaps to close.
 
 ### M14: Agent Fleet — breadth + detection *(highest ROI)*
 
@@ -325,12 +421,22 @@ The starkest deficit: rivals detect 13–18 agents out of the box; Quil ships 2.
 
 1. **Screen-content agent state detection** — infer blocked/working/done from
    terminal output for *any* agent, with no hooks required (herdr ships updatable
-   TOML detection manifests). Quil today only pattern-matches idle. Extends
-   [process-health](roadmap/process-health.md).
+   TOML detection manifests). *Partly closed:* Quil now derives working / blocked /
+   done from **hook events** for Claude Code and OpenCode (v1.18.0–v1.19.0, see
+   Completed above), which is more accurate than screen scraping but only works for
+   agents Quil ships an integration for. The gap that remains is the hookless
+   fallback — output heuristics that generalise to an agent nobody wrote an
+   integration for. Extends [process-health](roadmap/process-health.md).
 2. **Broad agent support + detection registry** — Codex, Gemini, Cursor, Copilot,
    Droid, Devin, Kimi, and more, detected by process name + output heuristics.
+   Still the starkest deficit: Quil's agent integrations remain Claude Code and
+   OpenCode.
 3. **One-command agent integration installer** — `quil integration install
    <agent>` writes the agent's hooks/settings for you (both rivals do this).
+   *Partly closed by a different route:* Quil installs its hooks **per spawn**
+   via inline `--settings` / `OPENCODE_CONFIG_CONTENT` and never writes to the
+   agent's own config, so there is nothing to install for the two supported
+   agents. A registry-driven installer only becomes necessary at #2's breadth.
 4. **Session fork** — branch a conversation into a new independent session, parent
    untouched (AoE).
 
@@ -406,7 +512,7 @@ section above.
 | ~~—~~ | ~~MCP server for AI integration~~ | ~~Medium~~ | ~~Very High~~ | ~~Done~~ |
 | ~~—~~ | ~~Notification center (sidebar + pane history)~~ | ~~Medium~~ | ~~High~~ | ~~Done~~ |
 | 2 | "Holy Shit" demo GIF/video | Small | Critical | Growth |
-| 3 | **[gap]** Screen-content agent detection + broad agent support (M14) | Medium | Very High | Core |
+| 3 | **[gap]** Broad agent support + hookless state detection (M14) — hook-based detection for Claude Code / OpenCode already ships | Medium | Very High | Core |
 | 4 | **[gap]** Git worktree-per-session + diff viewer (M15) | Medium | Very High | Core |
 | 5 | Project workspace files (`.quil.toml`) + repo hooks **[gap #19]** | Medium | Very High | Core |
 | ~~6~~ | ~~Command palette (`Alt+Shift+P`)~~ | ~~Medium~~ | ~~High~~ | ~~Done (v1)~~ |
@@ -444,10 +550,11 @@ Items 1-2 (install + demo) cost almost nothing and are **prerequisites for every
 
 The **notification center** (M12), **process health** (advanced), and **cross-pane events** (advanced) form a layered system:
 
-| Layer | Feature | Role |
-|-------|---------|------|
-| UI | Notification Center (M12) | Sidebar, pane navigation, history stack |
-| Monitoring | Process Health | Health states, auto-restart, stale detection |
-| Orchestration | Cross-Pane Events | Event bus, pane-to-pane context passing |
+| Layer | Feature | Status | Role |
+|-------|---------|--------|------|
+| UI | Notification Center (M12) | Shipped | Sidebar, pane navigation, history stack |
+| Signal | Hook-events pipeline (v1.18.0) | Shipped | Agent-reported work state, model/context, input history |
+| Monitoring | Process Health | Planned | Health states, auto-restart, stale detection |
+| Orchestration | Cross-Pane Events | Planned | Event bus, pane-to-pane context passing |
 
-M12 ships first as a standalone feature (process exit + output patterns). The other two extend it when they ship — health states and cross-pane events feed into the notification center's event queue.
+M12 shipped first as a standalone feature (process exit + output patterns). The hook-events pipeline then landed underneath it, feeding structured agent-reported events into the same queue — which is why work-state indicators, the model/context status segment, and per-pane input history all reuse it with no new IPC. Process health and cross-pane events are the remaining two layers; both extend the same queue rather than replacing it.

--- a/site/src/data/features.ts
+++ b/site/src/data/features.ts
@@ -138,6 +138,21 @@ export const features: Feature[] = [
   },
 
   {
+    slug: "model-context-readout",
+    icon: "sparkles",
+    title: "Model and context readout",
+    blurb:
+      "The status bar shows which model an AI pane is on and how much context it has burned — without asking the agent or reading its header.",
+    category: "ai",
+    detail: [
+      "AI panes show the model id and context-window token count from the last completed turn, e.g. `opus-4.8 · 612k ctx`.",
+      "Deliberately tokens, not a percentage: neither Claude Code nor OpenCode records the window size in its data, and a Claude session may be running at 200k or at 1M — a percentage would be a guess presented as a fact.",
+      "Right after a compaction the pane reads `· compacting` until the next turn reports the reduced size. The transcript doesn't contain the new count yet at that moment, so showing the old one would be worse than showing nothing.",
+      "Rides the same hook-event stream as the work indicators — no polling, no extra IPC, and it keeps working while the pane is muted.",
+    ],
+  },
+
+  {
     slug: "input-history",
     image: "https://cdn.stukans.com/quil/screenshots/input-history-800.webp",
     icon: "book-open",
@@ -163,9 +178,10 @@ export const features: Feature[] = [
       "Terminals are not all the same. Quil understands pane types and gives each one context-aware behaviour — including a per-spawn setup dialog with directory browser and runtime checkboxes.",
     category: "interaction",
     detail: [
-      "Five built-in pane types: Terminal, Claude Code, OpenCode (beta), SSH, Stripe.",
+      "Nine built-in pane types: Terminal, Terminal (keeps content on squeeze), Claude Code, OpenCode (beta), SSH, Stripe, lazygit, k9s, lazysql.",
       "Each type has its own resume strategy, error handler, and status line.",
       "Pane setup dialog (opt-in via plugin TOML): a directory browser pre-filled with the active pane's CWD plus one checkbox per declared `[[command.toggles]]` entry. claude-code uses both — picks up the project's `.claude/` context automatically and offers a `Dangerously skip permissions` toggle for unattended runs.",
+      "The directory step remembers where you've been: the last five folders you actually opened a pane in are offered as a one-keystroke quick pick (deleted ones filtered out), and for git-aware pane types the repositories discovered near the active pane take priority. Browse… always drops to the full picker.",
       "Toggle state rides through the existing `InstanceArgs` IPC field and survives daemon restarts; no IPC schema changes.",
       "User-definable additional types via TOML plugin files in ~/.quil/plugins/.",
     ],
@@ -180,7 +196,8 @@ export const features: Feature[] = [
     category: "interaction",
     detail: [
       "Binary split tree, each split with its own direction and ratio.",
-      "Click any pane to focus it; scroll wheel traverses terminal history.",
+      "Click any pane to focus it; the scroll wheel traverses terminal history.",
+      "Over a pane running something that handles its own mouse input — claude-code, opencode, vim, htop, lazygit — the wheel scrolls that program's viewport instead. Those apps run on the alternate screen and never fill Quil's scrollback, so the wheel is forwarded to them as the mouse sequence they expect. The daemon is what detects this, so it stays correct even when you reattach to a session that was already running.",
       "Click the scrollbar to jump the thumb; click-and-drag scrolls continuously. The hit zone is three cells wide so off-by-one clicks register as scroll instead of text selection.",
       "Spatial pane navigation: Alt+Left/Right/Up/Down focuses the closest neighbour in that direction. Three tie-breakers (gap, perpendicular overlap, perpendicular center distance) match tmux/vim/iTerm muscle memory.",
       "Drag any tab in the tab bar to reorder it — intermediate tabs slide one slot at a time. A click without motion still switches tabs. The active tab is prefixed with `* ` so it's visible at a glance even when colored.",
@@ -353,6 +370,21 @@ export const features: Feature[] = [
     ],
   },
   {
+    slug: "auto-update",
+    icon: "refresh-ccw",
+    title: "Updates without leaving the app",
+    blurb:
+      "Quil notices a new release, stages it in the background, and installs it on your say-so — no re-running the install script, no manual binary swap.",
+    category: "observability",
+    detail: [
+      "The daemon checks for new releases shortly after startup and once a day after that; the status bar shows `↑ v1.42.0 [ready]` once one is staged, and F1 → Check for updates runs a real check on demand.",
+      "Applying swaps both binaries and restarts — your tabs, panes, and AI sessions come back from the workspace snapshot exactly as they do after any restart.",
+      "Downloads are checksum-verified before anything is swapped, and the previous binaries are kept as a backup that is restored automatically if the swap fails halfway.",
+      "Two settings under `[update]` in config.toml, both in the Settings dialog: `check` (look for releases) and `auto` (download in the background so applying is instant). Turn both off and Quil never contacts GitHub.",
+      "Dev and debug builds have the pipeline compiled out entirely — a release binary applied over `quil-dev` would strip its dev-mode wiring and silently point the next launch at your production data directory.",
+    ],
+  },
+  {
     slug: "version-handshake",
     icon: "refresh-ccw",
     title: "Client/daemon version handshake",
@@ -375,6 +407,7 @@ export const features: Feature[] = [
     category: "observability",
     detail: [
       "`quil restart` stops the daemon with bounded escalation (graceful IPC shutdown with final snapshot → SIGTERM → force-kill, each tier timed out so even a deadlocked daemon can't stall it), cleans stale pid/socket files, starts fresh, and reopens the TUI.",
+      "`quil status` answers \"is it actually healthy?\" before you reach for restart: daemon state, pid, version, environment, uptime, and a per-tab/pane breakdown with each pane's state and memory. `--json` for scripts, and exit codes that distinguish healthy from not-running from wedged — so it works in a monitoring loop, not just by eye.",
       "Prints the target environment first — production (~/.quil) vs dev (QUIL_HOME) — so you can never kill the wrong daemon. PID-reuse guard: a recorded PID is only signaled if it actually belongs to a quild binary.",
       "Per-pane input isolation: every pane's stdin is written by its own goroutine behind a bounded queue. A process that stops reading input costs you a 'Pane not accepting input' sidebar warning on that one pane — everything else stays interactive. Alt+R restarts the stuck pane in place with its AI session resumed.",
       "Liveness watchdog: if no workspace snapshot completes for 2 minutes, the daemon writes a full goroutine stack dump to quild.log — a wedge becomes a precise bug report instead of a silent freeze.",
@@ -423,6 +456,7 @@ export const features: Feature[] = [
     category: "interaction",
     detail: [
       "PTY via creack/pty on Unix, ConPTY on Windows.",
+      "On Windows 10, Quil bundles Microsoft's OpenConsole (MIT) and hosts panes through it. The Windows 10 inbox console re-serializes an app's incremental screen updates incorrectly — typing `Hello` in claude-code showed `H ello`. Windows 11's built-in host is unaffected and is left alone; if the bundle is missing, Quil falls back to the inbox host rather than failing to start.",
       "IPC via Unix domain sockets on Linux/macOS, Named Pipes on Windows.",
       "Pre-built binaries for linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64.",
     ],


### PR DESCRIPTION
## Summary

- **Backfills 42 empty CHANGELOG sections** (v0.10.2 → v1.40.0). Nothing in the pipeline generates changelog prose — the release job only inserts a version header above whatever is already under `[Unreleased]` — so every PR that shipped without an entry produced a permanently empty section. `quil status`, split-border drag, auto-update, the pane context menu and the palette's content search all shipped with no changelog entry at all. Entries are reconstructed from the squash-commit bodies (each preserves its full PR description) and written for a user rather than a reviewer.
- **Corrects two misattributions.** v1.32.1's macOS render/word-jump fixes were filed under v1.32.0, and v1.40.0's palette content search under v1.39.0. Shared cause: the release job checks out `master` at trigger time, not the commit that triggered it, so two PRs merging back to back let the first run sweep both `[Unreleased]` entries into the first version.
- **Syncs `docs/roadmap.md` with the shipped binary**, which it trailed by ~14 releases. The roadmap tracked features that had a PRD in `docs/roadmap/` and missed nearly everything that shipped from a plan in `docs/superpowers/plans/`. Also fixes stale counts (4 plugins → 9, 17 MCP tools → 18), moves M11 out of Planned, and marks two competitive-gap items partly closed now that hook-based work-state detection ships.
- **Gates future entries** so this doesn't recur: CI fails a PR touching `cmd/`/`internal/` Go code without touching `CHANGELOG.md`; the release job fails an empty `[Unreleased]` before the bump is committed or tagged. Both accept `_No user-facing changes._` as an explicit opt-out, so "nothing to say" and "forgot to write it" are distinguishable.

## Test plan

- [x] No section in `CHANGELOG.md` is empty except `[Unreleased]` (verified by script over the whole file)
- [x] Both misattributed blocks appear under the version that shipped them and no longer under the neighbour
- [x] Release gate exercised against empty / sentinel / real-entry / `[Unreleased]`-is-last-section — fails only on empty
- [x] PR gate exercised against 9 file-set combinations (production Go, Go + CHANGELOG, test-only, docs-only, site-only, workflow-only, plugin TOML, mixed, and a `docs/CHANGELOG.md` decoy) — passes and fails where intended
- [x] Both workflows parse as YAML; new shell blocks are shellcheck-clean at `-S warning`
- [x] No Go code changed, so the suite was not run

Note: this PR is `docs:`/`ci:` only, so it deliberately does not bump the version — the new gates first apply to the next `feat:`/`fix:` PR.
