### PR TITLE
fix(ci): gate releases on changes that reach the binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,12 +101,21 @@ jobs:
           # release-worthy and changelog-required have to be the SAME
           # question, or every divergence is another red master.
           #
-          # Note this is broader than the `*.go` filter it replaced: embedded
-          # assets count. internal/plugin/defaults/*.toml and
-          # internal/shellinit/*.sh are go:embed'ed, so changing one really
-          # does change the binary — v1.28.0 shipped exactly that (lazysql.toml
-          # and nothing else), as did v0.10.2 (go.mod alone).
-          CODE=$(echo "$CHANGED" | grep -E '^(cmd/|internal/|go\.mod$|go\.sum$)' | grep -v '_test\.go$' || true)
+          # A DENYLIST of what provably does not ship, not an allowlist of
+          # what does — see release.yml for the full reasoning. Briefly: an
+          # allowlist silently omits build inputs added later, and the first
+          # version of this pair missed every Windows one (winres/ and
+          # scripts/fetch-conpty.sh both feed .goreleaser.yml's before.hooks
+          # and land in the shipped binaries).
+          #
+          # Non-obvious members: internal/plugin/defaults/*.toml and
+          # internal/shellinit/*.sh are go:embed'ed, so a TOML-only change
+          # really does change the binary — v1.28.0 shipped exactly that.
+          CODE=$(echo "$CHANGED" \
+            | grep -vE '^(site|docs|tools|techdebt|marketing|\.github|\.claude)/' \
+            | grep -vE '^[^/]+\.md$' \
+            | grep -vE '^(VERSION|LICENSE|Makefile|package-lock\.json|\.gitignore|\.gitattributes|\.editorconfig|\.dockerignore)$' \
+            | grep -v '_test\.go$' || true)
           if [ -z "$CODE" ]; then
             echo "::notice::No changes reach the binary — changelog entry not required"
             exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,12 +89,26 @@ jobs:
           echo "$CHANGED"
           echo "---"
 
-          # Production Go code only. Test-only, docs-only, site-only, workflow-
-          # only, and plugin-TOML-only PRs are exempt — they can't change what a
-          # user sees in the binary.
-          CODE=$(echo "$CHANGED" | grep -E '^(cmd|internal)/.*\.go$' | grep -v '_test\.go$' || true)
+          # Anything that reaches the binary. Test-only, docs-only, site-only
+          # and workflow-only PRs are exempt — they can't change what a user
+          # sees in the binary.
+          #
+          # This list MUST match release.yml's payload gate. The two used to
+          # disagree: this job asked "which files changed?" while release.yml
+          # asked "what type is the commit?", so a `fix(site):` PR was exempted
+          # here and then bumped a version there, dying on the [Unreleased]
+          # gate — a green PR that reliably turned master red (#130).
+          # release-worthy and changelog-required have to be the SAME
+          # question, or every divergence is another red master.
+          #
+          # Note this is broader than the `*.go` filter it replaced: embedded
+          # assets count. internal/plugin/defaults/*.toml and
+          # internal/shellinit/*.sh are go:embed'ed, so changing one really
+          # does change the binary — v1.28.0 shipped exactly that (lazysql.toml
+          # and nothing else), as did v0.10.2 (go.mod alone).
+          CODE=$(echo "$CHANGED" | grep -E '^(cmd/|internal/|go\.mod$|go\.sum$)' | grep -v '_test\.go$' || true)
           if [ -z "$CODE" ]; then
-            echo "::notice::No production Go changes — changelog entry not required"
+            echo "::notice::No changes reach the binary — changelog entry not required"
             exit 0
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,6 +150,51 @@ jobs:
             exit 0
           fi
 
+          # Nothing that reaches the binary => nothing to release.
+          #
+          # This gate exists because ci.yml and this workflow used to answer
+          # "is this user-facing?" DIFFERENTLY. ci.yml's changelog job decides
+          # by changed FILES and exempts site-only PRs; this step decided by
+          # commit TYPE alone. So `fix(site):` passed PR review with no
+          # changelog entry, then bumped a patch here and died on the
+          # [Unreleased] gate below — green PR, red master, every time. That
+          # is what happened to #130 (1.49.0 -> 1.49.1).
+          #
+          # Cutting the release anyway would be worse than failing: it
+          # publishes five platform binaries byte-identical to the previous
+          # tag, so users get an update notification for a CSS change.
+          #
+          # The path list is deliberately BROADER than ci.yml's `*.go` — it
+          # covers anything compiled or go:embed'ed into the binary. Both
+          # rescues are real and backtested: v1.28.0 shipped only
+          # internal/plugin/defaults/lazysql.toml (embedded — the binary
+          # really did gain a plugin) and v0.10.2 shipped only go.mod. A
+          # .go-only filter would have silently suppressed both.
+          #
+          # Deliberately a RANGE-level check, not a per-commit one. Pairing
+          # "changed code" with "declares a type" assumes both live on the
+          # same commit; that holds for squash-merged PRs but not for a
+          # trigger commit. v1.33.1 is the counter-example — #84 carried 15
+          # Go files under a non-conventional subject and #85 (`fix: publish
+          # merged...`) carried the type with no code. Per-commit pairing
+          # never cuts that release at all, and a release that silently does
+          # not happen is worse than one that fails loudly.
+          #
+          # Backtested over all 109 tag boundaries: 18 differ, and every one
+          # changed nothing under these paths.
+          #
+          # Keep the path list in sync with ci.yml's `changelog` job.
+          if git rev-parse "$LAST_TAG" >/dev/null 2>&1; then
+            PAYLOAD=$(git diff --name-only "${LAST_TAG}..HEAD" \
+              | grep -E '^(cmd/|internal/|go\.mod$|go\.sum$)' \
+              | grep -v '_test\.go$' || true)
+            if [ -z "$PAYLOAD" ]; then
+              echo "::notice::No changes reach the binary since ${LAST_TAG} (docs/site/workflow only) — skipping release"
+              echo "skip=true" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+          fi
+
           # Determine bump type from conventional commits.
           # - `-i` for case-insensitivity: GitHub's squash-merge auto-capitalizes
           #   branch-name-derived subjects (`feat/x` -> `Feat/x`).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,12 +164,25 @@ jobs:
           # publishes five platform binaries byte-identical to the previous
           # tag, so users get an update notification for a CSS change.
           #
-          # The path list is deliberately BROADER than ci.yml's `*.go` — it
-          # covers anything compiled or go:embed'ed into the binary. Both
-          # rescues are real and backtested: v1.28.0 shipped only
-          # internal/plugin/defaults/lazysql.toml (embedded — the binary
-          # really did gain a plugin) and v0.10.2 shipped only go.mod. A
-          # .go-only filter would have silently suppressed both.
+          # Expressed as a DENYLIST of things that provably do not ship,
+          # not an allowlist of things that do. An allowlist fails toward
+          # silently NOT releasing, which is the worst outcome available
+          # here: a user-facing fix that never reaches anyone and produces
+          # no signal that it didn't. Review caught exactly that — the
+          # first version listed cmd/ internal/ go.mod go.sum and so missed
+          # every Windows build input. .goreleaser.yml's before.hooks are
+          # the proof: `sh scripts/fetch-conpty.sh` fetches the conpty.dll
+          # and OpenConsole.exe that the Windows build go:embeds, and
+          # `go-winres make --in winres/winres.json` links .syso icon and
+          # version resources into both binaries. A winres-only or
+          # fetch-conpty-only fix is a real shipped change. Inverting it
+          # means a build input added LATER counts by default.
+          #
+          # Non-obvious members, all verified rather than assumed:
+          # internal/plugin/defaults/*.toml and internal/shellinit/*.sh are
+          # go:embed'ed (v1.28.0 shipped lazysql.toml and nothing else);
+          # go.mod alone changes the binary (v0.10.2); .goreleaser.yml
+          # controls ldflags and platforms.
           #
           # Deliberately a RANGE-level check, not a per-commit one. Pairing
           # "changed code" with "declares a type" assumes both live on the
@@ -177,16 +190,17 @@ jobs:
           # trigger commit. v1.33.1 is the counter-example — #84 carried 15
           # Go files under a non-conventional subject and #85 (`fix: publish
           # merged...`) carried the type with no code. Per-commit pairing
-          # never cuts that release at all, and a release that silently does
-          # not happen is worse than one that fails loudly.
+          # never cuts that release at all.
           #
-          # Backtested over all 109 tag boundaries: 18 differ, and every one
-          # changed nothing under these paths.
+          # Backtested over all 109 tag boundaries: 17 differ, and every one
+          # changed nothing outside the denied paths.
           #
-          # Keep the path list in sync with ci.yml's `changelog` job.
+          # Keep this list in sync with ci.yml's `changelog` job.
           if git rev-parse "$LAST_TAG" >/dev/null 2>&1; then
             PAYLOAD=$(git diff --name-only "${LAST_TAG}..HEAD" \
-              | grep -E '^(cmd/|internal/|go\.mod$|go\.sum$)' \
+              | grep -vE '^(site|docs|tools|techdebt|marketing|\.github|\.claude)/' \
+              | grep -vE '^[^/]+\.md$' \
+              | grep -vE '^(VERSION|LICENSE|Makefile|package-lock\.json|\.gitignore|\.gitattributes|\.editorconfig|\.dockerignore)$' \
               | grep -v '_test\.go$' || true)
             if [ -z "$PAYLOAD" ]; then
               echo "::notice::No changes reach the binary since ${LAST_TAG} (docs/site/workflow only) — skipping release"


### PR DESCRIPTION
Merging #130 turned master red. The [Release run](https://github.com/artyomsv/quil/actions/runs/31031583824) failed; the site deploy and CodeQL were fine, and no tag was cut.

## Root cause

`ci.yml` and `release.yml` were answering **"is this user-facing?"** two different ways.

| | asks | verdict on `fix(site):` |
|---|---|---|
| `ci.yml` changelog job | which **files** changed | exempt — no changelog needed |
| `release.yml` bump step | what **type** the commit is | `fix` → patch bump → demands a changelog |

So the PR passed review with no changelog entry, then bumped `1.49.0 → 1.49.1` on master and died on the `[Unreleased]` gate:

```
--- Subjects since v1.49.0 ---
fix(site): stop main painting over the sticky header (#130)
docs(projects): show the sidebar and the remote connect flow (#129)
Version bump: 1.49.0 → 1.49.1 (patch)
::error::The [Unreleased] section is empty — refusing to cut a release
```

This is a standing trap, not a one-off: every future `fix(site):` / `feat(site):` does the same.

Cutting the release instead would be the worse repair — five platform binaries byte-identical to v1.49.0, and an update notification for a CSS change.

## Fix

Skip the release when nothing since the last tag reaches the binary, and make **both** workflows ask that one question off one path list. `release-worthy` and `changelog-required` have to be the same predicate, or every divergence is another red master.

**Expressed as a denylist of what provably doesn't ship, not an allowlist of what does.** This is the part worth reviewing. My first version allowlisted `cmd/ internal/ go.mod go.sum` and thereby missed every Windows build input — review caught it, and `.goreleaser.yml`'s `before.hooks` are the proof:

```yaml
- sh scripts/fetch-conpty.sh
- go-winres make --in winres/winres.json --out cmd/quil/rsrc ...
```

`fetch-conpty.sh` fetches the `conpty.dll` / `OpenConsole.exe` the Windows build `go:embed`s; `go-winres` links `.syso` icon and version resources into both binaries. A winres-only fix is a genuinely shipped change, and the allowlist skipped its release.

The formulation was the bug, not the list. An allowlist fails toward silently *not* releasing — a fix that reaches nobody and emits no signal that it didn't — which is the same failure mode this PR already rejected in choosing a range-level check over a per-commit one. A denylist makes a build input added later count by default.

Non-obvious members, verified rather than assumed: `internal/plugin/defaults/*.toml` and `internal/shellinit/*.sh` are `go:embed`ed (v1.28.0 shipped `lazysql.toml` and nothing else); `go.mod` alone changes the binary (v0.10.2); `.goreleaser.yml` controls ldflags and platforms.

**Range-level, not per-commit.** I tried per-commit first — filter to commits touching code, classify those subjects. More precise in principle, wrong in practice: it assumes "changed code" and "declares a type" live on the same commit. True for squash-merged PRs, false for a trigger commit. v1.33.1 is the counter-example — #84 carried 15 Go files under a non-conventional subject (`Fix claude-code pane render artifacts…`) while #85 (`fix: publish merged…`) carried the type and no code. Per-commit pairing never cuts that release **at all**.

## Verification

Backtested across **all 109 tag boundaries**. 17 change outcome, and every one changed nothing outside the denied paths — releases whose binaries were identical to the prior tag. Zero boundaries with real payload change outcome.

Verified against the *shipped* logic rather than a paraphrase: both steps extracted from the YAML with a parser and run for real.

| Commit | Expected | Result |
|---|---|---|
| current master | skip | `skip=true` |
| `3a8cf64` — #128 Go feature | minor | `1.48.0 → 1.49.0`, `skip=false` |
| `bc42000` — the trigger-commit case | patch | `1.33.0 → 1.33.1`, `skip=false` |

The two gates now agree on every representative path:

| Changed files | `ci.yml` | `release.yml` |
|---|---|---|
| `winres/winres.json` | required | release |
| `scripts/fetch-conpty.sh` | required | release |
| `.goreleaser.yml` | required | release |
| `internal/plugin/defaults/*.toml` | required | release |
| `internal/shellinit/*.sh` | required | release |
| `go.mod` | required | release |
| production `.go` | required | release |
| site / docs / workflow / README / `_test.go` / tools | exempt | skip |

All three workflow files parse.

## Known imprecision

`scripts/dev.sh` counts as payload though it ships nothing. It errs toward releasing, which is the safe direction, and such changes are typed `chore:`/`ci:` — which don't bump anyway.

## After merge

Master carries #129 (docs), #130 (site) and this PR (workflows) since v1.49.0 — none reach the binary, so Release will skip and master goes green. The next PR touching real code releases normally.
