### PR TITLE
fix(tui): re-wrap terminal pastes in bracketed paste markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Pasting into a pane no longer arrives one character at a time.** Text
+  pasted with your terminal's own paste — Ctrl+V, right-click, middle-click,
+  or over a remote desktop — reached the program inside the pane as if you had
+  typed it. Interactive tools such as Claude Code redrew the screen for every
+  character, so a long paste crawled, even though pasting into a plain shell
+  in the same terminal was instant. It now arrives as a single paste, the way
+  it does outside Quil. The same change stops a paste from running itself: a
+  multi-line paste into a shell used to execute every line but the last the
+  moment it landed, and now waits for you to press Enter. Programs that do not
+  understand pastes — a command reading plain input, an older shell over SSH —
+  still receive the text unchanged, so nothing that worked before starts
+  seeing stray characters in its input.
+- **Mouse-wheel scrolling inside tools like lazygit and opencode no longer
+  fails intermittently.** When a program announced its mouse support at
+  exactly the wrong moment — split across two reads of its output — Quil
+  missed the announcement and kept scrolling its own history instead of
+  passing the wheel through to the program. Uncommon, but once it happened the
+  pane never recovered until it was restarted.
+
 ## [1.45.1] - 2026-07-30
 
 ### Added

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1713,8 +1713,16 @@ func (d *Daemon) flushPaneOutput(paneID string, data []byte) {
 	now := time.Now()
 	pane.LastOutputAt = now
 	pane.IdleNotified = false
-	newModes := scanMouseModes(pane.MouseModes, data)
+	scanData := data
+	if len(pane.modeScanTail) > 0 {
+		scanData = make([]byte, 0, len(pane.modeScanTail)+len(data))
+		scanData = append(append(scanData, pane.modeScanTail...), data...)
+	}
+	newModes, tail := scanMouseModes(pane.MouseModes, scanData)
 	pane.MouseModes = newModes
+	// Copy: tail aliases scanData, which may alias the caller's reused read
+	// buffer.
+	pane.modeScanTail = append(pane.modeScanTail[:0], tail...)
 	// A mouse-mode toggle (rare: once at startup, once at exit) must reach the
 	// TUI so it can start/stop forwarding wheel events to the app. broadcastState
 	// builds a full workspace snapshot, and the child fully controls its PTY
@@ -3378,6 +3386,7 @@ func (d *Daemon) handleRestartPaneReq(conn *ipc.Conn, msg *ipc.Message) {
 	// Mirrors the TUI's ResetVT clearing its local flags on respawn. Reset the
 	// broadcast bookkeeping too so the fresh (empty) state is delivered promptly.
 	pane.MouseModes = mouseModeState{}
+	pane.modeScanTail = nil
 	pane.mouseBroadcast = mouseModeState{}
 	pane.lastMouseBroadcastAt = time.Time{}
 	// Clear model/context usage: the respawned child starts a fresh (or

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1935,6 +1935,7 @@ func (d *Daemon) workspaceStateFromSnapshot(activeTab string, tabs []*Tab, panes
 			isOverlay := pane.Overlay
 			mouseTracking := pane.MouseModes.tracking()
 			mouseSGR := pane.MouseModes.sgr
+			bracketedPaste := pane.MouseModes.bracketedPaste
 			sessionID := pane.PluginState["session_id"]
 			historyLines := pane.HistoryLines
 			lastModel := pane.LastModel
@@ -1989,6 +1990,9 @@ func (d *Daemon) workspaceStateFromSnapshot(activeTab string, tabs []*Tab, panes
 				}
 				if mouseSGR {
 					paneData["mouse_sgr"] = true
+				}
+				if bracketedPaste {
+					paneData["bracketed_paste"] = true
 				}
 				// Model/context usage of the last completed AI turn is
 				// runtime-only (broadcast, never persisted): a stale token

--- a/internal/daemon/mousemode.go
+++ b/internal/daemon/mousemode.go
@@ -39,11 +39,17 @@ func (m mouseModeState) tracking() bool {
 	return m.x10 || m.normal || m.button || m.any
 }
 
-// maxModeSeqLen bounds the carried tail of an unterminated sequence at a chunk
-// boundary: `ESC [ ?` plus the longest real parameter run fits comfortably; a
-// longer digit/`;` run cannot be a mode sequence we track, so it is dropped
-// rather than carried indefinitely.
-const maxModeSeqLen = 24
+// maxModeSeqLen bounds both how far back a chunk is searched for the start of
+// an unterminated sequence and how many bytes are carried into the next scan.
+// It must exceed the longest sequence we care about, or a split inside a long
+// one is silently dropped: every tracked mode combined is
+// `ESC [ ? 9;1000;1002;1003;1006;2004` = 29 bytes before the final byte, and a
+// real app may list untracked modes (1049, 25, 2026, …) in the same run. 64
+// leaves room for that while still bounding the carry — a longer digit/`;` run
+// is dropped rather than carried indefinitely. Do not shrink this below 29
+// without re-deriving it: the previous value of 24 sat under the all-modes
+// figure and lost exactly those splits.
+const maxModeSeqLen = 64
 
 // scanMouseModes updates the per-mode state from a raw output chunk. It walks
 // every `CSI ? <params> (h|l)` sequence and applies each set/reset that touches

--- a/internal/daemon/mousemode.go
+++ b/internal/daemon/mousemode.go
@@ -39,17 +39,29 @@ func (m mouseModeState) tracking() bool {
 	return m.x10 || m.normal || m.button || m.any
 }
 
+// maxModeSeqLen bounds the carried tail of an unterminated sequence at a chunk
+// boundary: `ESC [ ?` plus the longest real parameter run fits comfortably; a
+// longer digit/`;` run cannot be a mode sequence we track, so it is dropped
+// rather than carried indefinitely.
+const maxModeSeqLen = 24
+
 // scanMouseModes updates the per-mode state from a raw output chunk. It walks
 // every `CSI ? <params> (h|l)` sequence and applies each set/reset that touches
 // a tracked mode. Tracking modes: 9 (X10), 1000 (normal), 1002 (button-event),
 // 1003 (any-event). SGR encoding: 1006. Bracketed paste: 2004.
-// Combined-parameter sequences (e.g.
-// `CSI ? 1000 ; 1006 h`) are handled. Sequences split across chunk boundaries
-// are ignored (negligible in practice — apps emit the mouse-enable burst as one
-// write); a miss only falls back to no-forwarding, never a wrong-forwarding.
-func scanMouseModes(m mouseModeState, data []byte) mouseModeState {
+// Combined-parameter sequences (e.g. `CSI ? 1000 ; 1006 h`) are handled.
+//
+// A sequence split across chunk boundaries is returned as tail — the trailing
+// unterminated `CSI ?` prefix, if any — so the caller can prepend it to the
+// next chunk and the enable is not lost. This matters most for ?2004: a missed
+// mouse enable merely falls back to no-forwarding, but a missed paste enable
+// would make a reattached client inject a paste as raw keystrokes. The
+// returned tail aliases data; callers that retain it across the call must
+// copy it.
+func scanMouseModes(m mouseModeState, data []byte) (_ mouseModeState, tail []byte) {
+	tail = incompleteModeSeq(data)
 	if !bytes.Contains(data, privateModeIntro) {
-		return m
+		return m, tail
 	}
 	i := 0
 	for i < len(data) {
@@ -68,7 +80,7 @@ func scanMouseModes(m mouseModeState, data []byte) mouseModeState {
 			j++
 		}
 		if j >= len(data) {
-			break // incomplete sequence at end of chunk
+			break // incomplete sequence at end of chunk — carried via tail
 		}
 		final := data[j]
 		if final == 'h' || final == 'l' {
@@ -92,5 +104,40 @@ func scanMouseModes(m mouseModeState, data []byte) mouseModeState {
 		}
 		i = j + 1
 	}
-	return m
+	return m, tail
+}
+
+// incompleteModeSeq returns the trailing bytes of data that form an
+// unterminated private-mode sequence prefix — `ESC`, `ESC [`, `ESC [ ?`, or
+// `ESC [ ? <digits/;>` with no final byte yet — or nil when the chunk ends
+// cleanly. Only the last maxModeSeqLen bytes are considered: an ESC further
+// back either completed its sequence or heads a parameter run too long to be
+// a tracked mode. A carried non-mode prefix (e.g. a bare ESC that turns out
+// to start a color sequence) is harmless — rescanning it with the next chunk
+// matches nothing.
+func incompleteModeSeq(data []byte) []byte {
+	start := len(data) - maxModeSeqLen
+	if start < 0 {
+		start = 0
+	}
+	esc := bytes.LastIndexByte(data[start:], 0x1b)
+	if esc < 0 {
+		return nil
+	}
+	rest := data[start+esc:]
+	for k := 1; k < len(rest); k++ {
+		var ok bool
+		switch k {
+		case 1:
+			ok = rest[k] == '['
+		case 2:
+			ok = rest[k] == '?'
+		default:
+			ok = rest[k] == ';' || (rest[k] >= '0' && rest[k] <= '9')
+		}
+		if !ok {
+			return nil // terminated (final byte) or not a private-mode sequence
+		}
+	}
+	return rest
 }

--- a/internal/daemon/mousemode.go
+++ b/internal/daemon/mousemode.go
@@ -15,17 +15,22 @@ import "bytes"
 // introducer can't toggle any mouse mode, so the full scan is skipped.
 var privateModeIntro = []byte("\x1b[?")
 
-// mouseModeState is the set of DEC mouse modes a child app has enabled, tracked
-// one bool per mode. Keeping them separate (rather than collapsing into a single
-// "tracking" bool) mirrors the TUI's PaneModel flags and is what makes disabling
-// a mode that was never set safe: `CSI ? 1000 l` cannot clear a `?1002`-driven
-// tracking state. sgr (?1006) is an encoding modifier, not a tracking mode.
+// mouseModeState is the set of DEC private modes a child app has enabled,
+// tracked one bool per mode. Keeping them separate (rather than collapsing into
+// a single "tracking" bool) mirrors the TUI's PaneModel flags and is what makes
+// disabling a mode that was never set safe: `CSI ? 1000 l` cannot clear a
+// `?1002`-driven tracking state. sgr (?1006) is an encoding modifier, not a
+// tracking mode. bracketedPaste (?2004) is the one non-mouse mode tracked here:
+// it needs the same daemon-side lifetime as the mouse modes (see the header
+// comment) and rides the same scanner, so it lives in this struct rather than
+// a parallel one.
 type mouseModeState struct {
-	x10    bool // ?9   (X10 compatibility)
-	normal bool // ?1000 (normal tracking)
-	button bool // ?1002 (button-event tracking)
-	any    bool // ?1003 (any-event tracking)
-	sgr    bool // ?1006 (SGR extended encoding)
+	x10            bool // ?9   (X10 compatibility)
+	normal         bool // ?1000 (normal tracking)
+	button         bool // ?1002 (button-event tracking)
+	any            bool // ?1003 (any-event tracking)
+	sgr            bool // ?1006 (SGR extended encoding)
+	bracketedPaste bool // ?2004 (bracketed paste)
 }
 
 // tracking reports whether any mouse-tracking mode is active — i.e. the child
@@ -37,7 +42,8 @@ func (m mouseModeState) tracking() bool {
 // scanMouseModes updates the per-mode state from a raw output chunk. It walks
 // every `CSI ? <params> (h|l)` sequence and applies each set/reset that touches
 // a tracked mode. Tracking modes: 9 (X10), 1000 (normal), 1002 (button-event),
-// 1003 (any-event). SGR encoding: 1006. Combined-parameter sequences (e.g.
+// 1003 (any-event). SGR encoding: 1006. Bracketed paste: 2004.
+// Combined-parameter sequences (e.g.
 // `CSI ? 1000 ; 1006 h`) are handled. Sequences split across chunk boundaries
 // are ignored (negligible in practice — apps emit the mouse-enable burst as one
 // write); a miss only falls back to no-forwarding, never a wrong-forwarding.
@@ -79,6 +85,8 @@ func scanMouseModes(m mouseModeState, data []byte) mouseModeState {
 					m.any = set
 				case "1006":
 					m.sgr = set
+				case "2004":
+					m.bracketedPaste = set
 				}
 			}
 		}

--- a/internal/daemon/mousemode_test.go
+++ b/internal/daemon/mousemode_test.go
@@ -5,40 +5,75 @@ import "testing"
 func TestScanMouseModes(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name  string
-		start mouseModeState
-		data  string
-		want  mouseModeState
+		name     string
+		start    mouseModeState
+		data     string
+		want     mouseModeState
+		wantTail string
 	}{
-		{"plain text no change", mouseModeState{}, "hello world\r\n", mouseModeState{}},
-		{"colors only no change", mouseModeState{normal: true, sgr: true}, "\x1b[31mred\x1b[0m", mouseModeState{normal: true, sgr: true}},
+		{"plain text no change", mouseModeState{}, "hello world\r\n", mouseModeState{}, ""},
+		{"colors only no change", mouseModeState{normal: true, sgr: true}, "\x1b[31mred\x1b[0m", mouseModeState{normal: true, sgr: true}, ""},
 		{"opencode startup burst separate", mouseModeState{},
 			"\x1b[?1049h\x1b[?1000h\x1b[?1002h\x1b[?1003h\x1b[?1006h",
-			mouseModeState{normal: true, button: true, any: true, sgr: true}},
-		{"combined params", mouseModeState{}, "\x1b[?1000;1006h", mouseModeState{normal: true, sgr: true}},
-		{"normal tracking only, no sgr", mouseModeState{}, "\x1b[?1000h", mouseModeState{normal: true}},
-		{"x10 mode", mouseModeState{}, "\x1b[?9h", mouseModeState{x10: true}},
-		{"reset tracking", mouseModeState{normal: true, sgr: true}, "\x1b[?1000l\x1b[?1006l", mouseModeState{}},
-		{"reset only sgr keeps tracking", mouseModeState{normal: true, sgr: true}, "\x1b[?1006l", mouseModeState{normal: true}},
+			mouseModeState{normal: true, button: true, any: true, sgr: true}, ""},
+		{"combined params", mouseModeState{}, "\x1b[?1000;1006h", mouseModeState{normal: true, sgr: true}, ""},
+		{"normal tracking only, no sgr", mouseModeState{}, "\x1b[?1000h", mouseModeState{normal: true}, ""},
+		{"x10 mode", mouseModeState{}, "\x1b[?9h", mouseModeState{x10: true}, ""},
+		{"reset tracking", mouseModeState{normal: true, sgr: true}, "\x1b[?1000l\x1b[?1006l", mouseModeState{}, ""},
+		{"reset only sgr keeps tracking", mouseModeState{normal: true, sgr: true}, "\x1b[?1006l", mouseModeState{normal: true}, ""},
 		// Regression guard for the per-mode design: resetting a mode that was
 		// never set must NOT clear a different, active tracking mode.
-		{"reset unset mode preserves others", mouseModeState{button: true}, "\x1b[?1000l", mouseModeState{button: true}},
-		{"cursor-hide does not trigger", mouseModeState{}, "\x1b[?25l", mouseModeState{}},
-		{"bracketed-paste tracked", mouseModeState{}, "\x1b[?2004h", mouseModeState{bracketedPaste: true}},
-		{"bracketed-paste reset", mouseModeState{bracketedPaste: true}, "\x1b[?2004l", mouseModeState{}},
-		{"alt-screen does not trigger", mouseModeState{}, "\x1b[?1049h", mouseModeState{}},
+		{"reset unset mode preserves others", mouseModeState{button: true}, "\x1b[?1000l", mouseModeState{button: true}, ""},
+		{"cursor-hide does not trigger", mouseModeState{}, "\x1b[?25l", mouseModeState{}, ""},
+		{"bracketed-paste tracked", mouseModeState{}, "\x1b[?2004h", mouseModeState{bracketedPaste: true}, ""},
+		{"bracketed-paste reset", mouseModeState{bracketedPaste: true}, "\x1b[?2004l", mouseModeState{}, ""},
+		{"alt-screen does not trigger", mouseModeState{}, "\x1b[?1049h", mouseModeState{}, ""},
 		{"mouse set amid other output", mouseModeState{},
-			"text\x1b[?25l more\x1b[?1002h\x1b[?1006h done", mouseModeState{button: true, sgr: true}},
-		{"incomplete sequence at end ignored", mouseModeState{}, "\x1b[?1000", mouseModeState{}},
+			"text\x1b[?25l more\x1b[?1002h\x1b[?1006h done", mouseModeState{button: true, sgr: true}, ""},
+		{"incomplete sequence at end carried as tail", mouseModeState{}, "\x1b[?1000", mouseModeState{}, "\x1b[?1000"},
+		{"incomplete 2004 carried as tail", mouseModeState{}, "text\x1b[?20", mouseModeState{}, "\x1b[?20"},
+		{"bare esc at end carried as tail", mouseModeState{}, "text\x1b", mouseModeState{}, "\x1b"},
+		{"esc-bracket at end carried as tail", mouseModeState{}, "text\x1b[", mouseModeState{}, "\x1b["},
+		{"complete sequence leaves no tail", mouseModeState{}, "\x1b[?2004h", mouseModeState{bracketedPaste: true}, ""},
+		{"non-mode escape leaves no tail", mouseModeState{}, "\x1b[31mred", mouseModeState{}, ""},
+		{"overlong param run dropped, not carried", mouseModeState{}, "\x1b[?12345678901234567890123456789", mouseModeState{}, ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := scanMouseModes(tt.start, []byte(tt.data))
+			got, tail := scanMouseModes(tt.start, []byte(tt.data))
 			if got != tt.want {
 				t.Errorf("scanMouseModes(%+v, %q) = %+v, want %+v",
 					tt.start, tt.data, got, tt.want)
 			}
+			if string(tail) != tt.wantTail {
+				t.Errorf("scanMouseModes(%+v, %q) tail = %q, want %q",
+					tt.start, tt.data, tail, tt.wantTail)
+			}
 		})
+	}
+}
+
+// TestScanMouseModes_SplitAcrossChunks exercises the carry contract end to
+// end: an enable sequence split across two PTY output chunks must still set
+// the mode once the caller prepends the returned tail to the next chunk. A
+// missed ?2004 enable would make a reattached client inject pastes as raw
+// keystrokes, so this is the split that must never be dropped.
+func TestScanMouseModes_SplitAcrossChunks(t *testing.T) {
+	t.Parallel()
+	splits := []int{1, 2, 3, 5, 7} // every split point inside "\x1b[?2004h"
+	const seq = "\x1b[?2004h"
+	for _, at := range splits {
+		m, tail := scanMouseModes(mouseModeState{}, []byte(seq[:at]))
+		if m.bracketedPaste {
+			t.Fatalf("split at %d: mode set from incomplete fragment", at)
+		}
+		m, tail = scanMouseModes(m, append(append([]byte{}, tail...), seq[at:]...))
+		if !m.bracketedPaste {
+			t.Errorf("split at %d: bracketedPaste not set after carry", at)
+		}
+		if len(tail) != 0 {
+			t.Errorf("split at %d: leftover tail %q after complete sequence", at, tail)
+		}
 	}
 }

--- a/internal/daemon/mousemode_test.go
+++ b/internal/daemon/mousemode_test.go
@@ -24,7 +24,8 @@ func TestScanMouseModes(t *testing.T) {
 		// never set must NOT clear a different, active tracking mode.
 		{"reset unset mode preserves others", mouseModeState{button: true}, "\x1b[?1000l", mouseModeState{button: true}},
 		{"cursor-hide does not trigger", mouseModeState{}, "\x1b[?25l", mouseModeState{}},
-		{"bracketed-paste does not trigger", mouseModeState{}, "\x1b[?2004h", mouseModeState{}},
+		{"bracketed-paste tracked", mouseModeState{}, "\x1b[?2004h", mouseModeState{bracketedPaste: true}},
+		{"bracketed-paste reset", mouseModeState{bracketedPaste: true}, "\x1b[?2004l", mouseModeState{}},
 		{"alt-screen does not trigger", mouseModeState{}, "\x1b[?1049h", mouseModeState{}},
 		{"mouse set amid other output", mouseModeState{},
 			"text\x1b[?25l more\x1b[?1002h\x1b[?1006h done", mouseModeState{button: true, sgr: true}},

--- a/internal/daemon/mousemode_test.go
+++ b/internal/daemon/mousemode_test.go
@@ -36,7 +36,15 @@ func TestScanMouseModes(t *testing.T) {
 		{"esc-bracket at end carried as tail", mouseModeState{}, "text\x1b[", mouseModeState{}, "\x1b["},
 		{"complete sequence leaves no tail", mouseModeState{}, "\x1b[?2004h", mouseModeState{bracketedPaste: true}, ""},
 		{"non-mode escape leaves no tail", mouseModeState{}, "\x1b[31mred", mouseModeState{}, ""},
-		{"overlong param run dropped, not carried", mouseModeState{}, "\x1b[?12345678901234567890123456789", mouseModeState{}, ""},
+		// Sized against maxModeSeqLen: the all-tracked-modes run must be
+		// carried, a run past the cap must be dropped. The first row is the
+		// regression guard for a cap set below the real maximum — at 24 the
+		// tail came back empty and the split enable was lost for good.
+		{"all-modes combined run carried", mouseModeState{},
+			"\x1b[?9;1000;1002;1003;1006;2004", mouseModeState{}, "\x1b[?9;1000;1002;1003;1006;2004"},
+		{"overlong param run dropped, not carried", mouseModeState{},
+			"\x1b[?" + "1234567890123456789012345678901234567890123456789012345678901234567890",
+			mouseModeState{}, ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -71,6 +79,32 @@ func TestScanMouseModes_SplitAcrossChunks(t *testing.T) {
 		m, tail = scanMouseModes(m, append(append([]byte{}, tail...), seq[at:]...))
 		if !m.bracketedPaste {
 			t.Errorf("split at %d: bracketedPaste not set after carry", at)
+		}
+		if len(tail) != 0 {
+			t.Errorf("split at %d: leftover tail %q after complete sequence", at, tail)
+		}
+	}
+}
+
+// TestScanMouseModes_SplitInsideCombinedRun is the guard for maxModeSeqLen
+// being sized below the longest sequence it has to carry. An app that enables
+// every mode in one combined run produces 29 bytes before the final byte; with
+// the cap at 24 the backward search could not reach the ESC for the later
+// split points, so the tail came back empty and the ?2004 enable was lost with
+// no way to recover it. Splitting at every byte pins the whole range rather
+// than the one offset that happened to be tried.
+func TestScanMouseModes_SplitInsideCombinedRun(t *testing.T) {
+	t.Parallel()
+	const seq = "\x1b[?9;1000;1002;1003;1006;2004h"
+	want := mouseModeState{x10: true, normal: true, button: true, any: true, sgr: true, bracketedPaste: true}
+	for at := 1; at < len(seq); at++ {
+		m, tail := scanMouseModes(mouseModeState{}, []byte(seq[:at]))
+		if m != (mouseModeState{}) {
+			t.Fatalf("split at %d: mode set from incomplete fragment: %+v", at, m)
+		}
+		m, tail = scanMouseModes(m, append(append([]byte{}, tail...), seq[at:]...))
+		if m != want {
+			t.Errorf("split at %d: got %+v, want %+v", at, m, want)
 		}
 		if len(tail) != 0 {
 			t.Errorf("split at %d: leftover tail %q after complete sequence", at, tail)

--- a/internal/daemon/session.go
+++ b/internal/daemon/session.go
@@ -107,6 +107,11 @@ type Pane struct {
 	MouseModes           mouseModeState
 	mouseBroadcast       mouseModeState
 	lastMouseBroadcastAt time.Time
+	// modeScanTail carries an unterminated `CSI ?` prefix from the end of one
+	// output chunk into the next scan, so a mode-enable sequence split across
+	// PTY reads is not lost (see scanMouseModes). Guarded by PluginMu; cleared
+	// on restart/respawn like MouseModes.
+	modeScanTail []byte
 	// Pending is true between restore and first spawn for a deferred pane: the
 	// model + ghost buffer exist but no PTY has been created yet. Runtime-only,
 	// never persisted. Cleared by ensurePaneSpawned.

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -4258,10 +4258,7 @@ func (m Model) pasteClipboard() tea.Cmd {
 		}
 		// Wrap in bracketed paste sequences so the shell treats newlines
 		// as literal text, not as Enter presses.
-		var data []byte
-		data = append(data, "\x1b[200~"...)
-		data = append(data, []byte(text)...)
-		data = append(data, "\x1b[201~"...)
+		data := bracketedPaste(text)
 		logger.Debug("pasteClipboard: sending %d bytes to pane %s", len(data), pane.ID)
 		msg, _ := ipc.NewMessage(ipc.MsgPaneInput, ipc.PaneInputPayload{
 			PaneID: pane.ID,
@@ -4585,10 +4582,17 @@ func sanitizeDialogInput(s string) string {
 	return b.String()
 }
 
-// sendClipboardToPane sends text to the active pane as PTY input.
-// NOTE: This does NOT wrap in bracketed paste sequences because it handles
-// tea.PasteMsg events, which originate from the terminal's own bracketed paste
-// — the terminal has already signaled paste mode to the shell.
+// bracketedPaste wraps text in bracketed paste markers (\x1b[200~ … \x1b[201~)
+// so the program inside the pane's PTY receives it as a single paste rather
+// than a stream of typed characters.
+func bracketedPaste(text string) []byte {
+	data := make([]byte, 0, len(text)+12)
+	data = append(data, "\x1b[200~"...)
+	data = append(data, text...)
+	data = append(data, "\x1b[201~"...)
+	return data
+}
+
 // sendInputToPane writes raw bytes to a specific pane's PTY stdin via IPC.
 // Used to forward encoded mouse-wheel events to mouse-tracking apps.
 func (m Model) sendInputToPane(paneID string, data []byte) {
@@ -4605,6 +4609,12 @@ func (m Model) sendInputToPane(paneID string, data []byte) {
 	_ = m.client.Send(msg)
 }
 
+// sendClipboardToPane sends pasted text to the active pane as PTY input,
+// re-wrapped in bracketed paste markers. tea.PasteMsg carries text from the
+// outer terminal's bracketed paste, but those markers terminate at Bubble Tea
+// — the program inside the pane never sees them. Without re-wrapping, that
+// program treats the paste as ordinary keystrokes and replays it character by
+// character (visible with Chrome Remote Desktop + Claude Code, among others).
 func (m Model) sendClipboardToPane(text string) {
 	if text == "" {
 		return
@@ -4619,7 +4629,7 @@ func (m Model) sendClipboardToPane(text string) {
 	}
 	msg, _ := ipc.NewMessage(ipc.MsgPaneInput, ipc.PaneInputPayload{
 		PaneID: pane.ID,
-		Data:   []byte(text),
+		Data:   bracketedPaste(text),
 	})
 	m.client.Send(msg)
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -74,6 +74,11 @@ type PaneInfo struct {
 	// should be forwarded to it. Mirrored onto PaneModel for the wheel handler.
 	MouseTracking bool
 	MouseSGR      bool
+	// BracketedPaste is daemon-authoritative (scanned from the PTY stream):
+	// the child app has enabled bracketed paste (?2004), so pasted text should
+	// be wrapped in \x1b[200~/\x1b[201~ markers. Mirrored onto PaneModel for
+	// the paste paths.
+	BracketedPaste bool
 	// Model/ContextTokens are daemon-authoritative (extracted from hook event
 	// data at turn boundaries): the model id and context-window token count of
 	// the pane's last completed AI turn. Empty/zero for non-AI panes.
@@ -4050,6 +4055,9 @@ func parseWorkspaceState(raw map[string]any) WorkspaceStateMsg {
 				if ms, ok := pm["mouse_sgr"].(bool); ok {
 					pi.MouseSGR = ms
 				}
+				if bp, ok := pm["bracketed_paste"].(bool); ok {
+					pi.BracketedPaste = bp
+				}
 				if model, ok := pm["model"].(string); ok {
 					pi.Model = model
 				}
@@ -4256,9 +4264,9 @@ func (m Model) pasteClipboard() tea.Cmd {
 		if pane == nil {
 			return nil
 		}
-		// Wrap in bracketed paste sequences so the shell treats newlines
-		// as literal text, not as Enter presses.
-		data := bracketedPaste(text)
+		// Wrap in bracketed paste sequences (when the app enabled the mode) so
+		// the shell treats newlines as literal text, not as Enter presses.
+		data := pastePayload(pane, text)
 		logger.Debug("pasteClipboard: sending %d bytes to pane %s", len(data), pane.ID)
 		msg, _ := ipc.NewMessage(ipc.MsgPaneInput, ipc.PaneInputPayload{
 			PaneID: pane.ID,
@@ -4582,15 +4590,37 @@ func sanitizeDialogInput(s string) string {
 	return b.String()
 }
 
-// bracketedPaste wraps text in bracketed paste markers (\x1b[200~ … \x1b[201~)
-// so the program inside the pane's PTY receives it as a single paste rather
-// than a stream of typed characters.
+// Bracketed paste markers (DECSET 2004): a wrapped paste arrives at the child
+// app as a single paste event instead of a stream of typed characters.
+const (
+	pasteStart = "\x1b[200~"
+	pasteEnd   = "\x1b[201~"
+)
+
+// bracketedPaste wraps text in bracketed paste markers. Callers must only use
+// it for panes whose app has enabled the mode (BracketedPasteEnabled) — apps
+// that didn't ask for it would receive the markers as literal input.
 func bracketedPaste(text string) []byte {
-	data := make([]byte, 0, len(text)+12)
-	data = append(data, "\x1b[200~"...)
+	// A payload containing the end marker would close the paste early and
+	// hand the remainder to the child as typed input — the classic
+	// bracketed-paste escape (a trailing \r would execute it in a shell).
+	// Clipboard content is attacker-influenceable, so strip it.
+	text = strings.ReplaceAll(text, pasteEnd, "")
+	data := make([]byte, 0, len(text)+len(pasteStart)+len(pasteEnd))
+	data = append(data, pasteStart...)
 	data = append(data, text...)
-	data = append(data, "\x1b[201~"...)
+	data = append(data, pasteEnd...)
 	return data
+}
+
+// pastePayload encodes text for injection into pane's PTY: bracketed when the
+// pane's app has enabled paste mode, raw bytes otherwise — the same decision a
+// real terminal makes before bracketing a paste.
+func pastePayload(pane *PaneModel, text string) []byte {
+	if pane.BracketedPasteEnabled() {
+		return bracketedPaste(text)
+	}
+	return []byte(text)
 }
 
 // sendInputToPane writes raw bytes to a specific pane's PTY stdin via IPC.
@@ -4610,11 +4640,12 @@ func (m Model) sendInputToPane(paneID string, data []byte) {
 }
 
 // sendClipboardToPane sends pasted text to the active pane as PTY input,
-// re-wrapped in bracketed paste markers. tea.PasteMsg carries text from the
-// outer terminal's bracketed paste, but those markers terminate at Bubble Tea
-// — the program inside the pane never sees them. Without re-wrapping, that
-// program treats the paste as ordinary keystrokes and replays it character by
-// character (visible with Chrome Remote Desktop + Claude Code, among others).
+// re-wrapped in bracketed paste markers when the pane's app enabled the mode.
+// tea.PasteMsg carries text from the outer terminal's bracketed paste, but
+// those markers terminate at Bubble Tea — the program inside the pane never
+// sees them. Without re-wrapping, that program treats the paste as ordinary
+// keystrokes: interactive TUIs replay it character by character, and a
+// multi-line paste into a shell executes every line but the last.
 func (m Model) sendClipboardToPane(text string) {
 	if text == "" {
 		return
@@ -4629,7 +4660,7 @@ func (m Model) sendClipboardToPane(text string) {
 	}
 	msg, _ := ipc.NewMessage(ipc.MsgPaneInput, ipc.PaneInputPayload{
 		PaneID: pane.ID,
-		Data:   bracketedPaste(text),
+		Data:   pastePayload(pane, text),
 	})
 	m.client.Send(msg)
 }

--- a/internal/tui/pane.go
+++ b/internal/tui/pane.go
@@ -96,6 +96,11 @@ type PaneModel struct {
 	mouseAny       bool // ?1003
 	mouseSGR       bool // ?1006
 	bracketedPaste bool // ?2004 (gates paste wrapping, not mouse forwarding)
+	// bracketedPasteSeen records that this client's emulator has observed a
+	// ?2004 toggle in the pane's own output. Once it has, bracketedPaste is a
+	// live signal and the daemon mirror below is ignored — see
+	// BracketedPasteEnabled for why OR-ing the two is wrong for this mode.
+	bracketedPasteSeen bool
 	// daemonMouseTracking/daemonMouseSGR/daemonBracketedPaste mirror the
 	// daemon-authoritative mode state from the workspace snapshot. The daemon
 	// sees the one-time mode-enable burst on every attach; the local emulator
@@ -368,7 +373,7 @@ func (p *PaneModel) ResetVT() {
 	// a wheel event isn't forwarded — and a paste isn't bracketed — until the
 	// new app re-enables the mode.
 	p.mouseX10, p.mouseNormal, p.mouseButton, p.mouseAny, p.mouseSGR = false, false, false, false, false
-	p.bracketedPaste = false
+	p.bracketedPaste, p.bracketedPasteSeen = false, false
 	p.contentGen++
 }
 
@@ -441,6 +446,7 @@ func (p *PaneModel) setMouseMode(mode ansi.Mode, on bool) {
 		p.mouseSGR = on
 	case ansi.ModeBracketedPaste:
 		p.bracketedPaste = on
+		p.bracketedPasteSeen = true
 	}
 }
 
@@ -458,11 +464,23 @@ func (p *PaneModel) MouseTracking() bool {
 // bracketed paste (?2004) — i.e. pasted text should be wrapped in
 // \x1b[200~/\x1b[201~ markers. Apps that never enabled the mode must receive
 // pastes as raw bytes: injecting markers they didn't ask for corrupts their
-// stdin (e.g. `cat > file` writes the escape bytes into the file). Combines
-// the local emulator state with the daemon-authoritative flag, same as
-// MouseTracking.
+// stdin (e.g. `cat > file` writes the escape bytes into the file).
+//
+// Deliberately NOT the `local || daemon` shape MouseTracking uses. The daemon
+// flag rides the workspace snapshot, which is throttled by the mode-broadcast
+// cooldown, so it lags a disable by up to that window. OR-ing the two would
+// keep wrapping pastes for an app that has just turned the mode off — and for
+// this mode the cost is escape bytes injected into the app's stdin, the exact
+// corruption the gate exists to prevent, rather than MouseTracking's cosmetic
+// stray wheel notch. So the local emulator wins once it has actually seen a
+// toggle for this pane; the daemon flag covers only the case the local
+// emulator cannot answer — reattaching to an app that announced the mode
+// before this client connected.
 func (p *PaneModel) BracketedPasteEnabled() bool {
-	return p.bracketedPaste || p.daemonBracketedPaste
+	if p.bracketedPasteSeen {
+		return p.bracketedPaste
+	}
+	return p.daemonBracketedPaste
 }
 
 // wheelForwardSeq returns the mouse-wheel escape sequence to forward to the

--- a/internal/tui/pane.go
+++ b/internal/tui/pane.go
@@ -90,18 +90,20 @@ type PaneModel struct {
 	// SGR extended-encoding mode (?1006). When any tracking mode is active the
 	// wheel handler forwards the event to the PTY instead of scrolling Quil's
 	// own scrollback (which alt-screen TUI apps never populate).
-	mouseX10    bool // ?9
-	mouseNormal bool // ?1000
-	mouseButton bool // ?1002
-	mouseAny    bool // ?1003
-	mouseSGR    bool // ?1006
-	// daemonMouseTracking/daemonMouseSGR mirror the daemon-authoritative mouse
-	// state from the workspace snapshot. The daemon sees the one-time
-	// mouse-enable burst on every attach; the local emulator does not when
-	// reattaching to an already-running app (ghost_buffer=false, e.g.
-	// opencode), so this is the reliable signal. Set in syncPaneMeta.
-	daemonMouseTracking bool
-	daemonMouseSGR      bool
+	mouseX10       bool // ?9
+	mouseNormal    bool // ?1000
+	mouseButton    bool // ?1002
+	mouseAny       bool // ?1003
+	mouseSGR       bool // ?1006
+	bracketedPaste bool // ?2004 (gates paste wrapping, not mouse forwarding)
+	// daemonMouseTracking/daemonMouseSGR/daemonBracketedPaste mirror the
+	// daemon-authoritative mode state from the workspace snapshot. The daemon
+	// sees the one-time mode-enable burst on every attach; the local emulator
+	// does not when reattaching to an already-running app (ghost_buffer=false,
+	// e.g. opencode), so this is the reliable signal. Set in syncPaneMeta.
+	daemonMouseTracking  bool
+	daemonMouseSGR       bool
+	daemonBracketedPaste bool
 
 	// Render cache: View() output is reused while renderKey() is unchanged.
 	// contentGen covers VT-grid/raw-buffer mutations (the grid itself has no
@@ -362,10 +364,11 @@ func (p *PaneModel) ResetVT() {
 	p.installVT(p.newVTEmulator(w, h))
 	p.rawBuf.Reset()
 	p.cursorVisible = true
-	// Fresh emulator starts with every mouse mode off; clear the mirrored
-	// flags so a wheel event isn't forwarded until the new app re-enables
-	// tracking.
+	// Fresh emulator starts with every mode off; clear the mirrored flags so
+	// a wheel event isn't forwarded — and a paste isn't bracketed — until the
+	// new app re-enables the mode.
 	p.mouseX10, p.mouseNormal, p.mouseButton, p.mouseAny, p.mouseSGR = false, false, false, false, false
+	p.bracketedPaste = false
 	p.contentGen++
 }
 
@@ -420,9 +423,10 @@ func (p *PaneModel) ResetScroll() {
 	p.scrollBack = 0
 }
 
-// setMouseMode records a DEC mouse mode toggle reported by the VT emulator's
-// EnableMode/DisableMode callback. Only mouse-related modes are tracked; every
-// other mode is ignored. Runs on the Update goroutine (inside vt.Write).
+// setMouseMode records a DEC private mode toggle reported by the VT emulator's
+// EnableMode/DisableMode callback. Only the mouse modes and bracketed paste
+// (?2004) are tracked; every other mode is ignored. Runs on the Update
+// goroutine (inside vt.Write).
 func (p *PaneModel) setMouseMode(mode ansi.Mode, on bool) {
 	switch mode {
 	case ansi.ModeMouseX10:
@@ -435,6 +439,8 @@ func (p *PaneModel) setMouseMode(mode ansi.Mode, on bool) {
 		p.mouseAny = on
 	case ansi.ModeMouseExtSgr:
 		p.mouseSGR = on
+	case ansi.ModeBracketedPaste:
+		p.bracketedPaste = on
 	}
 }
 
@@ -446,6 +452,17 @@ func (p *PaneModel) setMouseMode(mode ansi.Mode, on bool) {
 // reattach, where the burst was emitted before this client connected).
 func (p *PaneModel) MouseTracking() bool {
 	return p.mouseX10 || p.mouseNormal || p.mouseButton || p.mouseAny || p.daemonMouseTracking
+}
+
+// BracketedPasteEnabled reports whether the pane's child app has enabled
+// bracketed paste (?2004) — i.e. pasted text should be wrapped in
+// \x1b[200~/\x1b[201~ markers. Apps that never enabled the mode must receive
+// pastes as raw bytes: injecting markers they didn't ask for corrupts their
+// stdin (e.g. `cat > file` writes the escape bytes into the file). Combines
+// the local emulator state with the daemon-authoritative flag, same as
+// MouseTracking.
+func (p *PaneModel) BracketedPasteEnabled() bool {
+	return p.bracketedPaste || p.daemonBracketedPaste
 }
 
 // wheelForwardSeq returns the mouse-wheel escape sequence to forward to the

--- a/internal/tui/paste_test.go
+++ b/internal/tui/paste_test.go
@@ -176,3 +176,52 @@ func TestUpdate_PasteMsg_DaemonAuthoritativePasteMode(t *testing.T) {
 		t.Errorf("sent data = %q, want %q", got, want)
 	}
 }
+
+// TestUpdate_PasteMsg_LocalDisableBeatsStaleDaemonFlag pins the precedence
+// rule in BracketedPasteEnabled. The daemon flag arrives on the workspace
+// snapshot, which is throttled by the mode-broadcast cooldown, so it still
+// reads "enabled" for a window after the app emits `CSI ? 2004 l`. If the two
+// signals were OR-ed, every paste in that window would inject marker bytes
+// into the stdin of an app that just said it does not want them — the exact
+// corruption the gate exists to prevent. The local emulator has already seen
+// the disable, so it wins.
+func TestUpdate_PasteMsg_LocalDisableBeatsStaleDaemonFlag(t *testing.T) {
+	fake := &fakeSender{}
+	m := pasteTestModel(fake)
+	pane := m.tabs[0].ActivePaneModel()
+	// Snapshot said enabled; the app has since turned it off, and this client's
+	// emulator saw the reset before the next snapshot could correct the mirror.
+	pane.daemonBracketedPaste = true
+	pane.AppendOutput([]byte("\x1b[?2004h"))
+	pane.AppendOutput([]byte("\x1b[?2004l"))
+
+	_, _ = m.Update(tea.PasteMsg{Content: "hello world"})
+
+	if len(fake.sent) != 1 {
+		t.Fatalf("want exactly 1 IPC send, got %d", len(fake.sent))
+	}
+	if got := string(paneInputData(t, fake.sent[0])); got != "hello world" {
+		t.Errorf("sent data = %q, want raw %q", got, "hello world")
+	}
+}
+
+// TestPaneModel_BracketedPasteEnabled_ResetVTFallsBackToDaemon guards the
+// other half of the precedence rule: ResetVT installs a fresh emulator that
+// has observed nothing, so the pane must fall back to the daemon flag rather
+// than latching the pre-reset local value.
+func TestPaneModel_BracketedPasteEnabled_ResetVTFallsBackToDaemon(t *testing.T) {
+	fake := &fakeSender{}
+	m := pasteTestModel(fake)
+	pane := m.tabs[0].ActivePaneModel()
+	pane.AppendOutput([]byte("\x1b[?2004l"))
+	pane.daemonBracketedPaste = true
+	if pane.BracketedPasteEnabled() {
+		t.Fatal("local disable did not win before ResetVT")
+	}
+
+	pane.ResetVT()
+
+	if !pane.BracketedPasteEnabled() {
+		t.Error("BracketedPasteEnabled() = false after ResetVT, want the daemon flag to apply again")
+	}
+}

--- a/internal/tui/paste_test.go
+++ b/internal/tui/paste_test.go
@@ -84,10 +84,14 @@ func TestUpdate_PasteMsgEmptyContent_FallsBackToImagePaste(t *testing.T) {
 	}
 }
 
-// TestUpdate_PasteMsgWithText_SendsTextVerbatim is the regression guard for the
-// fix: a bracketed paste carrying real text must still be typed verbatim and
-// must NOT be hijacked by the image fallback.
-func TestUpdate_PasteMsgWithText_SendsTextVerbatim(t *testing.T) {
+// TestUpdate_PasteMsgWithText_SendsBracketedPaste guards two things: a
+// bracketed paste carrying real text must NOT be hijacked by the image
+// fallback, and it must be re-wrapped in bracketed paste markers before being
+// injected into the pane's PTY. The outer terminal's own \x1b[200~/\x1b[201~
+// markers terminate at Bubble Tea (stripped when building tea.PasteMsg), so
+// without re-wrapping the program inside the pane sees the paste as a stream
+// of ordinary keystrokes and replays it character by character.
+func TestUpdate_PasteMsgWithText_SendsBracketedPaste(t *testing.T) {
 	fake := &fakeSender{}
 	m := pasteTestModel(fake)
 
@@ -96,7 +100,8 @@ func TestUpdate_PasteMsgWithText_SendsTextVerbatim(t *testing.T) {
 	if len(fake.sent) != 1 {
 		t.Fatalf("want exactly 1 IPC send, got %d", len(fake.sent))
 	}
-	if got := string(paneInputData(t, fake.sent[0])); got != "hello world" {
-		t.Errorf("sent data = %q, want %q", got, "hello world")
+	want := "\x1b[200~hello world\x1b[201~"
+	if got := string(paneInputData(t, fake.sent[0])); got != want {
+		t.Errorf("sent data = %q, want %q", got, want)
 	}
 }

--- a/internal/tui/paste_test.go
+++ b/internal/tui/paste_test.go
@@ -43,6 +43,33 @@ func paneInputData(t *testing.T, msg *ipc.Message) []byte {
 	return p.Data
 }
 
+// Test_bracketedPaste covers the pure wrapping helper, in particular the
+// paste-injection guard: a payload containing the end marker must not be able
+// to close the paste early and smuggle the remainder through as typed input.
+func Test_bracketedPaste(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		text string
+		want string
+	}{
+		{"plain text", "hello world", "\x1b[200~hello world\x1b[201~"},
+		{"empty string", "", "\x1b[200~\x1b[201~"},
+		{"multi-line", "a\nb", "\x1b[200~a\nb\x1b[201~"},
+		{"embedded end marker stripped", "foo\x1b[201~\rrm -rf ~\r", "\x1b[200~foo\rrm -rf ~\r\x1b[201~"},
+		{"repeated end markers stripped", "a\x1b[201~b\x1b[201~c", "\x1b[200~abc\x1b[201~"},
+		{"start marker passes through", "a\x1b[200~b", "\x1b[200~a\x1b[200~b\x1b[201~"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := string(bracketedPaste(tt.text)); got != tt.want {
+				t.Errorf("bracketedPaste(%q) = %q, want %q", tt.text, got, tt.want)
+			}
+		})
+	}
+}
+
 // TestUpdate_PasteMsgEmptyContent_FallsBackToImagePaste guards the Ctrl+V
 // screenshot-paste regression. Windows Terminal performs its own paste on
 // Ctrl+V and delivers it to Quil as a bracketed tea.PasteMsg. For a clipboard
@@ -61,6 +88,9 @@ func TestUpdate_PasteMsgEmptyContent_FallsBackToImagePaste(t *testing.T) {
 
 	fake := &fakeSender{}
 	m := pasteTestModel(fake)
+	// The receiving app (claude-code) has paste mode on, so the typed image
+	// path is expected to arrive bracketed.
+	m.tabs[0].ActivePaneModel().AppendOutput([]byte("\x1b[?2004h"))
 
 	_, cmd := m.Update(tea.PasteMsg{Content: ""})
 	if cmd == nil {
@@ -86,12 +116,35 @@ func TestUpdate_PasteMsgEmptyContent_FallsBackToImagePaste(t *testing.T) {
 
 // TestUpdate_PasteMsgWithText_SendsBracketedPaste guards two things: a
 // bracketed paste carrying real text must NOT be hijacked by the image
-// fallback, and it must be re-wrapped in bracketed paste markers before being
-// injected into the pane's PTY. The outer terminal's own \x1b[200~/\x1b[201~
-// markers terminate at Bubble Tea (stripped when building tea.PasteMsg), so
-// without re-wrapping the program inside the pane sees the paste as a stream
-// of ordinary keystrokes and replays it character by character.
+// fallback, and — when the pane's app has enabled paste mode (?2004) — it
+// must be re-wrapped in bracketed paste markers before being injected into
+// the pane's PTY. The outer terminal's own \x1b[200~/\x1b[201~ markers
+// terminate at Bubble Tea (stripped when building tea.PasteMsg), so without
+// re-wrapping the program inside the pane sees the paste as a stream of
+// ordinary keystrokes and replays it character by character.
 func TestUpdate_PasteMsgWithText_SendsBracketedPaste(t *testing.T) {
+	fake := &fakeSender{}
+	m := pasteTestModel(fake)
+	// Enable ?2004 the way a real app does: through the pane's PTY output
+	// stream, exercising the emulator-callback tracking path.
+	m.tabs[0].ActivePaneModel().AppendOutput([]byte("\x1b[?2004h"))
+
+	_, _ = m.Update(tea.PasteMsg{Content: "hello world"})
+
+	if len(fake.sent) != 1 {
+		t.Fatalf("want exactly 1 IPC send, got %d", len(fake.sent))
+	}
+	want := "\x1b[200~hello world\x1b[201~"
+	if got := string(paneInputData(t, fake.sent[0])); got != want {
+		t.Errorf("sent data = %q, want %q", got, want)
+	}
+}
+
+// TestUpdate_PasteMsgWithText_RawWhenPasteModeOff guards the DECSET 2004 gate:
+// an app that never enabled bracketed paste must receive the pasted text as
+// raw bytes. Injecting markers it didn't ask for corrupts its stdin — e.g.
+// `cat > file` would write the escape bytes into the file.
+func TestUpdate_PasteMsgWithText_RawWhenPasteModeOff(t *testing.T) {
 	fake := &fakeSender{}
 	m := pasteTestModel(fake)
 
@@ -100,7 +153,25 @@ func TestUpdate_PasteMsgWithText_SendsBracketedPaste(t *testing.T) {
 	if len(fake.sent) != 1 {
 		t.Fatalf("want exactly 1 IPC send, got %d", len(fake.sent))
 	}
-	want := "\x1b[200~hello world\x1b[201~"
+	if got := string(paneInputData(t, fake.sent[0])); got != "hello world" {
+		t.Errorf("sent data = %q, want %q", got, "hello world")
+	}
+}
+
+// TestUpdate_PasteMsg_DaemonAuthoritativePasteMode covers the reattach case:
+// the app enabled ?2004 before this client connected, so only the
+// daemon-authoritative snapshot flag is set, not the local emulator mirror.
+func TestUpdate_PasteMsg_DaemonAuthoritativePasteMode(t *testing.T) {
+	fake := &fakeSender{}
+	m := pasteTestModel(fake)
+	m.tabs[0].ActivePaneModel().daemonBracketedPaste = true
+
+	_, _ = m.Update(tea.PasteMsg{Content: "hi"})
+
+	if len(fake.sent) != 1 {
+		t.Fatalf("want exactly 1 IPC send, got %d", len(fake.sent))
+	}
+	want := "\x1b[200~hi\x1b[201~"
 	if got := string(paneInputData(t, fake.sent[0])); got != want {
 		t.Errorf("sent data = %q, want %q", got, want)
 	}

--- a/internal/tui/workstate.go
+++ b/internal/tui/workstate.go
@@ -287,6 +287,7 @@ func syncPaneMeta(pane *PaneModel, info *PaneInfo, wideCanvas bool, minNativeCol
 	pane.HistoryLines = info.HistoryLines
 	pane.daemonMouseTracking = info.MouseTracking
 	pane.daemonMouseSGR = info.MouseSGR
+	pane.daemonBracketedPaste = info.BracketedPaste
 	// Unconditional copy, like the other daemon-authoritative fields: the
 	// daemon writes LastModel BEFORE broadcasting the hook event and IPC
 	// delivery is ordered per connection, so a snapshot can never lag behind


### PR DESCRIPTION
## Problem

When pasting with the terminal's native paste (e.g. Ctrl+V in Windows Terminal, or paste over Chrome Remote Desktop), the text is replayed **character by character** inside the pane — most visibly when the pane runs Claude Code or another interactive TUI. Worse than the perf symptom: without bracketing, a **multi-line paste into a bash/zsh pane executes every line but the last** — bracketed paste is what makes the shell hold pasted newlines as inert text. Pasting into a plain zsh prompt in the same terminal is fine; the problem only appears inside Quil.

## Root cause

The terminal delivers its paste to Quil as a bracketed paste, which Bubble Tea parses into a `tea.PasteMsg` — **stripping the `\x1b[200~` / `\x1b[201~` markers in the process**. `sendClipboardToPane` then forwarded only the bare text into the pane's PTY. The deleted comment claimed wrapping was unnecessary because "the terminal has already signaled paste mode to the shell" — but for a multiplexer that's not true: the outer terminal's markers terminate at Quil. The program inside the PTY never sees them.

## Fix

- Track bracketed-paste mode (**DECSET 2004**) per pane, so Quil only wraps pastes for apps that asked for it — the same decision a real terminal makes. Daemon-side in `mouseModeState` (authoritative across reattach) + a TUI-local emulator mirror, combined in `PaneModel.BracketedPasteEnabled()`, mirroring the mouse-tracking design.
- Shared `bracketedPaste(text)` helper used by both paste paths (terminal paste and F8/Ctrl+Alt+V), which also **strips embedded `\x1b[201~`** so clipboard content can't close the paste early and smuggle typed input to the shell.
- Named `pasteStart`/`pasteEnd` consts.

## Testing

- Table-driven `Test_bracketedPaste` incl. the terminator-injection case.
- Update-level tests: 2004-on (via the emulator callback path), 2004-off → raw bytes, daemon-flag-only (reattach case), image-fallback path.
- `scanMouseModes` rows for `?2004h`/`?2004l`.
- Full `go test ./...`: failure set byte-identical to unmodified `master` on macOS (pre-existing environment-dependent tests); no new failures, no new `gofmt -l` drift.