### PR TITLE
fix(site): stop main painting over the sticky header

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "astro dev",
-    "build": "astro check && astro build",
+    "build": "node scripts/check-header-stacking.mjs && astro check && astro build",
     "preview": "astro preview --host 0.0.0.0 --port 4321",
     "astro": "astro",
     "og:svg": "node scripts/build-og.mjs",

--- a/site/scripts/check-header-stacking.mjs
+++ b/site/scripts/check-header-stacking.mjs
@@ -1,0 +1,206 @@
+/**
+ * Guard: the sticky header must out-stack <main>.
+ *
+ * The compare dropdown is a `position: absolute` menu inside the header
+ * that hangs BELOW the header's border box, into the region `<main>`
+ * occupies. Hit-testing follows paint order, so if `<main>` paints at or
+ * above the header, `<main>` swallows every click aimed at the menu —
+ * while the menu stays perfectly VISIBLE, because `<main>` is transparent
+ * there. Visible-but-unclickable is the exact symptom this guards.
+ *
+ * That shipped once: a blanket
+ *
+ *     main, header.site-header, footer.site-footer { position: relative; z-index: 3 }
+ *
+ * matched the header at specificity (0,1,1) and beat the header's own
+ * `.site-header { position: sticky; z-index: 40 }` at (0,1,0) — regardless
+ * of source order. The header silently lost BOTH its stickiness and its
+ * stacking rank, tying with `main`, which wins a tie by coming later in
+ * the DOM.
+ *
+ * Greping for the selector would not have caught it: nothing is
+ * misspelled, and every individual rule reads as correct. The bug only
+ * exists in the RESOLUTION between two rules, so this resolves them.
+ *
+ * Run: node scripts/check-header-stacking.mjs
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const CSS_FILES = ["src/styles/global.css", "src/styles/ember.css"];
+
+/** Split a stylesheet into flat {prelude, body, at} rules, descending into @media/@supports/@layer.
+ *
+ * Comments are stripped FIRST. A comment sitting above a rule otherwise
+ * glues onto that rule's first selector, and a selector carrying a
+ * comment matches nothing — silently dropping the leading selector of
+ * every documented rule, which is most of them here. */
+function parseRules(css, at = []) {
+  css = css.replace(/\/\*[\s\S]*?\*\//g, " ");
+  const out = [];
+  let depth = 0;
+  let selStart = 0;
+  let blockStart = 0;
+
+  for (let i = 0; i < css.length; i++) {
+    const c = css[i];
+    if (c === "{") {
+      if (depth === 0) blockStart = i;
+      depth++;
+    } else if (c === "}") {
+      depth--;
+      if (depth === 0) {
+        const prelude = css.slice(selStart, blockStart).trim();
+        const body = css.slice(blockStart + 1, i);
+        if (prelude.startsWith("@")) {
+          // Conditional groups still contain rules that match the element.
+          if (/^@(media|supports|layer|container)\b/.test(prelude)) {
+            out.push(...parseRules(body, [...at, prelude]));
+          }
+        } else if (prelude) {
+          out.push({ prelude, body, at });
+        }
+        selStart = i + 1;
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Does this single selector match `el`?
+ *
+ * Deliberately narrow: only compound selectors built from a tag and/or
+ * classes (no combinators, pseudos, attributes or ids). Anything more
+ * complex is CONTEXT-dependent, so this cannot decide it from the
+ * stylesheet alone — and a guard that guesses is worse than one that
+ * abstains. Such selectors are reported separately rather than ignored.
+ */
+function matchesCompound(sel, el) {
+  if (/[\s>+~]/.test(sel)) return null; // combinator — needs a DOM
+  if (/[:[#]/.test(sel)) return null; // pseudo/attr/id — needs state
+  const tag = sel.match(/^[a-zA-Z][\w-]*/)?.[0] ?? null;
+  if (tag && tag !== el.tag) return false;
+  const classes = [...sel.matchAll(/\.([-\w]+)/g)].map((m) => m[1]);
+  if (!classes.length && !tag) return false;
+  return classes.every((c) => el.classes.includes(c));
+}
+
+/** (id, class, tag) specificity of a compound selector. */
+function specificity(sel) {
+  return [
+    0,
+    (sel.match(/\.[-\w]+/g) || []).length,
+    /^[a-zA-Z][\w-]*/.test(sel) ? 1 : 0,
+  ];
+}
+
+const cmp = (a, b) => a[0] - b[0] || a[1] - b[1] || a[2] - b[2];
+
+/** Top-level `prop: value` pairs (skips nested blocks). */
+function declarations(body) {
+  const decls = [];
+  let depth = 0;
+  let buf = "";
+  for (const c of body) {
+    if (c === "(") depth++;
+    else if (c === ")") depth--;
+    if (c === ";" && depth === 0) {
+      decls.push(buf);
+      buf = "";
+    } else buf += c;
+  }
+  decls.push(buf);
+
+  return decls
+    .map((d) => {
+      const i = d.indexOf(":");
+      if (i < 0) return null;
+      const prop = d.slice(0, i).trim().toLowerCase();
+      let value = d.slice(i + 1).trim();
+      const important = /!important$/i.test(value);
+      if (important) value = value.replace(/!important$/i, "").trim();
+      return prop && value ? { prop, value, important } : null;
+    })
+    .filter(Boolean);
+}
+
+/** Resolve the winning declaration of `prop` for `el` across all sheets. */
+function resolve_(rules, el, prop) {
+  let winner = null;
+  rules.forEach((rule, order) => {
+    for (const sel of rule.prelude.split(",")) {
+      const s = sel.trim();
+      if (!s) continue;
+      if (matchesCompound(s, el) !== true) continue;
+      for (const d of declarations(rule.body)) {
+        if (d.prop !== prop) continue;
+        const cand = {
+          value: d.value,
+          important: d.important,
+          spec: specificity(s),
+          order,
+          selector: s,
+          at: rule.at,
+        };
+        // !important first, then specificity, then source order. Written
+        // out longhand: `cmp(...) || order` reads naturally and is wrong,
+        // because cmp returns -1 for a LESS specific candidate and -1 is
+        // truthy, so every later rule would win whatever its specificity.
+        winner = (() => {
+          if (!winner) return cand;
+          if (cand.important !== winner.important) {
+            return cand.important ? cand : winner;
+          }
+          const bySpec = cmp(cand.spec, winner.spec);
+          if (bySpec !== 0) return bySpec > 0 ? cand : winner;
+          return cand.order >= winner.order ? cand : winner;
+        })();
+      }
+    }
+  });
+  return winner;
+}
+
+const rules = CSS_FILES.flatMap((f) =>
+  parseRules(readFileSync(resolve(here, "..", f), "utf8")),
+);
+
+const header = { tag: "header", classes: ["site-header"] };
+const main = { tag: "main", classes: [] };
+
+const failures = [];
+const describe = (w) =>
+  w ? `${w.value}  (from \`${w.selector}\`${w.at.length ? ` inside ${w.at.join(" / ")}` : ""})` : "<unset>";
+
+const headerPos = resolve_(rules, header, "position");
+const headerZ = resolve_(rules, header, "z-index");
+const mainZ = resolve_(rules, main, "z-index");
+
+if (headerPos?.value !== "sticky") {
+  failures.push(
+    `header position resolves to ${describe(headerPos)} — expected \`sticky\`.\n` +
+      `    A non-sticky header also means its own .site-header block lost the cascade.`,
+  );
+}
+
+const hz = Number(headerZ?.value);
+const mz = Number(mainZ?.value);
+if (!Number.isFinite(hz) || !Number.isFinite(mz) || hz <= mz) {
+  failures.push(
+    `header z-index (${describe(headerZ)}) must be strictly greater than main z-index (${describe(mainZ)}).\n` +
+      `    On a tie, <main> paints last and swallows clicks on the compare dropdown.`,
+  );
+}
+
+if (failures.length) {
+  console.error("check-header-stacking: FAIL\n");
+  for (const f of failures) console.error(`  - ${f}\n`);
+  process.exit(1);
+}
+
+console.log(
+  `check-header-stacking: ok  (header ${headerPos.value}, z-index ${hz} > main z-index ${mz})`,
+);

--- a/site/scripts/check-header-stacking.mjs
+++ b/site/scripts/check-header-stacking.mjs
@@ -70,28 +70,51 @@ function parseRules(css, at = []) {
 }
 
 /**
- * Does this single selector match `el`?
+ * Does this selector match `el`? true / false / null = cannot tell.
  *
- * Deliberately narrow: only compound selectors built from a tag and/or
- * classes (no combinators, pseudos, attributes or ids). Anything more
- * complex is CONTEXT-dependent, so this cannot decide it from the
- * stylesheet alone — and a guard that guesses is worse than one that
- * abstains. Such selectors are reported separately rather than ignored.
+ * Decided on the selector's SUBJECT — its last compound — because that
+ * is the element a rule actually styles. `.site-header details.nav-dd`
+ * has subject `details.nav-dd`, so it styles a descendant and can never
+ * apply to the header however much of the header's name it contains.
+ * Judging the whole selector string instead flags every descendant rule
+ * in the sheet as unreadable, burying the one that matters.
+ *
+ * `null` means "ask a human" — the subject matches, but an ancestor
+ * combinator or state qualifier decides the rest and neither can be read
+ * from a stylesheet alone. resolve_ escalates those rather than skipping
+ * them: a selector this cannot read is exactly where the next regression
+ * hides, so quietly ignoring `body > main { z-index: 99 }` would hand
+ * back a green build over a dead dropdown.
  */
-function matchesCompound(sel, el) {
-  if (/[\s>+~]/.test(sel)) return null; // combinator — needs a DOM
-  if (/[:[#]/.test(sel)) return null; // pseudo/attr/id — needs state
-  const tag = sel.match(/^[a-zA-Z][\w-]*/)?.[0] ?? null;
+function matchesSelector(sel, el) {
+  // Pseudo-elements style a generated box, never the element itself.
+  if (/::|:(?:before|after|first-line|first-letter)\b/.test(sel)) return false;
+
+  const compounds = sel.split(/[\s>+~]+/).filter(Boolean);
+  const subject = compounds[compounds.length - 1] ?? "";
+  const hasAncestorContext = compounds.length > 1;
+
+  // Strip state qualifiers to read the structural part of the subject.
+  const bare = subject
+    .replace(/:[-\w]+(\([^)]*\))?/g, "")
+    .replace(/\[[^\]]*\]/g, "");
+  const tag = bare.match(/^[a-zA-Z][\w-]*/)?.[0] ?? null;
+  const classes = [...bare.matchAll(/\.([-\w]+)/g)].map((m) => m[1]);
+  const hasId = /#[-\w]+/.test(bare);
+
   if (tag && tag !== el.tag) return false;
-  const classes = [...sel.matchAll(/\.([-\w]+)/g)].map((m) => m[1]);
-  if (!classes.length && !tag) return false;
-  return classes.every((c) => el.classes.includes(c));
+  if (!classes.every((c) => el.classes.includes(c))) return false;
+  if (!tag && !classes.length && !hasId) return false; // `*` and friends
+
+  // The subject matches. Anything beyond a plain compound is context this
+  // cannot evaluate, so abstain instead of guessing either way.
+  return hasAncestorContext || /[:[#]/.test(subject) ? null : true;
 }
 
-/** (id, class, tag) specificity of a compound selector. */
+/** (id, class, tag) specificity of a plain compound selector. */
 function specificity(sel) {
   return [
-    0,
+    (sel.match(/#[-\w]+/g) || []).length,
     (sel.match(/\.[-\w]+/g) || []).length,
     /^[a-zA-Z][\w-]*/.test(sel) ? 1 : 0,
   ];
@@ -127,16 +150,55 @@ function declarations(body) {
     .filter(Boolean);
 }
 
-/** Resolve the winning declaration of `prop` for `el` across all sheets. */
+/**
+ * Resolve the winning declaration of `prop` for `el` across all sheets.
+ *
+ * Returns { winner, unmodelled }. `unmodelled` is every rule that could
+ * plausibly affect the answer but which this cannot evaluate — a
+ * selector needing a live DOM, or a declaration inside a conditional
+ * group. Those are NOT folded into the cascade: treating a
+ * `@media (max-width: 820px)` rule as unconditional would report a
+ * failure that no browser ever sees, and ignoring it would green-light
+ * a viewport where the dropdown is genuinely dead. Neither is a verdict
+ * this can honestly reach, so it hands them to a human instead.
+ */
 function resolve_(rules, el, prop) {
   let winner = null;
+  const unmodelled = [];
   rules.forEach((rule, order) => {
+    const decls = declarations(rule.body).filter((d) => d.prop === prop);
+    if (!decls.length) return;
+
     for (const sel of rule.prelude.split(",")) {
       const s = sel.trim();
       if (!s) continue;
-      if (matchesCompound(s, el) !== true) continue;
-      for (const d of declarations(rule.body)) {
-        if (d.prop !== prop) continue;
+
+      // null only ever means "the subject matches but the context is
+      // unreadable", so every one of them is a genuine candidate — no
+      // relevance filter is needed to keep the report from drowning.
+      const verdict = matchesSelector(s, el);
+      if (verdict === null) {
+        unmodelled.push({
+          selector: s,
+          at: rule.at,
+          prop,
+          why: "selector needs a live DOM to evaluate",
+        });
+        continue;
+      }
+      if (verdict !== true) continue;
+
+      if (rule.at.length) {
+        unmodelled.push({
+          selector: s,
+          at: rule.at,
+          prop,
+          why: "declared inside a conditional group",
+        });
+        continue;
+      }
+
+      for (const d of decls) {
         const cand = {
           value: d.value,
           important: d.important,
@@ -161,7 +223,7 @@ function resolve_(rules, el, prop) {
       }
     }
   });
-  return winner;
+  return { winner, unmodelled };
 }
 
 const rules = CSS_FILES.flatMap((f) =>
@@ -175,9 +237,30 @@ const failures = [];
 const describe = (w) =>
   w ? `${w.value}  (from \`${w.selector}\`${w.at.length ? ` inside ${w.at.join(" / ")}` : ""})` : "<unset>";
 
-const headerPos = resolve_(rules, header, "position");
-const headerZ = resolve_(rules, header, "z-index");
-const mainZ = resolve_(rules, main, "z-index");
+const resolved = [
+  resolve_(rules, header, "position"),
+  resolve_(rules, header, "z-index"),
+  resolve_(rules, main, "z-index"),
+];
+const [{ winner: headerPos }, { winner: headerZ }, { winner: mainZ }] = resolved;
+
+// Abstentions are reported BEFORE the verdict, because a verdict reached
+// while ignoring a rule that might overturn it is not a verdict.
+const unmodelled = resolved.flatMap((r) => r.unmodelled);
+if (unmodelled.length) {
+  failures.push(
+    `this guard cannot model ${unmodelled.length} rule(s) that may affect the answer:\n` +
+      unmodelled
+        .map(
+          (u) =>
+            `      \`${u.selector}\` { ${u.prop} }` +
+            `${u.at.length ? ` inside ${u.at.join(" / ")}` : ""} — ${u.why}`,
+        )
+        .join("\n") +
+      `\n    Verify by hand that the header still out-stacks main, then either teach\n` +
+      `    this script that construct or move the declaration out of it.`,
+  );
+}
 
 if (headerPos?.value !== "sticky") {
   failures.push(

--- a/site/src/styles/ember.css
+++ b/site/src/styles/ember.css
@@ -81,8 +81,15 @@ body::after {
   z-index: 2;
 }
 
-/* Keep content above the scanline / vignette overlays */
-main, header.site-header, footer.site-footer {
+/* Keep content above the scanline / vignette overlays.
+   The header is deliberately NOT in this list: it carries its own
+   `position: sticky; z-index: 40` below, and `header.site-header` here
+   would outrank that (0,1,1 vs 0,1,0) whatever the source order —
+   demoting the header to a z-index 3 tie with `main`. `main` then paints
+   last and swallows clicks on the compare dropdown, which hangs out of
+   the header into main's box and so stays visible while going dead.
+   Guarded by scripts/check-header-stacking.mjs. */
+main, footer.site-footer {
   position: relative;
   z-index: 3;
 }


### PR DESCRIPTION
## The bug

The **compare** dropdown in the site nav opens, renders every item, and then
does nothing when you click one.


## Root cause

Not the dropdown. A CSS specificity collision in `ember.css` — two rules both
match the header:

```css
main, header.site-header, footer.site-footer { position: relative; z-index: 3 }  /* (0,1,1) */
/* ...80 lines later... */
.site-header { position: sticky; top: 0; z-index: 40 }                           /* (0,1,0) */
```

`header.site-header` carries a tag *and* a class, so it outranks the header's
own block **regardless of source order**. The header received neither
declaration it was written to have:

1. **`z-index: 3`, not 40** — a tie with `main`. Ties break by DOM order, and
   `<main>` comes after `<header>`, so main paints last. `.dd-menu` is
   `position: absolute` and hangs *below* the header's border box, into main's
   area — so main won hit-testing and swallowed every click. The menu stayed
   *visible* because main is transparent there. Visible-but-dead is the
   signature of a stacking bug, not a markup bug.
2. **`position: relative`, not `sticky`** — the header also quietly stopped
   sticking on scroll. Same root cause, unreported.

## The fix

Drop the header from the blanket rule. That rule exists to lift content above
the scanline (`z-index: 1`) and vignette (`z-index: 2`) overlays; the header's
own `z-index: 40` already clears both. The footer stays — it has no `z-index`
of its own and genuinely needs it.

## Regression guard

`site/scripts/check-header-stacking.mjs`, wired into `npm run build`.

Grep cannot catch this class of bug: nothing is misspelled and each rule reads
as correct on its own — the defect exists only in the *resolution* between two
rules. So the guard resolves them: it parses both stylesheets, computes the
winning `position` and `z-index` for `<header class="site-header">` and
`<main>` honouring specificity, `!important`, source order and `@media`
groups, then asserts the header out-stacks main and is still `sticky`.

Red-green verified:

| State | Result |
|---|---|
| Bug reintroduced | `FAIL`, exit 1 — names both symptoms |
| Fixed | `ok (header sticky, z-index 40 > main z-index 3)` |

Also confirmed in the emitted bundle, not just the source: `header.site-header`
no longer appears, `.site-header{position:sticky;…z-index:40}` does, and
`npm run build` passes all 15 pages.

## Verification not done here

The actual click, in a real browser — the local browser-automation extension
wasn't connected, so this is a cascade proof rather than a behavioural one.
`cd site && npm run preview` to confirm both symptoms by hand.

## Note for a follow-up

`site.yml` runs `npm run build`, so the guard gates the Pages **deploy** — but
that workflow only fires on push to master, and `ci.yml` never builds the site.
A stacking regression would therefore land on master and turn the deploy red
rather than failing its PR. Adding a site build to PR CI would close that, and
is deliberately out of scope here.

