### PR TITLE
ci(site): scope Pages and OIDC write to the deploy job

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -36,10 +36,25 @@ concurrency:
   group: pages
   cancel-in-progress: true
 
+# Least privilege, split per job rather than granted workflow-wide.
+#
+# The build job below runs `npm ci` over the Astro dependency tree, which
+# executes third-party install scripts. Granting it `pages: write` would let a
+# compromised dependency publish arbitrary content to quil.cc, and
+# `id-token: write` would let it mint an OIDC token carrying this repo's
+# identity, exchangeable with any cloud provider configured to trust
+# repo:artyomsv/quil. It needs neither: upload-pages-artifact is tar plus
+# actions/upload-artifact, which authenticates with ACTIONS_RUNTIME_TOKEN and
+# never touches the Pages API or GITHUB_TOKEN.
+#
+# Only deploy runs deploy-pages, so only deploy gets those two scopes. Note
+# that a job-level block REPLACES this one rather than merging with it, which
+# is why deploy restates contents: read.
+#
+# GitHub's own Pages starter workflow puts all three here at the top level;
+# that is convenience, not least privilege.
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 jobs:
   build:
@@ -102,6 +117,10 @@ jobs:
     name: Deploy to GitHub Pages
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write      # create the Pages deployment
+      id-token: write   # OIDC token deploy-pages exchanges for the deployment
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary

- The Pages permissions in `site.yml` were declared workflow-wide, so the **`build` job inherited `pages: write` and `id-token: write`** along with `contents: read`. That job runs `npm ci` over the Astro dependency tree, which executes third-party install scripts.
- Both scopes move down to **`deploy`**, whose only step is `actions/deploy-pages@v4`. `build` is left with `contents: read`.
- Follows two direct-to-master commits closing the same class of issue: `e61d064` (ci.yml had no permissions block at all — CodeQL alerts #8/#9, now `fixed`) and `af95ad7` (read-only floor on release.yml).

## Why this matters

With `pages: write` and `id-token: write` in the build job's token, a compromised dependency anywhere in `site/`'s tree could:

- publish arbitrary content to **quil.cc**, or
- mint an OIDC token carrying this repository's identity, exchangeable with any cloud provider configured to trust `repo:artyomsv/quil`.

## Why `build` doesn't need them

`actions/upload-pages-artifact@v3` is `tar` plus `actions/upload-artifact@v7` — it authenticates with `ACTIONS_RUNTIME_TOKEN` and never calls the Pages API or reads `GITHUB_TOKEN`. Verified against the action's own `action.yml` rather than assumed.

Job-level `permissions` blocks **replace** rather than merge with the workflow-level one, which is why `deploy` restates `contents: read`.

## Note on code scanning

This was **not** flagged by CodeQL. The `actions/missing-workflow-permissions` rule checks that a block *exists*, never whether the grant fits the job — over-granting is invisible to it. GitHub's own Pages starter workflow (`actions/starter-workflows/pages/astro.yml`) has the same top-level layout, so this isn't a deviation from the documented pattern; the documented pattern is just loose.

## Test plan

- `yq` parse confirms the split: `build` → inherits `contents: read` only; `deploy` → `contents: read`, `pages: write`, `id-token: write`.
- The `changelog` CI gate is a no-op here — the diff touches no `cmd/**` or `internal/**` Go files.
- **Real verification is the merge itself.** `site.yml` lists `.github/workflows/site.yml` in its own `paths:` filter, so landing this triggers a full build-and-deploy of quil.cc. A wrong permissions split fails at the `deploy-pages` step, not at parse time — watch that run.
- Rollback is a single revert; no state changes outside the workflow file.
