### PR TITLE
fix(daemon): repaint replay-less panes when a client reattaches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Claude Code panes no longer come back blank after you reattach.** Closing the
+  TUI and reopening it left them showing an empty rectangle, which looked exactly
+  like the session had died. It hadn't — the process was still running and the
+  conversation was still there, and pressing a key brought it straight back. AI
+  panes deliberately don't save scrollback (replaying a captured full-screen app
+  produces garbage rather than history), so there was simply nothing to draw
+  until the program next wrote something, and a full-screen program has no reason
+  to redraw unprompted. Quil now asks such a pane to repaint itself when you
+  reattach, so what you see matches what is actually running.
+
+  Pane types opt in to this by declaring the key that makes their program
+  repaint (`redraw_key` in the plugin's `[persistence]` section) — it is sent to
+  the program's input, so a pane that might be reading input as data must not
+  declare one. Claude Code is set up for it; OpenCode is not yet, pending
+  someone verifying which key it responds to.
+
 ## [1.43.0] - 2026-07-28
 
 ### Added
@@ -50,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   paths you type. Pane notes, clipboard paste and the log viewer are local by
   design. `quil status` also reports on the local daemon.
 
+||||||| parent of 3df441f (fix(daemon): repaint replay-less panes when a client reattaches)
 ## [1.42.1] - 2026-07-26
 
 ### Fixed

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -255,6 +255,23 @@ resume_args = ["--resume", "{session_id}"]
 |-------|------|----------|---------|-------------|
 | `strategy` | string | No | `""` (none) | Resume mechanism. See [Strategy Reference](#strategy-reference). |
 | `ghost_buffer` | bool | No | `true` | If `true`, PTY output is saved to disk and replayed on reconnect (shows previous terminal content with a dimmed "restored" label). Set to `false` for TUI apps that manage their own display. |
+| `redraw_key` | string | No | `""` | Byte(s) written to the pane's stdin when a client attaches and the pane had **no** ghost replay to send. Only meaningful with `ghost_buffer = false`, which is what leaves a reconnecting client with a blank rectangle in front of a live process. See below before setting it. |
+
+#### `redraw_key` — when to set it, and when not to
+
+With `ghost_buffer = false` there is nothing to replay on reconnect, so the pane renders blank until the program next writes something — and a full-screen program has no reason to do that unprompted. The pane looks dead while being perfectly healthy. `redraw_key` is how a plugin says "this byte makes my program repaint."
+
+**This is input, not a signal.** It lands in the child's stdin, so only set it when you know both that the program treats the byte as "redraw" *and* that nothing else is reading its stdin as data. A pane that might be sitting in `cat > file` or at a password prompt must leave it unset — there, a stray `\f` is silent data corruption rather than a repaint. That is why there is no default.
+
+**Why not `SIGWINCH`?** A resize would need no opt-in and would be safe everywhere, and it does not work for the programs that need this. Measured on a real PTY with a 1-column resize jiggle: `vim` repaints with ~5 KB of output, `claude-code` emits **0 bytes** from its main UI. It re-lays-out on a resize but only paints on its own render tick, which input drives.
+
+Verify before setting it rather than assuming. Spawn the program on a PTY, let it settle, confirm it is idle, write the candidate byte, and check that output follows.
+
+```toml
+[persistence]
+ghost_buffer = false
+redraw_key = "\f"   # Ctrl+L — verified to repaint claude-code
+```
 | `start_args` | string[] | No | `[]` | Template arguments appended on **fresh** pane creation. `{key}` placeholders expanded from plugin state (e.g., generated UUIDs). Used with `preassign_id` strategy. |
 | `resume_args` | string[] | No | `[]` | Template arguments used when **restoring** a pane after daemon restart. `{key}` placeholders expanded from previously scraped state. If any placeholder cannot be resolved, the pane starts fresh instead. |
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -984,16 +984,14 @@ func (d *Daemon) handleAttach(conn *ipc.Conn, msg *ipc.Message) {
 			// needs a live PTY, and reading it separately would race a restart.
 			// Same discipline as handleResizePane — pointer under the lock, the
 			// Resize syscall outside it.
-			kickPTY := pane.PTY
 			kickRunning := pane.PTY != nil && pane.ExitCode == nil
-			kickCols, kickRows := pane.Cols, pane.Rows
 			pane.PluginMu.Unlock()
 			if !ghostEnabled || len(ghost) == 0 {
 				// Nothing was replayed, so this pane's rectangle is blank on the
 				// client that just attached — even though the process behind it
 				// is alive and mid-conversation. Ask the child to repaint.
 				if kickRunning {
-					redrawKick(pane.ID, typ, kickPTY, kickCols, kickRows)
+					d.redrawKick(pane, typ)
 				}
 				continue
 			}
@@ -1564,33 +1562,35 @@ func resizeKick(pty apty.Session, cols, rows int) {
 // output can begin mid-escape-sequence, so replaying it produces garbage rather
 // than history. The cost is that a reconnecting client is sent nothing at all
 // for such a pane — the PTY is attached and the process is mid-conversation,
-// but the rectangle is blank until the child next writes something. An
-// alternate-screen app has no reason to do that unprompted, so the pane looks
-// dead until the user types into it.
+// but the rectangle is blank until the child next writes something, and a
+// full-screen program has no reason to do that unprompted. The pane reads as
+// dead when it is perfectly healthy.
 //
-// SIGWINCH is the way to ask, and the reason is worth stating: redrawing on a
-// size change is the one behaviour every TUI genuinely implements, and it
-// arrives out-of-band. Writing Ctrl+L (0x0C) instead would be INPUT — it lands
-// in the child's stdin, and only means "redraw" for programs that choose to
-// read it that way. A pane sitting in `cat > file`, a password prompt, or any
-// REPL reading raw bytes would receive a literal form feed, silently corrupting
-// real work. A program that ignores SIGWINCH just ignores it; the default
-// disposition is to do nothing, so the no-op case is safe rather than
-// destructive.
+// The mechanism is the plugin's declared RedrawKey, written to the child's
+// stdin. That is INPUT rather than a signal, which is why it is opt-in per
+// plugin rather than applied to every replay-less pane: the plugin author is
+// asserting both that their program treats the byte as "repaint" and that
+// nothing else is reading its stdin. A pane sitting in `cat > file` or at a
+// password prompt would receive it as data.
 //
-// This resizes the PTY only. The client's VT emulator is sized by the client
-// and is not touched here, so it never sees an unpaired resize — the failure
-// mode behind the 2026-07-15 split-drag corruption, where intermediate widths
-// rewrapped content with no matching redraw.
-func redrawKick(paneID, typ string, pty apty.Session, cols, rows int) {
-	if pty == nil || cols <= 0 || rows <= 0 {
-		// No size recorded yet means no client has ever sized this pane, so
-		// there is no correct size to jiggle back to. The first resize_pane
-		// will paint it.
+// SIGWINCH via a resize would be the safe universal alternative, needs no
+// per-plugin opt-in, and does not work. Measured on a real PTY: vim repaints
+// with ~5 KB of output after a 1-column jiggle, claude-code emits 0 bytes from
+// its main UI. It re-lays-out on a resize but only paints on its own render
+// tick, which input drives. An earlier version of this fix used the jiggle and
+// silently did nothing.
+//
+// Writes go through EnqueueInput, never pane.PTY.Write directly: a child that
+// has stopped reading stdin fills the kernel buffer and blocks the writer
+// forever, and this runs on the attaching client's dispatch goroutine.
+func (d *Daemon) redrawKick(pane *Pane, typ string) {
+	p := d.registry.Get(typ)
+	if p == nil || p.Persistence.RedrawKey == "" {
 		return
 	}
-	log.Printf("attach: redraw kick pane %s (type=%s, no ghost replay, %dx%d)", paneID, typ, cols, rows)
-	resizeKick(pty, cols, rows)
+	log.Printf("attach: redraw kick pane %s (type=%s, no ghost replay, %d bytes)",
+		pane.ID, typ, len(p.Persistence.RedrawKey))
+	pane.EnqueueInput([]byte(p.Persistence.RedrawKey))
 }
 
 func (d *Daemon) streamPTYOutput(paneID string, pty apty.Session) {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -711,7 +711,7 @@ func (d *Daemon) respawnPanes() {
 // sanity check and the fallback-to-terminal recovery. Extracted from
 // respawnPanes so the lazy-spawn path (ensurePaneSpawned) reuses it verbatim.
 func (d *Daemon) spawnRestoredPane(pane *Pane) {
-	ptySession := newRestoredPTY(pane)
+	ptySession := newRestoredPTY(paneSize(pane))
 	if pane.CWD != "" {
 		if info, err := os.Stat(pane.CWD); err != nil || !info.IsDir() {
 			log.Printf("pane %s: saved cwd %q gone, using default", pane.ID, pane.CWD)
@@ -730,12 +730,13 @@ func (d *Daemon) spawnRestoredPane(pane *Pane) {
 		pane.PluginMu.Lock()
 		pane.Type = "terminal"
 		pane.PluginMu.Unlock()
-		ptySession2 := newRestoredPTY(pane)
+		ptySession2 := newRestoredPTY(paneSize(pane))
 		if err := d.spawnPane(pane, ptySession2, false); err != nil {
 			log.Printf("fallback shell for pane %s also failed: %v", pane.ID, err)
 		}
 	} else {
-		log.Printf("respawned pane %s (type=%s, cwd=%s, size=%dx%d)", pane.ID, pane.Type, pane.CWD, pane.Cols, pane.Rows)
+		cols, rows := paneSize(pane)
+		log.Printf("respawned pane %s (type=%s, cwd=%s, size=%dx%d)", pane.ID, pane.Type, pane.CWD, cols, rows)
 	}
 }
 
@@ -767,9 +768,28 @@ func (d *Daemon) ensureTabSpawned(tabID string) {
 // (which interactive TUIs latch onto when the first resize event is lost —
 // see resizeKick). Falls back to the default constructor for pre-size
 // snapshots where Cols/Rows were never recorded.
-func newRestoredPTY(pane *Pane) apty.Session {
-	if pane.Cols > 0 && pane.Rows > 0 {
-		return newSessionFn(pane.Cols, pane.Rows)
+// paneSize reads a pane's last known dimensions under PluginMu.
+//
+// Every caller runs on a goroutine that can race handleResizePane, which writes
+// the pair from the resizing conn's dispatch goroutine: attach, lazy spawn,
+// restart, screenshot, snapshot, and the PTY output goroutine's resizeKick.
+// Reading the two fields together also keeps them consistent — a torn pair
+// (new cols, old rows) would size a PTY to a geometry that never existed.
+//
+// Callers already holding PluginMu must NOT use this; the mutex is not
+// reentrant. Those sites read the fields directly inside their own span.
+func paneSize(pane *Pane) (cols, rows int) {
+	pane.PluginMu.Lock()
+	defer pane.PluginMu.Unlock()
+	return pane.Cols, pane.Rows
+}
+
+// Takes the size explicitly rather than reading it off the pane: this runs on
+// the lazy-spawn path while the IPC server is live, so pane.Cols/Rows must be
+// snapshotted under PluginMu by the caller (see paneSize).
+func newRestoredPTY(cols, rows int) apty.Session {
+	if cols > 0 && rows > 0 {
+		return newSessionFn(cols, rows)
 	}
 	return newSessionFn(0, 0)
 }
@@ -1599,11 +1619,10 @@ func (d *Daemon) streamPTYOutput(paneID string, pty apty.Session) {
 			// the size in case the initial resize event was dropped during
 			// boot (see resizeKick).
 			if pane := d.session.Pane(paneID); pane != nil {
-				// Snapshot under the lock: this is the PTY output goroutine and
-				// handleResizePane writes these from a conn dispatch goroutine.
-				pane.PluginMu.Lock()
-				cols, rows := pane.Cols, pane.Rows
-				pane.PluginMu.Unlock()
+				// paneSize, not a direct read: this is the PTY output goroutine
+				// and handleResizePane writes the pair from a conn dispatch
+				// goroutine.
+				cols, rows := paneSize(pane)
 				resizeKick(pty, cols, rows)
 			}
 		},
@@ -3368,8 +3387,9 @@ func (d *Daemon) handleRestartPaneReq(conn *ipc.Conn, msg *ipc.Message) {
 		pane.OutputBuf.Reset()
 	}
 
-	// Respawn with same config, using last known dimensions
-	cols, rows := pane.Cols, pane.Rows
+	// Respawn with same config, using last known dimensions. Under PluginMu:
+	// another client can be resizing this pane while this restart runs.
+	cols, rows := paneSize(pane)
 	if cols <= 0 {
 		cols = 80
 	}
@@ -3410,9 +3430,13 @@ func (d *Daemon) handleScreenshotPaneReq(conn *ipc.Conn, msg *ipc.Message) {
 	d.ensurePaneSpawned(pane)
 	d.highlightPane(pane.ID)
 
+	// Snapshotted together under PluginMu — a concurrent resize would
+	// otherwise render the screenshot at a geometry that never existed.
+	paneCols, paneRows := paneSize(pane)
+
 	width := req.Width
 	if width <= 0 {
-		width = pane.Cols
+		width = paneCols
 	}
 	if width <= 0 {
 		width = 80
@@ -3422,7 +3446,7 @@ func (d *Daemon) handleScreenshotPaneReq(conn *ipc.Conn, msg *ipc.Message) {
 	}
 	height := req.Height
 	if height <= 0 {
-		height = pane.Rows
+		height = paneRows
 	}
 	if height <= 0 {
 		height = 24

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -960,8 +960,20 @@ func (d *Daemon) handleAttach(conn *ipc.Conn, msg *ipc.Message) {
 				}
 				pane.GhostSnap = nil // take-and-clear under the lock
 			}
+			// Captured in the same span as Type/GhostSnap: the redraw kick below
+			// needs a live PTY, and reading it separately would race a restart.
+			// Same discipline as handleResizePane — pointer under the lock, the
+			// Resize syscall outside it.
+			kickPTY := pane.PTY
+			kickRunning := pane.PTY != nil && pane.ExitCode == nil
 			pane.PluginMu.Unlock()
 			if !ghostEnabled || len(ghost) == 0 {
+				// Nothing was replayed, so this pane's rectangle is blank on the
+				// client that just attached — even though the process behind it
+				// is alive and mid-conversation. Ask the child to repaint.
+				if kickRunning {
+					redrawKick(pane.ID, typ, kickPTY, pane.Cols, pane.Rows)
+				}
 				continue
 			}
 			log.Printf("attach: ghost replay pane %s (type=%s, source=%s, bytes=%d)",
@@ -1517,6 +1529,43 @@ func resizeKick(pty apty.Session, cols, rows int) {
 	if err := pty.Resize(uint16(rows), uint16(cols)); err != nil {
 		log.Printf("resize kick: %v", err)
 	}
+}
+
+// redrawKick asks a live child to repaint itself, for a pane that received no
+// ghost replay on attach.
+//
+// Plugins with ghost_buffer = false (the AI panes) are deliberately excluded
+// from replay: they run on the alternate screen, and a ring buffer of their
+// output can begin mid-escape-sequence, so replaying it produces garbage rather
+// than history. The cost is that a reconnecting client is sent nothing at all
+// for such a pane — the PTY is attached and the process is mid-conversation,
+// but the rectangle is blank until the child next writes something. An
+// alternate-screen app has no reason to do that unprompted, so the pane looks
+// dead until the user types into it.
+//
+// SIGWINCH is the way to ask, and the reason is worth stating: redrawing on a
+// size change is the one behaviour every TUI genuinely implements, and it
+// arrives out-of-band. Writing Ctrl+L (0x0C) instead would be INPUT — it lands
+// in the child's stdin, and only means "redraw" for programs that choose to
+// read it that way. A pane sitting in `cat > file`, a password prompt, or any
+// REPL reading raw bytes would receive a literal form feed, silently corrupting
+// real work. A program that ignores SIGWINCH just ignores it; the default
+// disposition is to do nothing, so the no-op case is safe rather than
+// destructive.
+//
+// This resizes the PTY only. The client's VT emulator is sized by the client
+// and is not touched here, so it never sees an unpaired resize — the failure
+// mode behind the 2026-07-15 split-drag corruption, where intermediate widths
+// rewrapped content with no matching redraw.
+func redrawKick(paneID, typ string, pty apty.Session, cols, rows int) {
+	if pty == nil || cols <= 0 || rows <= 0 {
+		// No size recorded yet means no client has ever sized this pane, so
+		// there is no correct size to jiggle back to. The first resize_pane
+		// will paint it.
+		return
+	}
+	log.Printf("attach: redraw kick pane %s (type=%s, no ghost replay, %dx%d)", paneID, typ, cols, rows)
+	resizeKick(pty, cols, rows)
 }
 
 func (d *Daemon) streamPTYOutput(paneID string, pty apty.Session) {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -966,13 +966,14 @@ func (d *Daemon) handleAttach(conn *ipc.Conn, msg *ipc.Message) {
 			// Resize syscall outside it.
 			kickPTY := pane.PTY
 			kickRunning := pane.PTY != nil && pane.ExitCode == nil
+			kickCols, kickRows := pane.Cols, pane.Rows
 			pane.PluginMu.Unlock()
 			if !ghostEnabled || len(ghost) == 0 {
 				// Nothing was replayed, so this pane's rectangle is blank on the
 				// client that just attached — even though the process behind it
 				// is alive and mid-conversation. Ask the child to repaint.
 				if kickRunning {
-					redrawKick(pane.ID, typ, kickPTY, pane.Cols, pane.Rows)
+					redrawKick(pane.ID, typ, kickPTY, kickCols, kickRows)
 				}
 				continue
 			}
@@ -1428,13 +1429,17 @@ func (d *Daemon) handleResizePane(msg *ipc.Message) {
 		log.Printf("resize pane %s to %dx%d: %v", payload.PaneID, payload.Cols, payload.Rows, err)
 		return
 	}
-	// Record only after the syscall succeeds.
+	// Record only after the syscall succeeds. Cols/Rows are written INSIDE the
+	// lock with the applied* guards: they used to be set just below it, which
+	// made them a genuine data race — this runs on the resizing conn's dispatch
+	// goroutine while handleAttach (another conn), the PTY output goroutine's
+	// resizeKick, and snapshot() all read them concurrently.
 	pane.PluginMu.Lock()
 	pane.appliedCols = int(payload.Cols)
 	pane.appliedRows = int(payload.Rows)
-	pane.PluginMu.Unlock()
 	pane.Cols = int(payload.Cols)
 	pane.Rows = int(payload.Rows)
+	pane.PluginMu.Unlock()
 }
 
 func (d *Daemon) handleUpdatePane(msg *ipc.Message) {
@@ -1594,7 +1599,12 @@ func (d *Daemon) streamPTYOutput(paneID string, pty apty.Session) {
 			// the size in case the initial resize event was dropped during
 			// boot (see resizeKick).
 			if pane := d.session.Pane(paneID); pane != nil {
-				resizeKick(pty, pane.Cols, pane.Rows)
+				// Snapshot under the lock: this is the PTY output goroutine and
+				// handleResizePane writes these from a conn dispatch goroutine.
+				pane.PluginMu.Lock()
+				cols, rows := pane.Cols, pane.Rows
+				pane.PluginMu.Unlock()
+				resizeKick(pty, cols, rows)
 			}
 		},
 		func(b []byte) { d.flushPaneOutput(paneID, b) },
@@ -1924,6 +1934,10 @@ func (d *Daemon) workspaceStateFromSnapshot(activeTab string, tabs []*Tab, panes
 			if pane.Eager {
 				paneData["eager"] = true
 			}
+			// Captured here rather than read below: this runs on the snapshot
+			// goroutine while handleResizePane writes them from a conn dispatch
+			// goroutine.
+			snapCols, snapRows := pane.Cols, pane.Rows
 			pane.PluginMu.Unlock()
 			// Pending (deferred, not yet lazy-spawned) is spawnMu-guarded —
 			// read it the same way list_panes does. The TUI uses it to show the
@@ -1980,9 +1994,9 @@ func (d *Daemon) workspaceStateFromSnapshot(activeTab string, tabs []*Tab, panes
 			// ConPTY at the right dimensions instead of the 80x24 default
 			// (children that boot before the first resize event would
 			// otherwise render an 80-column UI — see resizeKick).
-			if pane.Cols > 0 && pane.Rows > 0 {
-				paneData["cols"] = pane.Cols
-				paneData["rows"] = pane.Rows
+			if snapCols > 0 && snapRows > 0 {
+				paneData["cols"] = snapCols
+				paneData["rows"] = snapRows
 			}
 			if isOverlay {
 				paneData["overlay"] = true

--- a/internal/daemon/redraw_kick_test.go
+++ b/internal/daemon/redraw_kick_test.go
@@ -1,98 +1,142 @@
 package daemon
 
 import (
+	"os"
+	"path/filepath"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/artyomsv/quil/internal/ipc"
+	"github.com/artyomsv/quil/internal/plugin"
 )
 
 // redrawKick exists because plugins with ghost_buffer = false get no replay on
 // attach, so a reconnecting client is sent nothing for a pane whose process is
 // alive and mid-conversation. The rectangle stays blank until the child writes
-// something, and an alternate-screen app has no reason to do that unprompted.
+// something, and a full-screen program has no reason to do that unprompted.
 //
-// These tests pin the two halves that matter: that the kick produces a real
-// size CHANGE (a same-size resize is swallowed and repaints nothing), and that
-// it declines in every state where there is nothing safe to signal.
+// The mechanism is the plugin's declared RedrawKey written to stdin. It is
+// opt-in per plugin because it is INPUT, not a signal: a program reading its
+// own stdin for data would receive it as data. SIGWINCH would need no opt-in
+// and does not work — claude-code emits 0 bytes from its main UI after a
+// resize, where vim emits ~5 KB.
 
-func TestRedrawKick_JigglesThenRestoresTheSize(t *testing.T) {
-	fake := &fakeSession{}
+// recordingSession captures stdin writes so a test can observe what the redraw
+// kick actually delivered to the child.
+type recordingSession struct {
+	fakeSession
+	mu      sync.Mutex
+	written []byte
+}
 
-	redrawKick("pane-1", "claude-code", fake, 120, 40)
+func (r *recordingSession) Write(data []byte) (int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.written = append(r.written, data...)
+	return len(data), nil
+}
 
-	// A single Resize to the size the PTY already has is a no-op the kernel
-	// never turns into SIGWINCH — the child would not repaint and the whole
-	// call would be silently useless. The jiggle is what makes it a change.
-	if len(fake.resizes) != 2 {
-		t.Fatalf("resizes = %v, want exactly 2 (jiggle then restore)", fake.resizes)
+func (r *recordingSession) got() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return string(r.written)
+}
+
+// waitForInput polls until the pane's input writer has drained the queue into
+// the PTY. EnqueueInput hands off to a goroutine, so the write is not visible
+// synchronously.
+func waitForInput(t *testing.T, s *recordingSession, want string) bool {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if s.got() == want {
+			return true
+		}
+		time.Sleep(5 * time.Millisecond)
 	}
-	if got, want := fake.resizes[0], [2]uint16{40, 119}; got != want {
-		t.Errorf("jiggle resize = %v, want %v (one column narrower)", got, want)
+	return false
+}
+
+// daemonWithPlugin loads a single plugin from TOML, so these tests also cover
+// the redraw_key parsing rather than hand-constructing the struct — a field
+// that never reaches the registry would otherwise pass every assertion here.
+func daemonWithPlugin(t *testing.T, name, redrawKey string, ghost bool) *Daemon {
+	t.Helper()
+	dir := t.TempDir()
+	redrawLine := ""
+	if redrawKey != "" {
+		// Written as a TOML escape so this exercises the same decoding path a
+		// real plugin file takes.
+		redrawLine = "redraw_key = \"\\f\"\n"
+		if redrawKey != "\f" {
+			t.Fatalf("fixture only models the \\f case, got %q", redrawKey)
+		}
 	}
-	// Ending on the real size matters as much as the jiggle: leaving the child
-	// one column narrow would make every pane render wrong until the next
-	// genuine resize.
-	if got, want := fake.resizes[1], [2]uint16{40, 120}; got != want {
-		t.Errorf("restore resize = %v, want %v (the pane's true size)", got, want)
+	toml := "[plugin]\n" +
+		"name = \"" + name + "\"\n" +
+		"display_name = \"" + name + "\"\n" +
+		"category = \"test\"\n" +
+		"schema_version = 1\n" +
+		"[command]\n" +
+		"cmd = \"echo\"\n" +
+		"[persistence]\n" +
+		"ghost_buffer = " + map[bool]string{true: "true", false: "false"}[ghost] + "\n" +
+		redrawLine
+	if err := os.WriteFile(filepath.Join(dir, name+".toml"), []byte(toml), 0o600); err != nil {
+		t.Fatalf("write plugin toml: %v", err)
+	}
+	reg := plugin.NewRegistry()
+	if err := reg.LoadFromDir(dir); err != nil {
+		t.Fatalf("LoadFromDir: %v", err)
+	}
+	if reg.Get(name) == nil {
+		t.Fatalf("plugin %q not loaded", name)
+	}
+	return &Daemon{registry: reg, session: NewSessionManager(4096)}
+}
+
+func TestRedrawKick_SendsThePluginsDeclaredKey(t *testing.T) {
+	d := daemonWithPlugin(t, "claude-code", "\f", false)
+	pty := &recordingSession{}
+	pane := &Pane{ID: "p1", Type: "claude-code", PTY: pty}
+	t.Cleanup(pane.StopInput)
+
+	d.redrawKick(pane, "claude-code")
+
+	if !waitForInput(t, pty, "\f") {
+		t.Errorf("child received %q, want %q (Ctrl+L)", pty.got(), "\f")
 	}
 }
 
-func TestRedrawKick_DeclinesWhenThereIsNothingToSignal(t *testing.T) {
+// TestRedrawKick_SilentWithoutAnOptIn is the safety property. Every pane that
+// got no replay reaches this call, including plain terminals — and a terminal
+// might be sitting in `cat > file` or at a password prompt, where an injected
+// form feed is data corruption, not a repaint.
+func TestRedrawKick_SilentWithoutAnOptIn(t *testing.T) {
 	tests := []struct {
-		name       string
-		nilPTY     bool
-		cols, rows int
-		why        string
+		name      string
+		plugin    string
+		redrawKey string
+		paneType  string
 	}{
-		{
-			name:   "no PTY",
-			nilPTY: true, cols: 120, rows: 40,
-			why: "a Pending lazy-restore pane has no child to signal",
-		},
-		{
-			name: "size never recorded",
-			cols: 0, rows: 0,
-			why: "no client has sized this pane, so there is no correct size to restore to",
-		},
-		{
-			name: "width recorded but height not",
-			cols: 120, rows: 0,
-			why: "a half-known size would resize the child to zero rows",
-		},
-		{
-			name: "single column",
-			cols: 1, rows: 40,
-			why: "cols-1 would be 0; resizeKick skips the jiggle, so only the restore lands",
-		},
+		{"plugin declares no key", "terminal", "", "terminal"},
+		{"pane type is not registered", "terminal", "\f", "some-unknown-plugin"},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fake := &fakeSession{}
-			var pty *fakeSession
-			if !tt.nilPTY {
-				pty = fake
-			}
+			d := daemonWithPlugin(t, tt.plugin, tt.redrawKey, true)
+			pty := &recordingSession{}
+			pane := &Pane{ID: "p1", Type: tt.paneType, PTY: pty}
+			t.Cleanup(pane.StopInput)
 
-			// Must not panic on a nil PTY, which is the whole point of the
-			// running check at the call site.
-			if pty == nil {
-				redrawKick("pane-1", "claude-code", nil, tt.cols, tt.rows)
-			} else {
-				redrawKick("pane-1", "claude-code", pty, tt.cols, tt.rows)
-			}
+			d.redrawKick(pane, tt.paneType)
 
-			if tt.cols == 1 {
-				// Degenerate but valid: resizeKick guards cols > 1 for the
-				// jiggle, so exactly one Resize lands. Pinned so a future
-				// change to that guard is visible here.
-				if len(fake.resizes) != 1 {
-					t.Errorf("resizes = %v, want 1 (restore only, no jiggle at width 1)", fake.resizes)
-				}
-				return
-			}
-			if len(fake.resizes) != 0 {
-				t.Errorf("resizes = %v, want none — %s", fake.resizes, tt.why)
+			// Give the writer goroutine a chance to deliver anything it was
+			// wrongly handed, so this cannot pass by being merely early.
+			time.Sleep(100 * time.Millisecond)
+			if got := pty.got(); got != "" {
+				t.Errorf("child received %q, want nothing written", got)
 			}
 		})
 	}
@@ -103,10 +147,10 @@ func TestRedrawKick_DeclinesWhenThereIsNothingToSignal(t *testing.T) {
 // pane.Cols/Rows used to be written just OUTSIDE handleResizePane's PluginMu
 // span, and were documented on the struct as "immutable once set". They are
 // not: handleResizePane rewrites them on every genuine resize from the
-// resizing conn's dispatch goroutine, while handleAttach (a different conn),
-// the PTY output goroutine's resizeKick, and snapshot() all read them. Three
-// live data races, invisible because no test ran a resize concurrently with a
-// read — `go test -race` only reports races it actually executes.
+// resizing conn's dispatch goroutine, while attach, lazy spawn, restart,
+// screenshot, snapshot, and the PTY output goroutine's resizeKick all read
+// them. Six live data races, invisible because no test ran a resize
+// concurrently with a read — `go test -race` only reports races it executes.
 //
 // This fails under -race if the write moves back out of the lock, or if a new
 // reader takes the field without it.
@@ -136,12 +180,10 @@ func TestPaneSize_ConcurrentResizeAndRead(t *testing.T) {
 		}
 	}()
 
-	// Reader: stands in for handleAttach / resizeKick / snapshot, all of which
-	// read the pair the same way.
+	// Reader: stands in for every guarded reader, all of which take the pair
+	// the same way via paneSize.
 	for i := 0; i < iterations; i++ {
-		pane.PluginMu.Lock()
-		cols, rows := pane.Cols, pane.Rows
-		pane.PluginMu.Unlock()
+		cols, rows := paneSize(pane)
 		if cols != 0 && (cols < 100 || cols > 101 || rows != 40) {
 			t.Fatalf("torn read: %dx%d", cols, rows)
 		}

--- a/internal/daemon/redraw_kick_test.go
+++ b/internal/daemon/redraw_kick_test.go
@@ -1,0 +1,95 @@
+package daemon
+
+import "testing"
+
+// redrawKick exists because plugins with ghost_buffer = false get no replay on
+// attach, so a reconnecting client is sent nothing for a pane whose process is
+// alive and mid-conversation. The rectangle stays blank until the child writes
+// something, and an alternate-screen app has no reason to do that unprompted.
+//
+// These tests pin the two halves that matter: that the kick produces a real
+// size CHANGE (a same-size resize is swallowed and repaints nothing), and that
+// it declines in every state where there is nothing safe to signal.
+
+func TestRedrawKick_JigglesThenRestoresTheSize(t *testing.T) {
+	fake := &fakeSession{}
+
+	redrawKick("pane-1", "claude-code", fake, 120, 40)
+
+	// A single Resize to the size the PTY already has is a no-op the kernel
+	// never turns into SIGWINCH — the child would not repaint and the whole
+	// call would be silently useless. The jiggle is what makes it a change.
+	if len(fake.resizes) != 2 {
+		t.Fatalf("resizes = %v, want exactly 2 (jiggle then restore)", fake.resizes)
+	}
+	if got, want := fake.resizes[0], [2]uint16{40, 119}; got != want {
+		t.Errorf("jiggle resize = %v, want %v (one column narrower)", got, want)
+	}
+	// Ending on the real size matters as much as the jiggle: leaving the child
+	// one column narrow would make every pane render wrong until the next
+	// genuine resize.
+	if got, want := fake.resizes[1], [2]uint16{40, 120}; got != want {
+		t.Errorf("restore resize = %v, want %v (the pane's true size)", got, want)
+	}
+}
+
+func TestRedrawKick_DeclinesWhenThereIsNothingToSignal(t *testing.T) {
+	tests := []struct {
+		name       string
+		nilPTY     bool
+		cols, rows int
+		why        string
+	}{
+		{
+			name:   "no PTY",
+			nilPTY: true, cols: 120, rows: 40,
+			why: "a Pending lazy-restore pane has no child to signal",
+		},
+		{
+			name: "size never recorded",
+			cols: 0, rows: 0,
+			why: "no client has sized this pane, so there is no correct size to restore to",
+		},
+		{
+			name: "width recorded but height not",
+			cols: 120, rows: 0,
+			why: "a half-known size would resize the child to zero rows",
+		},
+		{
+			name: "single column",
+			cols: 1, rows: 40,
+			why: "cols-1 would be 0; resizeKick skips the jiggle, so only the restore lands",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &fakeSession{}
+			var pty *fakeSession
+			if !tt.nilPTY {
+				pty = fake
+			}
+
+			// Must not panic on a nil PTY, which is the whole point of the
+			// running check at the call site.
+			if pty == nil {
+				redrawKick("pane-1", "claude-code", nil, tt.cols, tt.rows)
+			} else {
+				redrawKick("pane-1", "claude-code", pty, tt.cols, tt.rows)
+			}
+
+			if tt.cols == 1 {
+				// Degenerate but valid: resizeKick guards cols > 1 for the
+				// jiggle, so exactly one Resize lands. Pinned so a future
+				// change to that guard is visible here.
+				if len(fake.resizes) != 1 {
+					t.Errorf("resizes = %v, want 1 (restore only, no jiggle at width 1)", fake.resizes)
+				}
+				return
+			}
+			if len(fake.resizes) != 0 {
+				t.Errorf("resizes = %v, want none — %s", fake.resizes, tt.why)
+			}
+		})
+	}
+}

--- a/internal/daemon/redraw_kick_test.go
+++ b/internal/daemon/redraw_kick_test.go
@@ -1,6 +1,10 @@
 package daemon
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/artyomsv/quil/internal/ipc"
+)
 
 // redrawKick exists because plugins with ghost_buffer = false get no replay on
 // attach, so a reconnecting client is sent nothing for a pane whose process is
@@ -92,4 +96,55 @@ func TestRedrawKick_DeclinesWhenThereIsNothingToSignal(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestPaneSize_ConcurrentResizeAndRead is a race-detector regression guard.
+//
+// pane.Cols/Rows used to be written just OUTSIDE handleResizePane's PluginMu
+// span, and were documented on the struct as "immutable once set". They are
+// not: handleResizePane rewrites them on every genuine resize from the
+// resizing conn's dispatch goroutine, while handleAttach (a different conn),
+// the PTY output goroutine's resizeKick, and snapshot() all read them. Three
+// live data races, invisible because no test ran a resize concurrently with a
+// read — `go test -race` only reports races it actually executes.
+//
+// This fails under -race if the write moves back out of the lock, or if a new
+// reader takes the field without it.
+func TestPaneSize_ConcurrentResizeAndRead(t *testing.T) {
+	d := &Daemon{session: NewSessionManager(4096)}
+	pane := &Pane{ID: "p1", PTY: &fakeSession{}}
+	d.session.panes["p1"] = pane
+
+	const iterations = 200
+
+	// Built on the test goroutine, not inside the writer below: resizeMsg
+	// calls t.Fatalf, and testing.T's failure methods are only valid from the
+	// goroutine running the test. Alternating sizes so the same-size guard
+	// never short-circuits the write — a guard hit would make this vacuous.
+	msgs := make([]*ipc.Message, iterations)
+	for i := range msgs {
+		msgs[i] = resizeMsg(t, "p1", uint16(100+i%2), 40)
+	}
+
+	done := make(chan struct{})
+
+	// Writer: the resizing client's dispatch goroutine.
+	go func() {
+		defer close(done)
+		for _, m := range msgs {
+			d.handleResizePane(m)
+		}
+	}()
+
+	// Reader: stands in for handleAttach / resizeKick / snapshot, all of which
+	// read the pair the same way.
+	for i := 0; i < iterations; i++ {
+		pane.PluginMu.Lock()
+		cols, rows := pane.Cols, pane.Rows
+		pane.PluginMu.Unlock()
+		if cols != 0 && (cols < 100 || cols > 101 || rows != 40) {
+			t.Fatalf("torn read: %dx%d", cols, rows)
+		}
+	}
+	<-done
 }

--- a/internal/daemon/session.go
+++ b/internal/daemon/session.go
@@ -40,8 +40,13 @@ type Pane struct {
 	// branches (CWD="" when the saved dir is gone, Type="terminal" on spawn
 	// fallback) WHILE the IPC server is live, racing snapshot() /
 	// workspaceStateFromSnapshot / buildPaneInfos / handlePaneStatusReq
-	// readers. Immutable post-creation fields (ID, TabID, OutputBuf pointer,
-	// Cols/Rows once set) are read without it.
+	// readers. Cols/Rows join the set too: handleResizePane rewrites them on
+	// every genuine resize, from the resizing conn's dispatch goroutine, while
+	// handleAttach (a different conn), the PTY output goroutine's resizeKick,
+	// and snapshot() all read them. They were previously described here as
+	// "immutable once set" and written just outside this lock, which made all
+	// three readers data races. Only genuinely immutable post-creation fields
+	// (ID, TabID, OutputBuf pointer) are read without it.
 	PluginMu     sync.Mutex
 	InstanceName string    // Which instance config was used
 	InstanceArgs []string  // Args used to start (for rerun strategy)

--- a/internal/plugin/defaults/claude-code.toml
+++ b/internal/plugin/defaults/claude-code.toml
@@ -6,7 +6,7 @@ name = "claude-code"
 display_name = "Claude Code"
 category = "ai"
 description = "AI coding assistant"
-schema_version = 9
+schema_version = 10
 
 [command]
 cmd = "claude"
@@ -54,6 +54,19 @@ default = false
 [persistence]
 strategy = "preassign_id"
 ghost_buffer = false
+# Written to this pane's stdin when a client attaches and the pane had no ghost
+# replay to send — which is exactly what ghost_buffer = false above causes, and
+# what otherwise leaves a reconnecting client staring at a blank rectangle in
+# front of a live conversation.
+#
+# Ctrl+L (form feed) rather than a resize: claude-code re-lays-out on SIGWINCH
+# but only paints on its own render tick, so a resize produces nothing at all.
+# Measured on a real PTY — vim repaints with ~5 KB after a 1-column jiggle,
+# claude-code emits 0 bytes from its main UI.
+#
+# This is INPUT rather than a signal, which is why it is opt-in per plugin: a
+# program that reads its own stdin for data would receive this as data.
+redraw_key = "\f"
 # Pre-assign a UUID to the new session so Quil can identify the pane.
 start_args = ["--session-id", "{session_id}"]
 # On restore, the daemon picks one of two templates per pane:

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -14,15 +14,15 @@ type StalePlugin struct {
 // PanePlugin defines a pane type with its command, persistence strategy,
 // and optional error handlers.
 type PanePlugin struct {
-	Name          string
-	DisplayName   string
-	Category      string
-	Description   string
-	Homepage      string // optional project/tool URL, shown when the binary is missing
-	Command       CommandConfig
-	Persistence   PersistenceConfig
-	Display       DisplayConfig
-	Instances     []InstanceConfig
+	Name                 string
+	DisplayName          string
+	Category             string
+	Description          string
+	Homepage             string // optional project/tool URL, shown when the binary is missing
+	Command              CommandConfig
+	Persistence          PersistenceConfig
+	Display              DisplayConfig
+	Instances            []InstanceConfig
 	ErrorHandlers        []ErrorHandler
 	NotificationHandlers []NotificationHandler
 	IdleHandlers         []IdleHandler
@@ -32,7 +32,7 @@ type PanePlugin struct {
 // CommandConfig describes how to launch the plugin's process.
 type CommandConfig struct {
 	Cmd              string
-	Path             string      // optional: full path to binary (overrides PATH lookup)
+	Path             string // optional: full path to binary (overrides PATH lookup)
 	Args             []string
 	Env              []string
 	DetectCmd        string
@@ -96,11 +96,27 @@ type Toggle struct {
 
 // PersistenceConfig describes how to restore the pane after daemon restart.
 type PersistenceConfig struct {
-	Strategy    string // "none", "cwd_only", "rerun", "session_scrape", "preassign_id"
+	Strategy    string   // "none", "cwd_only", "rerun", "session_scrape", "preassign_id"
 	StartArgs   []string // template args for fresh start (e.g., ["--session-id", "{session_id}"])
 	ResumeArgs  []string
 	Scrapers    []ScrapePattern
 	GhostBuffer bool // save PTY output to disk for replay on reconnect (default true)
+
+	// RedrawKey is written to the pane's stdin when a client attaches and the
+	// pane had no ghost replay to send. Empty (the default) means send nothing.
+	//
+	// Only meaningful with GhostBuffer = false, which is what leaves a
+	// reconnecting client with a blank rectangle in front of a live process.
+	// It is opt-IN per plugin on purpose: this is INPUT, not a signal, so the
+	// plugin author is asserting that their program treats the byte as
+	// "repaint" and that nothing else is reading its stdin. A pane running
+	// `cat > file` or a password prompt would receive it as data.
+	//
+	// SIGWINCH would be the safe universal alternative and does not work:
+	// claude-code re-lays-out on a resize but only paints on its own render
+	// tick, so a resize produces zero output (measured — vim repaints with
+	// ~5 KB under the same test, claude-code with 0 bytes).
+	RedrawKey string
 }
 
 // ScrapePattern extracts named values from PTY output via regex.

--- a/internal/plugin/registry.go
+++ b/internal/plugin/registry.go
@@ -316,11 +316,12 @@ type tomlPlugin struct {
 		Sessions      string   `toml:"sessions"`
 	} `toml:"command"`
 	Persistence struct {
-		Strategy    string `toml:"strategy"`
+		Strategy    string   `toml:"strategy"`
 		StartArgs   []string `toml:"start_args"`
 		ResumeArgs  []string `toml:"resume_args"`
-		GhostBuffer *bool  `toml:"ghost_buffer"` // pointer to detect unset (default true)
-		Scrape     []struct {
+		GhostBuffer *bool    `toml:"ghost_buffer"` // pointer to detect unset (default true)
+		RedrawKey   string   `toml:"redraw_key"`   // stdin byte(s) that make this program repaint; see PersistenceConfig
+		Scrape      []struct {
 			Name    string `toml:"name"`
 			Pattern string `toml:"pattern"`
 		} `toml:"scrape"`
@@ -433,6 +434,7 @@ func loadPluginTOML(path string) (*PanePlugin, error) {
 			StartArgs:   append([]string{}, tp.Persistence.StartArgs...),
 			ResumeArgs:  append([]string{}, tp.Persistence.ResumeArgs...),
 			GhostBuffer: tp.Persistence.GhostBuffer == nil || *tp.Persistence.GhostBuffer, // default true
+			RedrawKey:   tp.Persistence.RedrawKey,
 		},
 		Display: DisplayConfig{
 			BorderColor:   tp.Display.BorderColor,


### PR DESCRIPTION
## Summary

- Reattaching left AI panes (Claude Code) rendering an **empty rectangle**, indistinguishable from a dead session. The process was alive the whole time — any keystroke brought the conversation straight back.
- Root cause: plugins with `ghost_buffer = false` are excluded from ghost replay, so `handleAttach` sends a reconnecting client **nothing at all** for them. A full-screen program has no reason to write unprompted, so the pane stays blank until the user types.
- Fix: on attach, write the plugin's declared `redraw_key` to a replay-less live pane. `claude-code` declares `"\f"` (Ctrl+L).
- Also fixes six pre-existing data races on `pane.Cols`/`Rows` (found in review).

Verified end-to-end against a remote daemon on a real VM.

## Why the exclusion is correct, and why the gap followed from it

AI panes opt out of ghost buffers deliberately: they run on the alternate screen, and a ring buffer of their output can begin **mid-escape-sequence**, so replaying it reconstructs garbage rather than history. That decision is right and this PR does not touch it.

What it left behind is the skip branch in `handleAttach`: `if !ghostEnabled || len(ghost) == 0 { continue }`. Correct about not replaying — but it also means the client is told nothing whatsoever about a pane that is attached, running, and mid-conversation. The blank rectangle is not stale state; it is the *absence* of any state. Nothing is broken, so nothing recovers it, and it fixes itself the moment you type — which is why it reads as an intermittent restore failure.

## The mechanism, and the one I got wrong first

The first version of this PR used a 1-column resize jiggle to raise `SIGWINCH`, on the reasoning that redrawing on a size change is universal among TUI programs and arrives out-of-band.

**That is false for the program this fix exists for.** Measured on a real PTY — same harness, same idle state, sizes matching the live panes:

| Program | Bytes emitted after a 1-column resize jiggle |
|---|---|
| `vim` | **5077** (repaints) |
| `claude-code`, main UI | **0** (nothing) |
| `claude-code`, after `\f` | **3812** (repaints) |

`claude-code` re-lays-out on `SIGWINCH` but only *paints* on its own render tick, which input drives. The jiggle version fired on every attach, logged that it had, and changed nothing on screen — confirmed in the daemon log of a live remote session before this was corrected.

The `resizeKick` precedent misled me: that fixes a child rendering at the wrong **size** under ConPTY, which is not the same problem as making it repaint.

## Why `redraw_key` is opt-in

`Ctrl+L` is **input**, not a signal. It lands in the child's stdin and only means "redraw" to programs that choose to read it that way. A pane sitting in `cat > notes.txt`, at a password prompt, or in a REPL reading raw bytes would receive a literal form feed — silent data corruption in a session holding real work.

So the plugin declares it, and in doing so asserts two things: that its program treats the byte as repaint, and that nothing else is reading its stdin. There is no default, and terminal panes never receive one.

`opencode` deliberately does **not** declare a key. It was not installed on the machine used for these measurements, and asserting unverified behaviour is precisely what produced the first attempt. It can opt in once someone measures it.

Writes go through `EnqueueInput`, never `pane.PTY.Write`: a child that has stopped reading stdin fills the kernel buffer and blocks the writer forever, and this runs on the attaching client's dispatch goroutine.

## Scope

Fires only when **all** hold:

| Condition | Why |
|---|---|
| The pane received no ghost replay | Replaying *and* kicking would double-paint |
| `PTY != nil && ExitCode == nil` | A `Pending` lazy-restore pane has no child; an exited one has nothing to repaint |
| The plugin declares a `redraw_key` | See above — no key, no write |

## The data races (review finding)

Greptile flagged the new code reading `pane.Cols`/`Rows` unsynchronized. The underlying problem was older and wider: the write in `handleResizePane` sat deliberately just **outside** its `PluginMu` span, and the struct documented the pair as *"immutable post-creation, once set."*

They are not immutable — `handleResizePane` rewrites them on every genuine resize from the resizing conn's goroutine, while **six** readers ran concurrently on others: attach, lazy spawn, restart, screenshot, snapshot, and the PTY output goroutine's `resizeKick`. All were live races, and the comment is what made each one look safe to write.

Fixed by moving the write inside the lock (next to `appliedCols`/`appliedRows`, so the fields describing one resize update together), routing every reader through a `paneSize()` accessor, changing `newRestoredPTY` to take explicit dimensions rather than reaching into the pane, and correcting the comment. Fixing only the new reader would have been worse than leaving it: a half-guarded field with a comment claiming otherwise is harder to reason about than an honestly unsynchronized one.

Reading the pair together matters beyond the race — a torn read (new cols, old rows) would size a PTY or render a screenshot at a geometry that never existed.

## Test plan

```bash
./scripts/dev.sh test        # green
./scripts/dev.sh test-race   # green
./scripts/dev.sh vet         # clean
```

New tests:

- `redrawKick` sends the declared key, and sends **nothing** when the plugin declares none or the pane type is unregistered — the safety property, since every replay-less pane reaches this call including plain terminals. Plugins are loaded from real TOML so the `redraw_key` decoding is covered too; a field that never reached the registry would otherwise pass every assertion.
- A `-race` regression guard that resizes a pane concurrently with reads. `go test -race` only reports races it actually *executes*, and nothing in the suite did this — which is why six survived.

Manual, against a remote daemon on an Ubuntu VM: open a Claude Code pane, let it render, `Ctrl+Q`, reattach. Pane shows its conversation immediately instead of blank. Confirmed by the reporter.

## Migration

`claude-code`'s `schema_version` goes 9 → 10, so existing installs are offered the new field through the normal migration dialog. Without the bump the on-disk plugin file keeps its old shape and the fix never reaches anyone who has already run Quil — the daemon reads plugins from disk, not from the embedded defaults.

## Relationship to #108

Independent, branched from `master`. #108 adds the SSH transport and touches no daemon code; this is attach behaviour that fires identically for a purely local daemon and predates that work.

It was *found* while testing #108 — remote sessions make detach/reattach the normal rhythm rather than an occasional event, so a long-standing gap became impossible to miss.
