### PR TITLE
fix(tui): keep a typed branch and allow replace into a new worktree

### DIFF
--- a/.claude/reviews/global/worktree-replace-and-branch-capture.md
+++ b/.claude/reviews/global/worktree-replace-and-branch-capture.md
@@ -1,0 +1,20 @@
+# Code Review State: global / worktree-replace-and-branch-capture
+
+Last reviewed: 2026-08-07
+Rounds completed: 1
+
+## Resolved (fixed in code; do not re-raise)
+- [security/M1 + code-quality/1 + qa/4] worktreeReplaced leaked permanently when any broadcast landed mid-flight — both settling paths gate on worktreeCreates, which rebuildTabs cleared. Dispose moved to the leaf-fill; rebuildTabs skips the held pane — round 1
+- [code-quality/6] PrunePlaceholders cannot repair a ROOT placeholder, so the root-insert fallback panicked on tab.Leaves()[0]. Guarded — round 1
+- [code-quality/2 + security/L1 + qa/5] renderPendingPane overflowed its rect: the 18-cell prefix was never budgeted and lipgloss pads rather than truncates (10x4 rendered 10x5; 1x4 rendered 1x18). Whole line budgeted + MaxWidth/MaxHeight — round 1
+- [code-quality/4 + qa/6] an ordinary split's placeholder rendered "Creating worktree…". Empty branch now renders blank — round 1
+- [code-quality/3 + qa/3] a second create on the same tab overwrote worktreeCreates, worktreeReplaced and pendingSplit. Refused with a reason — round 1
+- [code-quality/5] the post-add re-check covered the tab but not the replace target, orphaning a worktree. Re-checked, and every abandonment after a successful add now removes the worktree + branch (gitworktree.Remove) — round 1
+- [security/M2] the failure-restore premise was false when the spawn failed after a successful swap. CreatePaneRespPayload.Swapped added; settleReplacedPane is the single restore/dispose choke point — round 1
+- [security/L2 + code-quality/10] p.TabID was validated but ReplacePane resolves pane ids globally, so a mismatched pair destroyed another tab's pane. Validated before and after the add — round 1
+- [qa/1] TestReplace_WithoutAWorktreeStillDisposesImmediately was vacuous — deleting old.Dispose() kept the suite green. Now asserts the dispose itself (p.vt nilled) — round 1
+- [code-quality/8] the timeout mutated the leaf before its own nil-root guard, leaving a stale leaves cache. Folded into settleReplacedPane — round 1
+- [code-quality/9] fmt.Errorf put the verb mid-sentence; reworded to context-first — round 1
+
+## Dismissed (acknowledged, will not fix; agents may escalate with explicit justification)
+- [code-quality/7] the timeout flash says "worktree not created" even after a success response whose pane never landed. Not reachable as stated: success now settles on the broadcast that fills the leaf, which also clears worktreeCreates, so the timeout returns early and flashes nothing (round 1)

--- a/.claude/rules/projects.md
+++ b/.claude/rules/projects.md
@@ -580,11 +580,59 @@ Daemon: `worktreeAddAndCreate` creates the worktree FIRST and only then calls
 `replacePaneAt` (extracted from `handleReplacePane` so the worktree path can
 report failure instead of logging it), so every failure path returns before the
 pane being replaced is touched. Client: a worktree replace holds the detached
-pane in `Model.worktreeReplaced` instead of disposing it — `applyCreatePaneResp`
-disposes it on success (the swap really happened, so the model describes a pane
-that no longer exists) and puts it back in its leaf on failure or timeout. An
-ordinary replace still disposes at send time, because there the daemon destroys
-the pane the moment it handles the message and there is nothing to go back to.
+pane in `Model.worktreeReplaced` instead of disposing it. An ordinary replace
+still disposes at send time, because there the daemon destroys the pane the
+moment it handles the message and there is nothing to go back to.
+
+**The SUCCESS dispose lives in `rebuildTabs`, not in `applyCreatePaneResp`, and
+putting it in the handler was a leak on every successful replace.** The daemon
+calls `broadcastState()` and THEN `respondTo`, both must-deliver on one serial
+reader — so the broadcast that fills the reserved leaf is processed first and
+clears `worktreeCreates`, after which the response handler bails on its own
+`worktreeCreates[tabID] == ""` guard and never reaches its dispose. A pane
+really landing in the leaf is the only proof of the swap that arrives reliably.
+
+**`rebuildTabs` must SKIP the held pane, or a routine broadcast dismantles the
+whole request.** While the add runs the daemon has not swapped yet, so it keeps
+reporting the OLD pane id — which is absent from the tree because the client
+detached it, and `existingPanes` is built from `tab.Leaves()`. Without the skip
+that reads as a new pane: an empty `PaneModel` is built for a live one, the
+reserved leaf is consumed, and `worktreeCreates` is cleared, after which nothing
+can settle the held model. The trigger is ordinary — the git ticker alone
+broadcasts every 5 s against a window that is seconds to minutes wide.
+
+**`CreatePaneRespPayload.Swapped` is a statement about what HAPPENED, and it is
+not derivable from `Error`.** The swap precedes the new pane's PTY spawn, so a
+spawn failure is an error with the old pane already destroyed; a client that
+inferred "error means untouched" restored a pane the daemon no longer had.
+`settleReplacedPane` is the single restore/dispose choke point — the three
+settling paths had this subtly different when they were written out separately,
+including a timeout that mutated the leaf before its own nil-root guard.
+
+**One worktree create per tab, refused in `handleCreatePaneSplit`.**
+`worktreeCreates`, `worktreeReplaced` and `pendingSplit` are all keyed by tab,
+so a second create overwrites all three — leaking the first held pane and
+pointing the first's response at the second's leaf. Reachable from the keyboard
+because the dialog closes on submit and `ActivePaneModel` adopts another leaf
+once the first replace detaches its pane. The daemon's `worktreeAdding`
+single-flight would refuse it anyway; this just says so when the user asks.
+
+**Every abandonment after a successful add REMOVES the worktree**
+(`removeWorktreeFn`, paired with `addWorktreeFn` so a stub can observe the
+undo). The tab or the replace target can be closed inside the checkout window;
+returning without cleanup strands a full checkout plus a branch pointing at it,
+and the next attempt at that name fails with "already exists" against a
+directory the user never made. `gitworktree.Remove` is the one place `--force`
+is right — the tree was created by this daemon seconds ago and handed to nobody
+— and it removes the worktree BEFORE the branch, because git refuses to delete a
+branch a worktree still has checked out.
+
+**The replace target is validated against `p.TabID`, before AND after the add.**
+`ReplacePane` resolves the pane id globally and swaps it inside its OWN tab, so
+a payload pairing tab A with a pane in tab B destroys B's pane while the
+response echoes A — and the client arms and unwinds its placeholder on the
+echoed tab. Any IPC client can send the pair; the pre-existing `p.TabID`
+existence checks read as tab scoping and were not.
 
 **A placeholder leaf RENDERS, and it did not used to.** `renderNode`'s
 `IsLeaf()` is `Pane != nil`, so a placeholder fell through to the split arm and
@@ -599,6 +647,29 @@ cannot paint over a sibling in a split. `worktreeCreates` is
 is pushed from the SAME read that decides the prune exemption, so the
 placeholder and the message standing in it cannot disagree about whether a
 create is in flight.
+
+**The WHOLE line is budgeted, not just the branch, and the box is CLAMPED.**
+lipgloss `Width`/`Height` pad but never truncate, so granting the branch `w-4`
+while prepending an 18-cell literal produced a line up to `w+14` wide that
+wrapped into extra rows — and a box taller than the rect `resizeNode` recorded
+pushes every sibling below it down. Measured before the fix: a 10×4 leaf (the
+documented minimum) rendered 10×5, and 1×4 rendered 1×18. `MaxWidth`/`MaxHeight`
+are the clamp; the whole-line `truncateCells` is the budget; either alone
+happens to hold today, which is why the test asserts the PROPERTY (fits its
+rect) rather than one mechanism.
+
+**An empty branch renders BLANK, deliberately.** `renderNode` reaches this for
+any childless nil-`Pane` node, including an ordinary split's placeholder, which
+has no worktree at all — and an ordinary create over ssh is not microseconds.
+Claiming "Creating worktree…" there is the same class of confidently-wrong
+answer the rest of this feature exists to remove.
+
+**`PrunePlaceholders` cannot repair a ROOT placeholder** — it only inspects a
+split node's CHILDREN — and a replace on a single-pane tab creates exactly that.
+`rebuildTabs`' root-insert fallback therefore checks `len(tab.Leaves()) == 0`
+before indexing `[0]`. Latent until the held-pane skip above landed: the
+broadcast used to refill the root in the same pass that consumed the leaf, which
+masked the panic.
 
 **`handleCreatePaneSplit` tears the setup dialog down before it builds the
 payload.** The branch name is captured with the other choices at the top;

--- a/.claude/rules/projects.md
+++ b/.claude/rules/projects.md
@@ -567,12 +567,38 @@ fresh daemon re-stats, and a stored one would resurrect a complaint about a
 worktree since restored. The pane offers `Alt+R` and nothing more specific:
 Quil records the worktree path, not the repository it branched from.
 
-**Replace mode is refused, in the CLIENT at the split step and in the daemon.**
-The field cannot gate itself — the user picks replace *after* the worktree
-field — so `handleCreatePaneSplit` refuses before it does anything destructive.
-That path sets `leaf.Pane = nil` and calls `old.Dispose()` BEFORE the send, and
-unlike a dangling placeholder a `Dispose()` is not something
-`PrunePlaceholders` can undo, so a failed add there costs a LIVE pane.
+**Replace mode is SUPPORTED, and what makes it safe is ordering rather than a
+guard.** It was refused at first, on both sides, because the client set
+`leaf.Pane = nil` and called `old.Dispose()` BEFORE the send — so a failed add
+cost a LIVE pane, and unlike a dangling placeholder a `Dispose()` is not
+something `PrunePlaceholders` can undo. That is a statement about WHEN the
+client disposes, not about the operation: replacing a scratch shell with an
+agent on a fresh branch is an ordinary thing to want, and the refusal was
+overruled by the project owner on exactly those grounds.
+
+Daemon: `worktreeAddAndCreate` creates the worktree FIRST and only then calls
+`replacePaneAt` (extracted from `handleReplacePane` so the worktree path can
+report failure instead of logging it), so every failure path returns before the
+pane being replaced is touched. Client: a worktree replace holds the detached
+pane in `Model.worktreeReplaced` instead of disposing it — `applyCreatePaneResp`
+disposes it on success (the swap really happened, so the model describes a pane
+that no longer exists) and puts it back in its leaf on failure or timeout. An
+ordinary replace still disposes at send time, because there the daemon destroys
+the pane the moment it handles the message and there is nothing to go back to.
+
+**A placeholder leaf RENDERS, and it did not used to.** `renderNode`'s
+`IsLeaf()` is `Pane != nil`, so a placeholder fell through to the split arm and
+joined two empty children — the empty string. Invisible while a create took
+microseconds; a black rectangle for the ~16 s a `git worktree add` takes against
+a large repository, and on the replace path the whole tab, because the pane it
+stands in for has already gone. `resizeNode` records the placeholder's rect
+(`phW`/`phH`, runtime-only — persistence goes through `SerializedNode`) and
+`renderPendingPane` draws a box naming the branch, sized from that rect so it
+cannot paint over a sibling in a split. `worktreeCreates` is
+`map[string]string` (tab → branch) rather than a bool set, and `TabModel.CreatingBranch`
+is pushed from the SAME read that decides the prune exemption, so the
+placeholder and the message standing in it cannot disagree about whether a
+create is in flight.
 
 **`handleCreatePaneSplit` tears the setup dialog down before it builds the
 payload.** The branch name is captured with the other choices at the top;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **A pane can now be replaced with one in a new worktree.** Swapping a scratch
+  shell for an agent on a fresh branch is an ordinary thing to want, and the
+  dialog refused it. The worktree is created before the pane you are replacing
+  is touched, so a branch git rejects leaves that pane exactly where it was.
+- **Creating a worktree now says so while it works.** A checkout of a large
+  repository takes tens of seconds, and the space the new pane will occupy was
+  blank for all of it — on the replace path the tab was blank entirely, because
+  the pane being replaced had already gone. It now names the branch it is
+  checking out.
+
+### Fixed
+- **A branch typed for a new worktree was discarded if you pressed Tab.** Tab
+  moves between fields without closing the name box, so the dialog went on
+  showing `new branch <name>` while Continue silently dropped it — and the pane
+  opened in the repository root with no worktree and no error, which is the
+  relocation the feature exists to prevent. What the dialog shows is what it now
+  does; an incomplete name is refused with a reason instead.
+- **Esc in the branch-name box no longer abandons the whole dialog.** It was
+  documented as backing out of just the name, but the dialog took Esc first, so
+  that never happened.
+- **A create that refuses to run now says why.** Three paths could close the
+  dialog and create nothing — one of them with no message at all — while the log
+  recorded that a request had been sent. Each reports its own reason now.
+
+### Changed
+- **`+ new branch…` moved to the top of the Worktree field**, directly under
+  `off`. In a repository with a dozen worktrees it was buried at the bottom.
+
 ## [1.52.1] - 2026-08-07
 
 ### Fixed
@@ -85,7 +114,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pushed everything below it down by one. Clicking a project then selected its
   neighbour.
 
-||||||| parent of 6e6d633 (docs: describe the setup dialog's worktree field)
 ## [1.49.0] - 2026-08-05
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **A create that refuses to run now says why.** Three paths could close the
   dialog and create nothing — one of them with no message at all — while the log
   recorded that a request had been sent. Each reports its own reason now.
+- **A worktree that could not be handed to a pane is cleaned up.** If the
+  checkout succeeded but the pane could not be created — the tab or the pane
+  being replaced was closed while git was working — the worktree and its branch
+  were left behind, and the next attempt at the same name failed against a
+  directory nobody made.
+- **A second worktree pane can no longer be started in a tab that is already
+  making one.** It replaced the first one's bookkeeping, so the first pane could
+  end up neither restored nor closed.
+- **A pane being replaced is no longer restored after the swap has happened.**
+  If the worktree was created and the pane then failed to start, the old pane
+  was already gone; Quil put a dead one back in its place and typing into it did
+  nothing.
+- **An ordinary split no longer says a worktree is being created** while it
+  waits, and the waiting message can no longer overflow into the pane beside it.
 
 ### Changed
 - **`+ new branch…` moved to the top of the Worktree field**, directly under

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1763,7 +1763,7 @@ func (d *Daemon) createPaneAt(payload ipc.CreatePanePayload, cwd, paneType strin
 // the result — while the worktree path, which must ANSWER its requester, uses
 // replacePaneAt directly.
 func (d *Daemon) handleReplacePane(payload ipc.CreatePanePayload, cwd, paneType string) {
-	if _, err := d.replacePaneAt(payload, cwd, paneType); err != nil {
+	if _, _, err := d.replacePaneAt(payload, cwd, paneType); err != nil {
 		log.Printf("replace pane: %v", err)
 	}
 }
@@ -1776,7 +1776,13 @@ func (d *Daemon) handleReplacePane(payload ipc.CreatePanePayload, cwd, paneType 
 // git has succeeded, so the pane being replaced is never destroyed on behalf of
 // a worktree that does not exist — which was the whole reason the combination
 // used to be refused.
-func (d *Daemon) replacePaneAt(payload ipc.CreatePanePayload, cwd, paneType string) (*Pane, error) {
+//
+// The second return says whether the OLD pane was actually removed. It is not
+// derivable from the error: the swap happens before the new pane's PTY spawns,
+// so a spawn failure returns an error with the old pane already gone. The
+// worktree path forwards it to the client as CreatePaneRespPayload.Swapped,
+// which is what stops the client restoring a pane the daemon has destroyed.
+func (d *Daemon) replacePaneAt(payload ipc.CreatePanePayload, cwd, paneType string) (*Pane, bool, error) {
 	newPane := d.session.NewPane(cwd)
 	newPane.Type = paneType
 	newPane.InstanceName = payload.InstanceName
@@ -1785,8 +1791,9 @@ func (d *Daemon) replacePaneAt(payload ipc.CreatePanePayload, cwd, paneType stri
 
 	// Atomically swap old → new in the tab's pane list
 	if err := d.session.ReplacePane(payload.ReplacePaneID, newPane); err != nil {
-		return nil, fmt.Errorf("swap error: %w", err)
+		return nil, false, fmt.Errorf("swap error: %w", err)
 	}
+	// From here on the old pane is GONE, whatever else fails.
 	// The old pane is no longer reachable via the session — clean up its
 	// hook artifacts so the spool watcher stops re-polling a dead file.
 	d.cleanupPaneArtifacts(payload.ReplacePaneID)
@@ -1801,11 +1808,13 @@ func (d *Daemon) replacePaneAt(payload ipc.CreatePanePayload, cwd, paneType stri
 		d.session.DestroyPane(newPane.ID)
 		d.broadcastState()
 		d.requestSnapshot()
-		return nil, fmt.Errorf("start PTY error: %w, removed dead pane", err)
+		// swapped=true: the old pane went with the swap above and is not coming
+		// back, even though this is an error.
+		return nil, true, fmt.Errorf("start PTY (dead pane removed): %w", err)
 	}
 	d.broadcastState()
 	d.requestSnapshot()
-	return newPane, nil
+	return newPane, true, nil
 }
 
 // cleanupPaneArtifacts tears down everything keyed by paneID outside the

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1757,7 +1757,26 @@ func (d *Daemon) createPaneAt(payload ipc.CreatePanePayload, cwd, paneType strin
 	return pane, nil
 }
 
+// handleReplacePane is the fire-and-forget entry point: it logs what
+// replacePaneAt reports and returns. Kept so the ordinary replace path behaves
+// exactly as it always has — errors are logged and the next broadcast shows
+// the result — while the worktree path, which must ANSWER its requester, uses
+// replacePaneAt directly.
 func (d *Daemon) handleReplacePane(payload ipc.CreatePanePayload, cwd, paneType string) {
+	if _, err := d.replacePaneAt(payload, cwd, paneType); err != nil {
+		log.Printf("replace pane: %v", err)
+	}
+}
+
+// replacePaneAt is the replace counterpart of createPaneAt: swap the old pane
+// for a new one at cwd, and report what happened.
+//
+// Returning the error rather than logging it is what lets the worktree path
+// reuse this. That path creates the worktree FIRST and only reaches here once
+// git has succeeded, so the pane being replaced is never destroyed on behalf of
+// a worktree that does not exist — which was the whole reason the combination
+// used to be refused.
+func (d *Daemon) replacePaneAt(payload ipc.CreatePanePayload, cwd, paneType string) (*Pane, error) {
 	newPane := d.session.NewPane(cwd)
 	newPane.Type = paneType
 	newPane.InstanceName = payload.InstanceName
@@ -1766,8 +1785,7 @@ func (d *Daemon) handleReplacePane(payload ipc.CreatePanePayload, cwd, paneType 
 
 	// Atomically swap old → new in the tab's pane list
 	if err := d.session.ReplacePane(payload.ReplacePaneID, newPane); err != nil {
-		log.Printf("replace pane: swap error: %v", err)
-		return
+		return nil, fmt.Errorf("swap error: %w", err)
 	}
 	// The old pane is no longer reachable via the session — clean up its
 	// hook artifacts so the spool watcher stops re-polling a dead file.
@@ -1780,14 +1798,14 @@ func (d *Daemon) handleReplacePane(payload ipc.CreatePanePayload, cwd, paneType 
 
 	ptySession := apty.New()
 	if err := d.spawnPane(newPane, ptySession, false); err != nil {
-		log.Printf("replace pane: start PTY error: %v, removing dead pane", err)
 		d.session.DestroyPane(newPane.ID)
 		d.broadcastState()
 		d.requestSnapshot()
-		return
+		return nil, fmt.Errorf("start PTY error: %w, removed dead pane", err)
 	}
 	d.broadcastState()
 	d.requestSnapshot()
+	return newPane, nil
 }
 
 // cleanupPaneArtifacts tears down everything keyed by paneID outside the

--- a/internal/daemon/worktree_add.go
+++ b/internal/daemon/worktree_add.go
@@ -63,14 +63,15 @@ func (d *Daemon) worktreeAddAndCreate(p ipc.CreatePanePayload) ipc.CreatePaneRes
 	if spec == nil {
 		return fail("no worktree spec")
 	}
-	// Refused rather than supported. The client-side replace path sets
-	// leaf.Pane = nil and calls old.Dispose() BEFORE the send, so a failed add
-	// there costs a LIVE pane — and unlike a dangling placeholder, Dispose() is
-	// not something PrunePlaceholders can undo. The dialog omits the field;
-	// this is the other half, because any IPC client can send the pair.
-	if p.ReplacePaneID != "" {
-		return fail("a pane cannot be replaced with one in a new worktree")
-	}
+	// Replace mode is SUPPORTED, and the ordering below is what makes it safe:
+	// the worktree is created first, and the pane being replaced is not touched
+	// until git has succeeded. Every failure path above and at the add itself
+	// returns before replacePaneAt runs, so a failed add costs nothing.
+	//
+	// This was refused at first, on the grounds that the client detached and
+	// Disposed the old pane BEFORE the send — but that was a bug in the send
+	// ordering, not a reason the operation cannot exist. Replacing a scratch
+	// shell with an agent in a fresh worktree is an ordinary thing to want.
 	// Validated BEFORE any repository write, so a bad name costs no git
 	// invocation, no permit and no slot — and never reaches argv.
 	if err := gitworktree.ValidateBranch(spec.Branch); err != nil {
@@ -153,7 +154,17 @@ func (d *Daemon) createPaneInWorktree(p ipc.CreatePanePayload, path string) (*Pa
 	if paneType == "" {
 		paneType = "terminal"
 	}
-	pane, err := d.createPaneAt(p, path, paneType)
+	// Replace and create differ only in how the pane joins the tab; both land
+	// in the worktree, and both are reached only after git has succeeded.
+	// replacePaneAt already destroys its new pane on a spawn failure, so the
+	// "a failure leaves no pane" guarantee holds down either branch.
+	var pane *Pane
+	var err error
+	if p.ReplacePaneID != "" {
+		pane, err = d.replacePaneAt(p, path, paneType)
+	} else {
+		pane, err = d.createPaneAt(p, path, paneType)
+	}
 	if err != nil {
 		if pane != nil {
 			d.session.DestroyPane(pane.ID)

--- a/internal/daemon/worktree_add.go
+++ b/internal/daemon/worktree_add.go
@@ -29,6 +29,13 @@ const worktreeAddTimeout = 120 * time.Second
 // field so the handler's OWN claim and validation paths are what run.
 var addWorktreeFn = gitworktree.Add
 
+// removeWorktreeFn is the cleanup seam, paired with addWorktreeFn so a test
+// that stubs the add can observe the undo. Every abandonment after a successful
+// add goes through it: leaving the checkout behind strands a directory the user
+// never made, and makes the next attempt at the same branch fail with "already
+// exists" for a reason they cannot see.
+var removeWorktreeFn = gitworktree.Remove
+
 // beginWorktreeAdd claims the worktree-CREATION slot.
 //
 // Its own atomic, not worktreeScanning: the setup dialog LISTS a directory's
@@ -98,6 +105,22 @@ func (d *Daemon) worktreeAddAndCreate(p ipc.CreatePanePayload) ipc.CreatePaneRes
 	if d.session.Tab(p.TabID) == nil {
 		return fail("no such tab")
 	}
+	// The replace target must live in the tab this request names. ReplacePane
+	// resolves the pane id GLOBALLY and swaps it inside its own tab, so a
+	// payload pairing tab A with a pane in tab B destroys the pane in B while
+	// the response echoes A — and the client arms and unwinds its placeholder
+	// on the echoed tab, so the wrong tab's layout is mutated. The TUI derives
+	// both from the same tab, but any IPC client can send the pair, and the
+	// existing p.TabID checks read as tab scoping without providing it.
+	if p.ReplacePaneID != "" {
+		target := d.session.Pane(p.ReplacePaneID)
+		if target == nil {
+			return fail("no such pane to replace")
+		}
+		if target.TabID != p.TabID {
+			return fail("the pane to replace is not in that tab")
+		}
+	}
 
 	if !d.beginWorktreeAdd() {
 		return fail("another worktree is being created — try again in a moment")
@@ -121,15 +144,49 @@ func (d *Daemon) worktreeAddAndCreate(p ipc.CreatePanePayload) ipc.CreatePaneRes
 	// Re-validated AFTER the add: the window is seconds wide here, not the
 	// microseconds an ordinary create has, and a tab can be destroyed inside
 	// it. Without this the pane lands in a tab nobody is looking at.
+	//
+	// Every abandonment past this point REMOVES the worktree git just made.
+	// Returning without it strands a full checkout on disk plus a branch
+	// pointing at it, and the next attempt at the same name then fails with
+	// "already exists" against a directory the user never created — which is
+	// indistinguishable from a name genuinely in use.
+	abandon := func(format string, args ...any) ipc.CreatePaneRespPayload {
+		ctx, cancel := context.WithTimeout(context.Background(), worktreeAddTimeout)
+		defer cancel()
+		if rmErr := removeWorktreeFn(ctx, spec.RepoRoot, path, spec.Branch); rmErr != nil {
+			log.Printf("worktree create: could not clean up %s after a failed create: %v", path, rmErr)
+		}
+		return fail(format, args...)
+	}
 	if d.session.Tab(p.TabID) == nil {
-		return fail("the tab was closed while the worktree was being created")
+		return abandon("the tab was closed while the worktree was being created")
+	}
+	// The replace target can vanish inside the same window — the user can close
+	// that pane while the checkout runs. ReplacePane would return "pane not
+	// found" and the worktree would be orphaned; checked here so the failure
+	// names what happened and the cleanup runs.
+	if p.ReplacePaneID != "" {
+		target := d.session.Pane(p.ReplacePaneID)
+		if target == nil {
+			return abandon("the pane to replace was closed while the worktree was being created")
+		}
+		if target.TabID != p.TabID {
+			return abandon("the pane to replace moved to another tab while the worktree was being created")
+		}
 	}
 
-	pane, err := d.createPaneInWorktree(p, path)
+	pane, swapped, err := d.createPaneInWorktree(p, path)
 	if err != nil {
-		return fail("%v", err)
+		// swapped is forwarded on the ERROR path too, and that is the whole
+		// point of carrying it: the swap happens before the new pane's PTY is
+		// spawned, so a spawn failure is an error with the old pane already
+		// destroyed. A client that inferred "error means untouched" would put a
+		// pane the daemon no longer has back into its layout.
+		resp := abandon("%v", err)
+		resp.Swapped = swapped
+		return resp
 	}
-	return ipc.CreatePaneRespPayload{PaneID: pane.ID, TabID: p.TabID, Worktree: spec}
+	return ipc.CreatePaneRespPayload{PaneID: pane.ID, TabID: p.TabID, Worktree: spec, Swapped: swapped}
 }
 
 // createPaneInWorktree builds the pane with the worktree as its CWD.
@@ -145,9 +202,13 @@ func (d *Daemon) worktreeAddAndCreate(p ipc.CreatePanePayload) ipc.CreatePaneRes
 // guarantee this path makes is that a failure produces no pane at all, and a
 // half-created one in the tab is exactly what the client's placeholder unwind
 // is about to remove.
-func (d *Daemon) createPaneInWorktree(p ipc.CreatePanePayload, path string) (*Pane, error) {
+// The second return says whether a REPLACE removed the old pane; see
+// replacePaneAt. It is true on some ERROR paths, which is exactly why it cannot
+// be inferred from the error.
+func (d *Daemon) createPaneInWorktree(p ipc.CreatePanePayload, path string) (*Pane, bool, error) {
+	var swapped bool
 	if info, err := os.Stat(path); err != nil || !info.IsDir() {
-		return nil, fmt.Errorf("worktree %s is not there after creating it: %v", path, err)
+		return nil, swapped, fmt.Errorf("worktree %s is not there after creating it: %v", path, err)
 	}
 	p.CWD = path
 	paneType := p.Type
@@ -161,7 +222,7 @@ func (d *Daemon) createPaneInWorktree(p ipc.CreatePanePayload, path string) (*Pa
 	var pane *Pane
 	var err error
 	if p.ReplacePaneID != "" {
-		pane, err = d.replacePaneAt(p, path, paneType)
+		pane, swapped, err = d.replacePaneAt(p, path, paneType)
 	} else {
 		pane, err = d.createPaneAt(p, path, paneType)
 	}
@@ -169,7 +230,7 @@ func (d *Daemon) createPaneInWorktree(p ipc.CreatePanePayload, path string) (*Pa
 		if pane != nil {
 			d.session.DestroyPane(pane.ID)
 		}
-		return nil, err
+		return nil, swapped, err
 	}
 	// PluginMu-protected like every other post-publish write: CreatePane has
 	// already published the pane, so a snapshot or broadcast goroutine may be
@@ -177,5 +238,5 @@ func (d *Daemon) createPaneInWorktree(p ipc.CreatePanePayload, path string) (*Pa
 	pane.PluginMu.Lock()
 	pane.WorktreeOwned = true
 	pane.PluginMu.Unlock()
-	return pane, nil
+	return pane, swapped, nil
 }

--- a/internal/daemon/worktree_add_test.go
+++ b/internal/daemon/worktree_add_test.go
@@ -148,20 +148,89 @@ func TestWorktreeAdd_RefusesAVanishedTab(t *testing.T) {
 // live pane — and unlike a dangling placeholder, PrunePlaceholders cannot undo
 // a Dispose(). The dialog omits the field; this is the daemon half of that,
 // because any IPC client can send the pair.
-func TestWorktreeAdd_RefusesReplaceMode(t *testing.T) {
+// Replacing a pane with one in a NEW worktree is supported: swapping a scratch
+// shell for an agent in a fresh branch is an ordinary thing to want. It was
+// refused at first because the client destroyed the old pane before the send,
+// which is a property of WHEN the client disposed rather than of the operation.
+func TestWorktreeAdd_ReplaceModeIsAccepted(t *testing.T) {
 	d := newTestDaemon(t)
 	tab := d.session.CreateTab("t")
-	calls := stubAdd(t, func(context.Context, string, string, string) error { return nil })
+	// A real repo root under TempDir, because createPaneInWorktree STATS the
+	// derived path — the pane must land in a directory that exists, which is
+	// the guarantee it enforces. The stub stands in for git by creating it.
+	repo := filepath.Join(t.TempDir(), "proj", "repo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	old, err := d.session.CreatePane(tab.ID, repo)
+	if err != nil {
+		t.Fatalf("seed pane: %v", err)
+	}
+	calls := stubAdd(t, func(_ context.Context, _, path, _ string) error {
+		return os.MkdirAll(path, 0o755)
+	})
 
-	p := worktreeCreate(tab.ID, "/repo", "feat/x")
-	p.ReplacePaneID = "pane-0000000a"
+	p := worktreeCreate(tab.ID, repo, "feat/x")
+	p.ReplacePaneID = old.ID
+	resp := d.worktreeAddAndCreate(p)
+
+	if resp.Error != "" {
+		t.Fatalf("a worktree replace was refused: %s", resp.Error)
+	}
+	if len(*calls) != 1 {
+		t.Fatalf("git ran %d times, want 1", len(*calls))
+	}
+	if resp.PaneID == "" {
+		t.Fatal("no pane was reported")
+	}
+	if resp.PaneID == old.ID {
+		t.Error("the reported pane is the one being replaced")
+	}
+	if d.session.Pane(old.ID) != nil {
+		t.Error("the replaced pane is still in the session")
+	}
+	if got := d.session.Pane(resp.PaneID); got == nil {
+		t.Error("the new pane is not in the session")
+	} else if !got.WorktreeOwned {
+		t.Error("the new pane is not marked WorktreeOwned")
+	}
+}
+
+// The ordering that makes the above safe: git runs BEFORE the pane is touched,
+// so an add that fails must leave the pane being replaced exactly where it was.
+// This is the property the original refusal was protecting, kept as a test now
+// that the operation is allowed.
+func TestWorktreeAdd_ReplaceFailureLeavesTheOldPaneAlone(t *testing.T) {
+	d := newTestDaemon(t)
+	tab := d.session.CreateTab("t")
+	repo := filepath.Join(t.TempDir(), "proj", "repo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	old, err := d.session.CreatePane(tab.ID, repo)
+	if err != nil {
+		t.Fatalf("seed pane: %v", err)
+	}
+	before := len(d.session.Panes(tab.ID))
+	stubAdd(t, func(context.Context, string, string, string) error {
+		return errors.New("fatal: a branch named 'feat/x' already exists")
+	})
+
+	p := worktreeCreate(tab.ID, repo, "feat/x")
+	p.ReplacePaneID = old.ID
 	resp := d.worktreeAddAndCreate(p)
 
 	if resp.Error == "" {
-		t.Error("a worktree create was accepted on the replace path")
+		t.Fatal("a failed add reported success")
 	}
-	if len(*calls) != 0 {
-		t.Errorf("git ran %d times for a refused replace", len(*calls))
+	if resp.PaneID != "" {
+		t.Errorf("a failed add created pane %q", resp.PaneID)
+	}
+	if d.session.Pane(old.ID) == nil {
+		t.Error("a failed worktree add DESTROYED the pane it was going to replace")
+	}
+	if got := len(d.session.Panes(tab.ID)); got != before {
+		t.Errorf("pane count %d, want %d", got, before)
 	}
 }
 

--- a/internal/daemon/worktree_realgit_test.go
+++ b/internal/daemon/worktree_realgit_test.go
@@ -1,0 +1,211 @@
+package daemon
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/artyomsv/quil/internal/gitworktree"
+)
+
+// The whole worktree-create path had never run end to end. Every daemon test
+// above stubs addWorktreeFn, and in production the branch name was dropped
+// client-side before the daemon ever saw a spec — so the sequence
+// "validate → real git worktree add → pane whose CWD is the new tree" was
+// asserted nowhere and observed never.
+//
+// These tests remove the stub. They need a real git and a real filesystem, so
+// they skip where git is absent: the build container has none, and they are run
+// natively on Windows, which is also the platform whose separator handling
+// DerivePath's other tests cannot reach.
+
+func realGitRepoForDaemon(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is not on PATH")
+	}
+	// Nested one level down so the derived SIBLING lands inside the temp tree
+	// and is removed with it.
+	root := filepath.Join(t.TempDir(), "proj", "repo")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = root
+		cmd.Env = append(os.Environ(),
+			"GIT_CONFIG_GLOBAL="+os.DevNull, "GIT_CONFIG_SYSTEM="+os.DevNull,
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+		}
+	}
+	run("init", "-b", "master")
+	if err := os.WriteFile(filepath.Join(root, "f.txt"), []byte("x\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	run("add", "f.txt")
+	run("commit", "-m", "init")
+	return root
+}
+
+// The pane's CWD is the entire feature. A pane at the repository root is an
+// agent running on master while the user believes it is isolated — the exact
+// outcome the reported bug produced, and the one nothing had ever verified the
+// absence of against real git.
+func TestWorktreeAddAndCreate_RealGit_PaneLandsInTheNewWorktree(t *testing.T) {
+	repo := realGitRepoForDaemon(t)
+	d := newTestDaemon(t)
+	tab := d.session.CreateTab("t")
+
+	resp := d.worktreeAddAndCreate(worktreeCreate(tab.ID, repo, "feat/login"))
+
+	if resp.Error != "" {
+		t.Fatalf("create failed: %s", resp.Error)
+	}
+	if resp.PaneID == "" {
+		t.Fatal("create reported success but no pane")
+	}
+	pane := d.session.Pane(resp.PaneID)
+	if pane == nil {
+		t.Fatalf("pane %s is not in the session", resp.PaneID)
+	}
+
+	want := gitworktree.DerivePath(repo, "feat/login")
+	if !samePath(pane.CWD, want) {
+		t.Errorf("pane CWD = %q, want the worktree %q", pane.CWD, want)
+	}
+	// Stated separately from the equality above: if DerivePath itself ever
+	// returned the repo root, the check above would pass and this one would
+	// still catch the pane running on master.
+	if samePath(pane.CWD, repo) {
+		t.Error("pane CWD is the REPOSITORY ROOT — the isolation the feature promises is absent")
+	}
+	if !pane.WorktreeOwned {
+		t.Error("pane is not marked WorktreeOwned, so a missing worktree would silently relocate on restore")
+	}
+	if info, err := os.Stat(pane.CWD); err != nil || !info.IsDir() {
+		t.Errorf("the pane's CWD does not exist on disk: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(pane.CWD, "f.txt")); err != nil {
+		t.Errorf("the worktree has no checked-out content: %v", err)
+	}
+}
+
+// Replace + new worktree against real git, end to end: the pane being replaced
+// goes away, the new one lands in the worktree git actually created, and the
+// worktree is a sibling of the repository. This is the combination that was
+// refused outright until it was pointed out to be a legitimate scenario.
+func TestWorktreeAddAndCreate_RealGit_ReplaceLandsInTheNewWorktree(t *testing.T) {
+	repo := realGitRepoForDaemon(t)
+	d := newTestDaemon(t)
+	tab := d.session.CreateTab("t")
+	old, err := d.session.CreatePane(tab.ID, repo)
+	if err != nil {
+		t.Fatalf("seed pane: %v", err)
+	}
+
+	p := worktreeCreate(tab.ID, repo, "feat/swap")
+	p.ReplacePaneID = old.ID
+	resp := d.worktreeAddAndCreate(p)
+
+	if resp.Error != "" {
+		t.Fatalf("replace failed: %s", resp.Error)
+	}
+	if d.session.Pane(old.ID) != nil {
+		t.Error("the replaced pane is still in the session")
+	}
+	pane := d.session.Pane(resp.PaneID)
+	if pane == nil {
+		t.Fatalf("new pane %s is not in the session", resp.PaneID)
+	}
+	want := gitworktree.DerivePath(repo, "feat/swap")
+	if !samePath(pane.CWD, want) {
+		t.Errorf("pane CWD = %q, want the worktree %q", pane.CWD, want)
+	}
+	if samePath(pane.CWD, repo) {
+		t.Error("the replacement pane is at the REPOSITORY ROOT, not in a worktree")
+	}
+	if _, err := os.Stat(filepath.Join(pane.CWD, "f.txt")); err != nil {
+		t.Errorf("the worktree has no checked-out content: %v", err)
+	}
+}
+
+// The safety property, against real git: a branch git refuses must leave the
+// pane being replaced untouched. This is what the original refusal was
+// protecting, and the reason the add runs before the swap.
+func TestWorktreeAddAndCreate_RealGit_FailedReplaceKeepsTheOldPane(t *testing.T) {
+	repo := realGitRepoForDaemon(t)
+	d := newTestDaemon(t)
+	tab := d.session.CreateTab("t")
+	old, err := d.session.CreatePane(tab.ID, repo)
+	if err != nil {
+		t.Fatalf("seed pane: %v", err)
+	}
+	// Take the branch first so the replace's own add is the one git refuses.
+	if resp := d.worktreeAddAndCreate(worktreeCreate(tab.ID, repo, "taken")); resp.Error != "" {
+		t.Fatalf("seed worktree: %s", resp.Error)
+	}
+
+	p := worktreeCreate(tab.ID, repo, "taken")
+	p.ReplacePaneID = old.ID
+	resp := d.worktreeAddAndCreate(p)
+
+	if resp.Error == "" {
+		t.Fatal("a duplicate branch was accepted on the replace path")
+	}
+	if resp.PaneID != "" {
+		t.Errorf("a failed replace created pane %q", resp.PaneID)
+	}
+	if d.session.Pane(old.ID) == nil {
+		t.Fatal("a failed git worktree add DESTROYED the pane it was going to replace")
+	}
+}
+
+// A real git failure must still produce no pane. The stubbed test above asserts
+// this against an invented error; this one asserts it against the error git
+// actually returns, which is what the daemon puts in front of the user.
+func TestWorktreeAddAndCreate_RealGit_DuplicateBranchCreatesNoPane(t *testing.T) {
+	repo := realGitRepoForDaemon(t)
+	d := newTestDaemon(t)
+	tab := d.session.CreateTab("t")
+
+	if resp := d.worktreeAddAndCreate(worktreeCreate(tab.ID, repo, "dup")); resp.Error != "" {
+		t.Fatalf("first create failed: %s", resp.Error)
+	}
+	before := len(d.session.Panes(tab.ID))
+
+	resp := d.worktreeAddAndCreate(worktreeCreate(tab.ID, repo, "dup"))
+
+	if resp.Error == "" {
+		t.Fatal("a duplicate branch was accepted")
+	}
+	if resp.PaneID != "" {
+		t.Errorf("a failed create produced pane %q", resp.PaneID)
+	}
+	if got := len(d.session.Panes(tab.ID)); got != before {
+		t.Errorf("pane count %d, want %d", got, before)
+	}
+	if !strings.Contains(resp.Error, "dup") {
+		t.Errorf("the error does not name the branch, so the flash cannot point anywhere: %q", resp.Error)
+	}
+}
+
+// samePath compares two filesystem paths for equality, tolerating the
+// separator and case differences Windows introduces between a path git printed
+// and one filepath built.
+func samePath(a, b string) bool {
+	a, b = filepath.Clean(a), filepath.Clean(b)
+	if ra, err := filepath.EvalSymlinks(a); err == nil {
+		a = filepath.Clean(ra)
+	}
+	if rb, err := filepath.EvalSymlinks(b); err == nil {
+		b = filepath.Clean(rb)
+	}
+	return strings.EqualFold(a, b)
+}

--- a/internal/daemon/worktree_review_test.go
+++ b/internal/daemon/worktree_review_test.go
@@ -1,0 +1,260 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/artyomsv/quil/internal/gitworktree"
+	"github.com/artyomsv/quil/internal/ipc"
+)
+
+// Regression tests for the daemon-side defects a code review found in the
+// worktree-replace work. Each one fails against the code as it was reviewed.
+
+// stubRemove swaps the cleanup seam and records what it was asked to remove.
+func stubRemove(t *testing.T, fn func(ctx context.Context, repo, path, branch string) error) *[][]string {
+	t.Helper()
+	var calls [][]string
+	prev := removeWorktreeFn
+	removeWorktreeFn = func(ctx context.Context, repo, path, branch string) error {
+		calls = append(calls, []string{repo, path, branch})
+		if fn == nil {
+			return nil
+		}
+		return fn(ctx, repo, path, branch)
+	}
+	t.Cleanup(func() { removeWorktreeFn = prev })
+	return &calls
+}
+
+// realRepoDir returns an existing directory to stand in for a repository root.
+// The absoluteness guard rejects a bare "/repo" on Windows, so the fixtures
+// that must reach git use a real temp path.
+func realRepoDir(t *testing.T) string {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), "proj", "repo")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	return root
+}
+
+// An add that succeeds followed by a create that fails used to leave the
+// checkout on disk with a branch pointing at it. The next attempt at the same
+// name then failed with "already exists" against a directory the user never
+// made — indistinguishable from a name genuinely in use.
+func TestWorktreeAdd_RemovesTheWorktreeWhenThePaneCannotBeCreated(t *testing.T) {
+	d := newTestDaemon(t)
+	tab := d.session.CreateTab("t")
+	repo := realRepoDir(t)
+	// The add "succeeds" without creating the directory, so the stat inside
+	// createPaneInWorktree fails — the same shape as a checkout that vanished.
+	stubAdd(t, func(context.Context, string, string, string) error { return nil })
+	removes := stubRemove(t, nil)
+
+	resp := d.worktreeAddAndCreate(worktreeCreate(tab.ID, repo, "feat/x"))
+
+	if resp.Error == "" {
+		t.Fatal("a create that could not place its pane reported success")
+	}
+	if len(*removes) != 1 {
+		t.Fatalf("cleanup ran %d times, want 1 — the worktree is orphaned on disk", len(*removes))
+	}
+	call := (*removes)[0]
+	if call[0] != repo {
+		t.Errorf("cleanup ran against %q, want the repository %q", call[0], repo)
+	}
+	if want := gitworktree.DerivePath(repo, "feat/x"); call[1] != want {
+		t.Errorf("cleanup removed %q, want the derived path %q", call[1], want)
+	}
+	if call[2] != "feat/x" {
+		t.Errorf("cleanup deleted branch %q, want feat/x", call[2])
+	}
+}
+
+// A failed ADD must NOT run the cleanup: there is nothing to remove, and
+// `git worktree remove` against a path git never created is noise in the log
+// that reads like a second failure.
+func TestWorktreeAdd_DoesNotCleanUpWhenTheAddItselfFailed(t *testing.T) {
+	d := newTestDaemon(t)
+	tab := d.session.CreateTab("t")
+	repo := realRepoDir(t)
+	stubAdd(t, func(context.Context, string, string, string) error {
+		return errors.New("fatal: a branch named 'feat/x' already exists")
+	})
+	removes := stubRemove(t, nil)
+
+	if resp := d.worktreeAddAndCreate(worktreeCreate(tab.ID, repo, "feat/x")); resp.Error == "" {
+		t.Fatal("a failed add reported success")
+	}
+	if len(*removes) != 0 {
+		t.Errorf("cleanup ran %d times for a worktree that was never created", len(*removes))
+	}
+}
+
+// ReplacePane resolves the pane id GLOBALLY and swaps it inside its OWN tab, so
+// a payload pairing tab A with a pane in tab B destroys the pane in B while the
+// response echoes A — and the client arms and unwinds its placeholder on the
+// echoed tab. The existing p.TabID checks read as tab scoping without providing
+// it. Any IPC client can send the pair.
+func TestWorktreeAdd_RefusesAReplaceTargetInAnotherTab(t *testing.T) {
+	d := newTestDaemon(t)
+	tabA := d.session.CreateTab("a")
+	tabB := d.session.CreateTab("b")
+	repo := realRepoDir(t)
+	victim, err := d.session.CreatePane(tabB.ID, repo)
+	if err != nil {
+		t.Fatalf("seed pane: %v", err)
+	}
+	calls := stubAdd(t, func(_ context.Context, _, path, _ string) error { return os.MkdirAll(path, 0o755) })
+
+	p := worktreeCreate(tabA.ID, repo, "feat/x")
+	p.ReplacePaneID = victim.ID
+	resp := d.worktreeAddAndCreate(p)
+
+	if resp.Error == "" {
+		t.Fatal("a replace targeting another tab's pane was accepted")
+	}
+	if d.session.Pane(victim.ID) == nil {
+		t.Error("the pane in the OTHER tab was destroyed")
+	}
+	if len(*calls) != 0 {
+		t.Errorf("git ran %d times for a refused replace — the check must precede the checkout", len(*calls))
+	}
+}
+
+// A missing replace target is refused before the checkout too, so a bogus id
+// cannot spend a full `git worktree add` per request.
+func TestWorktreeAdd_RefusesAMissingReplaceTargetBeforeRunningGit(t *testing.T) {
+	d := newTestDaemon(t)
+	tab := d.session.CreateTab("t")
+	repo := realRepoDir(t)
+	calls := stubAdd(t, func(context.Context, string, string, string) error { return nil })
+
+	p := worktreeCreate(tab.ID, repo, "feat/x")
+	p.ReplacePaneID = "pane-doesnotexist"
+	resp := d.worktreeAddAndCreate(p)
+
+	if resp.Error == "" {
+		t.Fatal("a replace naming no pane was accepted")
+	}
+	if len(*calls) != 0 {
+		t.Errorf("git ran %d times for a replace target that does not exist", len(*calls))
+	}
+}
+
+// The replace target can be closed DURING the checkout — the window is seconds
+// wide. Without the post-add re-check ReplacePane returns "pane not found", and
+// the worktree git just made is orphaned.
+func TestWorktreeAdd_ReplaceTargetClosedDuringTheAddCleansUp(t *testing.T) {
+	d := newTestDaemon(t)
+	tab := d.session.CreateTab("t")
+	repo := realRepoDir(t)
+	victim, err := d.session.CreatePane(tab.ID, repo)
+	if err != nil {
+		t.Fatalf("seed pane: %v", err)
+	}
+	// The user closes that pane while the checkout runs.
+	stubAdd(t, func(_ context.Context, _, path, _ string) error {
+		d.session.DestroyPane(victim.ID)
+		return os.MkdirAll(path, 0o755)
+	})
+	removes := stubRemove(t, nil)
+
+	p := worktreeCreate(tab.ID, repo, "feat/x")
+	p.ReplacePaneID = victim.ID
+	resp := d.worktreeAddAndCreate(p)
+
+	if resp.Error == "" {
+		t.Fatal("a replace whose target vanished mid-checkout reported success")
+	}
+	if len(*removes) != 1 {
+		t.Errorf("cleanup ran %d times, want 1 — the worktree is orphaned", len(*removes))
+	}
+	if resp.Swapped {
+		t.Error("Swapped is set although no swap happened — the client would refuse to restore a live pane")
+	}
+}
+
+// Swapped is what stops the client restoring a pane the daemon destroyed. It
+// must be true whenever the swap ran, INCLUDING on the error paths that follow
+// it, which is exactly why it cannot be inferred from Error.
+func TestWorktreeAdd_ReplaceSuccessReportsSwapped(t *testing.T) {
+	d := newTestDaemon(t)
+	tab := d.session.CreateTab("t")
+	repo := realRepoDir(t)
+	old, err := d.session.CreatePane(tab.ID, repo)
+	if err != nil {
+		t.Fatalf("seed pane: %v", err)
+	}
+	stubAdd(t, func(_ context.Context, _, path, _ string) error { return os.MkdirAll(path, 0o755) })
+
+	p := worktreeCreate(tab.ID, repo, "feat/x")
+	p.ReplacePaneID = old.ID
+	resp := d.worktreeAddAndCreate(p)
+
+	if resp.Error != "" {
+		t.Fatalf("replace failed: %s", resp.Error)
+	}
+	if !resp.Swapped {
+		t.Error("a successful replace did not report Swapped — the client would hold the old pane forever")
+	}
+}
+
+// A plain create never swaps anything, so Swapped must stay false or the client
+// would dispose a pane it should have kept.
+func TestWorktreeAdd_PlainCreateDoesNotReportSwapped(t *testing.T) {
+	d := newTestDaemon(t)
+	tab := d.session.CreateTab("t")
+	repo := realRepoDir(t)
+	stubAdd(t, func(_ context.Context, _, path, _ string) error { return os.MkdirAll(path, 0o755) })
+
+	resp := d.worktreeAddAndCreate(worktreeCreate(tab.ID, repo, "feat/x"))
+
+	if resp.Error != "" {
+		t.Fatalf("create failed: %s", resp.Error)
+	}
+	if resp.Swapped {
+		t.Error("a plain create reported Swapped")
+	}
+}
+
+// The tab closing mid-checkout was already refused; it must clean up too.
+func TestWorktreeAdd_TabClosedDuringTheAddCleansUp(t *testing.T) {
+	d := newTestDaemon(t)
+	tab := d.session.CreateTab("t")
+	repo := realRepoDir(t)
+	stubAdd(t, func(_ context.Context, _, path, _ string) error {
+		d.session.DestroyTab(tab.ID)
+		return os.MkdirAll(path, 0o755)
+	})
+	removes := stubRemove(t, nil)
+
+	if resp := d.worktreeAddAndCreate(worktreeCreate(tab.ID, repo, "feat/x")); resp.Error == "" {
+		t.Fatal("a create into a closed tab reported success")
+	}
+	if len(*removes) != 1 {
+		t.Errorf("cleanup ran %d times, want 1", len(*removes))
+	}
+}
+
+// ipc.CreatePaneRespPayload.Swapped must survive the wire — it is a new field
+// and a client that never sees it would restore destroyed panes.
+func TestCreatePaneRespPayload_SwappedRoundTrips(t *testing.T) {
+	msg, err := ipc.NewMessage(ipc.MsgCreatePaneResp, ipc.CreatePaneRespPayload{
+		TabID: "tab-1", Error: "boom", Swapped: true,
+	})
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	var got ipc.CreatePaneRespPayload
+	if err := msg.DecodePayload(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !got.Swapped {
+		t.Error("Swapped did not survive the round trip")
+	}
+}

--- a/internal/gitworktree/gitworktree.go
+++ b/internal/gitworktree/gitworktree.go
@@ -175,3 +175,29 @@ func Add(ctx context.Context, repo, path, branch string) error {
 	}
 	return nil
 }
+
+// Remove undoes an Add whose pane could not be created, and deletes the branch
+// that Add made along with it.
+//
+// This is the ONE place --force is right, and for a reason that does not
+// generalise to Add: the worktree being removed was created by this daemon
+// seconds ago and has never been handed to anyone, so there is no user work to
+// protect — while without it git refuses to remove a worktree it considers
+// dirty, which a fresh checkout can be on a repository with line-ending or
+// filemode differences. Leaving it instead strands a full checkout on disk plus
+// a branch pointing at it, and the next attempt at the same name then fails
+// with "already exists" against a directory the user never made.
+//
+// Best-effort by contract: the caller is already reporting a failure and this
+// is cleanup, so the error is for the log, not for the user.
+func Remove(ctx context.Context, repo, path string, branch string) error {
+	if _, err := runGit(ctx, repo, "worktree", "remove", "--force", path); err != nil {
+		return fmt.Errorf("git worktree remove %s: %w", path, err)
+	}
+	// Only after the worktree is gone: git refuses to delete a branch that a
+	// worktree still has checked out, so the order is load-bearing.
+	if _, err := runGit(ctx, repo, "branch", "-D", branch); err != nil {
+		return fmt.Errorf("git branch -D %s: %w", branch, err)
+	}
+	return nil
+}

--- a/internal/gitworktree/realgit_test.go
+++ b/internal/gitworktree/realgit_test.go
@@ -164,3 +164,67 @@ func TestAdd_RealGit_KeepsTheSlashInTheBranchName(t *testing.T) {
 		}
 	}
 }
+
+// Remove is new production code and uses --force plus a branch delete, so it
+// gets real-git coverage rather than a stub: the ordering (worktree first, then
+// branch) is a git constraint, not a preference, and a stub cannot show it.
+func TestRemove_RealGit_UndoesAnAddCompletely(t *testing.T) {
+	repo := realGitRepo(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	path := DerivePath(repo, "feat/undo")
+	if err := Add(ctx, repo, path, "feat/undo"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := Remove(ctx, repo, path, "feat/undo"); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("the worktree directory survived Remove: %v", err)
+	}
+	list, err := List(ctx, repo)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	for _, w := range list {
+		if filepath.Clean(w.Path) == filepath.Clean(path) {
+			t.Errorf("git still lists the removed worktree: %+v", w)
+		}
+	}
+	// The branch must go too, or the whole point is lost: the next attempt at
+	// the same name would fail with "already exists" against a branch the user
+	// never made.
+	if err := Add(ctx, repo, DerivePath(repo, "feat/undo"), "feat/undo"); err != nil {
+		t.Errorf("the branch outlived Remove, so the name cannot be reused: %v", err)
+	}
+}
+
+// A dirty worktree must still be removable. It was created by the daemon
+// seconds ago and never handed to anyone, so there is no user work to protect —
+// and git refuses a plain remove on a checkout it considers dirty, which a
+// fresh one can be on a repository with line-ending differences.
+func TestRemove_RealGit_RemovesADirtyWorktree(t *testing.T) {
+	repo := realGitRepo(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	path := DerivePath(repo, "feat/dirty")
+	if err := Add(ctx, repo, path, "feat/dirty"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(path, "f.txt"), []byte("modified\n"), 0o644); err != nil {
+		t.Fatalf("dirty the worktree: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(path, "untracked.txt"), []byte("new\n"), 0o644); err != nil {
+		t.Fatalf("add an untracked file: %v", err)
+	}
+
+	if err := Remove(ctx, repo, path, "feat/dirty"); err != nil {
+		t.Fatalf("Remove refused a dirty worktree: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("the dirty worktree survived Remove: %v", err)
+	}
+}

--- a/internal/gitworktree/realgit_test.go
+++ b/internal/gitworktree/realgit_test.go
@@ -1,0 +1,166 @@
+package gitworktree
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Every other Add test stubs git, so the pair that actually decides where a
+// checkout lands — DerivePath composing the path, Add handing it to git — had
+// never run against a real repository in the suite. It had never run in
+// production either: the branch name was dropped client-side before the daemon
+// saw it, so `git worktree add` was reached for the first time only after that
+// was fixed. These tests exercise the real binary.
+
+func realGitRepo(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is not on PATH")
+	}
+	// The repo sits in a subdirectory of TempDir, so DerivePath's sibling
+	// lands inside the temp tree and is cleaned up with it.
+	root := filepath.Join(t.TempDir(), "proj", "repo")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = root
+		// A worktree add reads user.name/user.email when it creates the
+		// branch's first ref; a container with no global config fails without
+		// these, which would look like a bug in Add.
+		// os.DevNull, not "/dev/null": these run natively on Windows, where the
+		// build container has no git at all and the separator handling in
+		// DerivePath differs from the Linux CI leg.
+		cmd.Env = append(os.Environ(),
+			"GIT_CONFIG_GLOBAL="+os.DevNull, "GIT_CONFIG_SYSTEM="+os.DevNull,
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+		}
+	}
+	run("init", "-b", "master")
+	if err := os.WriteFile(filepath.Join(root, "f.txt"), []byte("x\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	run("add", "f.txt")
+	run("commit", "-m", "init")
+	return root
+}
+
+// The headline guarantee: the new checkout is a SIBLING of the repository, not
+// nested inside it. A nested worktree is what makes `git clean -xfd` in the
+// main checkout delete another pane's uncommitted work, and what makes every
+// tree-walking tool traverse two copies of the project.
+func TestAdd_RealGit_CreatesASiblingWorktreeOnTheBranch(t *testing.T) {
+	repo := realGitRepo(t)
+	path := DerivePath(repo, "feat/login")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	if err := Add(ctx, repo, path, "feat/login"); err != nil {
+		t.Fatalf("Add against real git: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil || !info.IsDir() {
+		t.Fatalf("worktree is not at the derived path %q: %v", path, err)
+	}
+	// Nested is the failure this layout exists to prevent, so assert the
+	// containment directly rather than trusting the string shape.
+	if rel, err := filepath.Rel(repo, path); err == nil && !strings.HasPrefix(rel, "..") {
+		t.Errorf("worktree %q is INSIDE the repository %q (rel %q)", path, repo, rel)
+	}
+	if got, want := filepath.Dir(path), repo+worktreesSuffix; got != want {
+		t.Errorf("worktree parent = %q, want %q", got, want)
+	}
+	// The checked-out file proves this is a real working tree, not just a
+	// directory git recorded.
+	if _, err := os.Stat(filepath.Join(path, "f.txt")); err != nil {
+		t.Errorf("the worktree has no checked-out content: %v", err)
+	}
+
+	// And the listing the dialog reads must now show it, on its own branch —
+	// the per-checkout key is what keeps it from reporting master.
+	list, err := List(ctx, repo)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	var found bool
+	for _, w := range list {
+		if filepath.Clean(w.Path) != filepath.Clean(path) {
+			continue
+		}
+		found = true
+		if w.Branch != "feat/login" {
+			t.Errorf("listed branch = %q, want %q", w.Branch, "feat/login")
+		}
+		if w.Main {
+			t.Error("the new worktree is listed as the main checkout")
+		}
+	}
+	if !found {
+		t.Errorf("the new worktree is not in the listing: %+v", list)
+	}
+}
+
+// A branch that already exists must FAIL rather than silently reusing or
+// relocating. The daemon turns this error into "no pane at all", which is the
+// contract the whole feature rests on.
+func TestAdd_RealGit_RefusesAnExistingBranch(t *testing.T) {
+	repo := realGitRepo(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	if err := Add(ctx, repo, DerivePath(repo, "dup"), "dup"); err != nil {
+		t.Fatalf("first Add: %v", err)
+	}
+	// A different path, the same branch — the shape a user retrying a name
+	// produces.
+	second := DerivePath(repo, "dup") + "-2"
+	err := Add(ctx, repo, second, "dup")
+	if err == nil {
+		t.Fatal("Add reused an existing branch instead of failing")
+	}
+	// git's own stderr names the worktree already holding it, which is what
+	// makes the flash actionable.
+	if !strings.Contains(err.Error(), "dup") {
+		t.Errorf("error does not name the branch: %v", err)
+	}
+	if _, statErr := os.Stat(second); statErr == nil {
+		t.Error("a failed Add left a directory behind")
+	}
+}
+
+// A branch name with a slash is flattened for the directory but must reach git
+// UNFLATTENED, or the pane sits on a branch nobody asked for.
+func TestAdd_RealGit_KeepsTheSlashInTheBranchName(t *testing.T) {
+	repo := realGitRepo(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	path := DerivePath(repo, "feat/nested/deep")
+	if err := Add(ctx, repo, path, "feat/nested/deep"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if base := filepath.Base(path); strings.ContainsAny(base, `/\`) {
+		t.Errorf("derived directory %q still contains a separator", base)
+	}
+	list, err := List(ctx, repo)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	for _, w := range list {
+		if filepath.Clean(w.Path) == filepath.Clean(path) && w.Branch != "feat/nested/deep" {
+			t.Errorf("branch = %q, want the unflattened %q", w.Branch, "feat/nested/deep")
+		}
+	}
+}

--- a/internal/ipc/protocol.go
+++ b/internal/ipc/protocol.go
@@ -431,6 +431,21 @@ type CreatePaneRespPayload struct {
 	// worktree '/x/feat-y'" names the pane to go look at, and no message Quil
 	// could invent would.
 	Error string `json:"error,omitempty"`
+	// Swapped reports whether a REPLACE actually removed the pane named by
+	// ReplacePaneID. It is a statement about what happened, unlike Worktree
+	// below, and it exists because the two are not implied by Error.
+	//
+	// A worktree-backed replace creates the worktree BEFORE the swap, so an add
+	// that fails leaves the pane alive and the client must put it back. But the
+	// swap itself happens before the new pane's PTY is spawned — so a spawn
+	// failure reports an error with the old pane already destroyed, and a
+	// client that inferred "error means untouched" would restore a pane the
+	// daemon no longer has. Keystrokes then route to a pane id that does not
+	// exist until the next broadcast prunes the leaf.
+	//
+	// omitempty: absent means false, which is the correct reading for every
+	// non-replace response and for an older daemon that does not send it.
+	Swapped bool `json:"swapped,omitempty"`
 	// Worktree echoes the request's spec VERBATIM on every path, including the
 	// error one. It is the client's staleness key, not a statement about what
 	// was created — the client armed a layout placeholder before the send and

--- a/internal/tui/dialog.go
+++ b/internal/tui/dialog.go
@@ -1750,6 +1750,25 @@ func (m Model) handleCreatePaneSplit() (tea.Model, tea.Cmd) {
 		return m, m.flashCmd()
 	}
 
+	// ONE worktree create per tab at a time. worktreeCreates, worktreeReplaced
+	// and pendingSplit are all keyed by TAB, so a second create on the same tab
+	// overwrites all three: the first create's held pane is never disposed and
+	// never restored, and its reserved leaf is replaced by the second's — so
+	// the first's response restores a pane into the wrong slot.
+	//
+	// Widening the maps to hold both was the alternative and is the wrong
+	// trade: the daemon's worktreeAdding single-flight already refuses a
+	// concurrent add, so the second create could not have succeeded anyway.
+	// Refusing here just says so at the moment the user asks, instead of
+	// seconds later and less legibly. Reachable from the keyboard because the
+	// dialog closes on submit and ActivePaneModel falls back to another leaf
+	// once the first replace detaches its pane.
+	if inflight := m.worktreeCreates[tab.ID]; inflight != "" {
+		logger.Debug("create pane: REFUSED, tab %s already has a worktree create in flight (branch %q)", tab.ID, inflight)
+		m.setFlash("still creating the worktree for " + truncateCells(sanitizeRemoteText(inflight), createErrFlashCap) + " — wait for it to finish")
+		return m, m.flashCmd()
+	}
+
 	// Option 2: Replace current pane
 	if m.dialogCursor == 2 {
 		oldPaneID := pane.ID

--- a/internal/tui/dialog.go
+++ b/internal/tui/dialog.go
@@ -1725,7 +1725,15 @@ func (m Model) handleCreatePaneSplit() (tea.Model, tea.Cmd) {
 	// tab does not share.
 	tabID, tabDest := tab.ID, tab.Dest
 
-	logger.Debug("create pane: sending IPC with cwd=%q type=%s instance=%s", cwd, pluginName, instanceName)
+	// "submitting", NOT "sending IPC". Three paths below return without ever
+	// sending, so a line claiming the send has happened is a lie the log tells
+	// on exactly the runs somebody is reading the log to explain. It cost a
+	// full investigation once: the daemon had no create_pane, the client
+	// insisted it had sent one, and the truth was a silent refusal underneath.
+	// Each of those paths now logs its own reason, so the next occurrence is
+	// one grep rather than a bisect of the handler.
+	logger.Debug("create pane: submitting cwd=%q type=%s instance=%s branch=%q repo=%q split=%d",
+		cwd, pluginName, instanceName, newBranch, newBranchRepo, m.dialogCursor)
 
 	// Refused BEFORE anything destructive or stateful happens — before the
 	// replace path disposes a pane, and before the split path arms a
@@ -1736,40 +1744,53 @@ func (m Model) handleCreatePaneSplit() (tea.Model, tea.Cmd) {
 		// The listing never answered, so the repository root is unknown.
 		// Refused rather than falling back to the browsed directory: that
 		// fallback is exactly the nested-worktree bug.
+		logger.Debug("create pane: REFUSED, branch %q has no known repository root (worktrees loaded=%v pending=%v repo=%v path=%q)",
+			newBranch, m.worktrees.loaded, m.worktrees.pending, m.worktrees.repo, m.worktrees.path)
 		m.setFlash("worktree not created: the repository root is not known yet")
 		return m, m.flashCmd()
 	}
 
 	// Option 2: Replace current pane
 	if m.dialogCursor == 2 {
-		// Refused, and refused HERE because this is the first moment the
-		// combination is known: the worktree field runs before this step, so
-		// it cannot gate itself on a choice the user has not made yet.
-		//
-		// The replace path below sets leaf.Pane = nil and calls old.Dispose()
-		// BEFORE the send, so a worktree add that then fails costs a LIVE
-		// pane — and unlike a dangling placeholder, Dispose() is not something
-		// PrunePlaceholders can undo. Refusing before any of that is
-		// destructive is the honest answer; the daemon refuses the pair too,
-		// because any IPC client can send it.
-		if newBranch != "" {
-			m.setFlash("a pane cannot be replaced with one in a new worktree — split instead")
-			return m, m.flashCmd()
-		}
 		oldPaneID := pane.ID
+		// The spec, when the user asked for a new branch — replace carries one
+		// exactly as split does. The daemon creates the worktree BEFORE it
+		// touches the pane being replaced, so a failed add costs nothing there.
+		var spec *ipc.WorktreeSpec
+		if newBranch != "" {
+			spec = &ipc.WorktreeSpec{RepoRoot: newBranchRepo, Branch: newBranch}
+		}
 
 		if leaf := tab.Root.FindLeaf(oldPaneID); leaf != nil {
-			// Detach + dispose immediately: the daemon destroys the old pane
-			// server-side and this PaneModel is never rendered again (output
-			// and rendering resolve panes via FindLeaf, which skips nil-Pane
-			// leaves). Disposing here — not via the reconciliation sweep —
-			// keeps the leaves cache honest: a stale cache was previously
-			// what fed the detached pane into the sweep's existingPanes.
+			// Detach immediately either way: the leaf must be reserved so the
+			// arriving pane lands WHERE THE OLD ONE WAS rather than through the
+			// root-insert fallback, and rendering resolves panes via FindLeaf,
+			// which skips nil-Pane leaves.
 			old := leaf.Pane
 			leaf.Pane = nil
 			tab.invalidateLeaves()
-			if old != nil {
-				old.Dispose()
+			if spec == nil {
+				// Ordinary replace: the daemon destroys the old pane the moment
+				// it handles this message, so the model is never rendered again.
+				// Disposing here — not via the reconciliation sweep — keeps the
+				// leaves cache honest: a stale cache was previously what fed the
+				// detached pane into the sweep's existingPanes.
+				if old != nil {
+					old.Dispose()
+				}
+			} else if old != nil {
+				// A worktree replace is ANSWERED, not fire-and-forget, and the
+				// answer can be a failure seconds later. Disposing now would
+				// make a failed `git worktree add` cost a live pane — the exact
+				// hazard this combination used to be refused over, which is a
+				// property of WHEN we dispose rather than of the operation. The
+				// model is held until the daemon says the swap really happened;
+				// applyCreatePaneResp disposes it on success and puts it back on
+				// failure.
+				if m.worktreeReplaced == nil {
+					m.worktreeReplaced = make(map[string]*PaneModel)
+				}
+				m.worktreeReplaced[tab.ID] = old
 			}
 			if m.pendingSplit == nil {
 				m.pendingSplit = make(map[string]*LayoutNode)
@@ -1777,7 +1798,17 @@ func (m Model) handleCreatePaneSplit() (tea.Model, tea.Cmd) {
 			m.pendingSplit[tab.ID] = leaf
 		}
 
-		return m, func() tea.Msg {
+		if spec != nil {
+			// Same bookkeeping the split path arms: keyed by tab, because two
+			// creates can be in flight and their responses can arrive in either
+			// order.
+			if m.worktreeCreates == nil {
+				m.worktreeCreates = make(map[string]string)
+			}
+			m.worktreeCreates[tab.ID] = newBranch
+		}
+
+		send := func() tea.Msg {
 			msg, _ := ipc.NewMessage(ipc.MsgCreatePane, ipc.CreatePanePayload{
 				TabID:           tabID,
 				CWD:             cwd,
@@ -1786,10 +1817,17 @@ func (m Model) handleCreatePaneSplit() (tea.Model, tea.Cmd) {
 				InstanceArgs:    instanceArgs,
 				ReplacePaneID:   oldPaneID,
 				ResumeSessionID: resumeSessionID,
+				Worktree:        spec,
 			})
 			m.sendForDest(tabDest, msg)
 			return nil
 		}
+		if spec == nil {
+			return m, send
+		}
+		return m, tea.Batch(send, tea.Tick(createPaneTimeout, func(time.Time) tea.Msg {
+			return createPaneTimeoutMsg{tabID: tabID}
+		}))
 	}
 
 	// Options 0/1: Split horizontal or vertical
@@ -1802,7 +1840,14 @@ func (m Model) handleCreatePaneSplit() (tea.Model, tea.Cmd) {
 
 	placeholder := tab.SplitAtPane(pane.ID, dir)
 	if placeholder == nil {
-		return m, nil
+		// The only one of these paths that used to surface NOTHING — no send,
+		// no flash, no log. The dialog closed on submit, so the user saw it
+		// vanish and no pane appear, which is indistinguishable from the pane
+		// having been created somewhere they cannot see. It means the active
+		// pane is not in its own tab's layout tree, so say so.
+		logger.Debug("create pane: REFUSED, SplitAtPane found no leaf for pane %s in tab %s", pane.ID, tabID)
+		m.setFlash("pane not created: the active pane is not in this tab's layout")
+		return m, m.flashCmd()
 	}
 
 	if m.pendingSplit == nil {
@@ -1825,9 +1870,9 @@ func (m Model) handleCreatePaneSplit() (tea.Model, tea.Cmd) {
 		// routinely arrive out of order. A scalar would be overwritten by the
 		// second create and leave the first's placeholder stranded forever.
 		if m.worktreeCreates == nil {
-			m.worktreeCreates = make(map[string]bool)
+			m.worktreeCreates = make(map[string]string)
 		}
-		m.worktreeCreates[tab.ID] = true
+		m.worktreeCreates[tab.ID] = newBranch
 	}
 
 	send := func() tea.Msg {
@@ -3267,6 +3312,19 @@ func (m Model) handleCreatePaneSetupKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd
 		return m, nil
 	}
 
+	// The open name field takes Esc for the same reason, and needs it for a
+	// sharper one: handleWorktreeNameKey documents Esc as abandoning the
+	// new-branch row, but the shared branch below returns unconditionally, so
+	// that case was unreachable from the keyboard — Esc backed out of pane
+	// creation entirely and the typed branch was never abandoned at all. It is
+	// the only way to undo a name now that tabbing away commits one; backspace
+	// to empty was otherwise the whole vocabulary. Routed INTO the field
+	// handler rather than clearing here, so "abandon" has one definition and
+	// the field handler's own coverage describes something reachable.
+	if kind == "worktree" && m.worktreeNaming && key == "esc" {
+		return m.handleWorktreeNameKey(key)
+	}
+
 	// Esc and Tab/Shift+Tab work the same regardless of which field is focused.
 	switch key {
 	case "esc":
@@ -3779,14 +3837,24 @@ func (m Model) handleWorktreeNameKey(key string) (tea.Model, tea.Cmd) {
 func (m Model) submitSetupDialog(p *plugin.PanePlugin) (tea.Model, tea.Cmd) {
 	if p.Command.PromptsCWD {
 		m.selectedCWD = m.setupSpawnDir()
-		// A name still being typed is not a choice. Committing it here would
-		// spawn on a branch the user was mid-way through naming — and Esc on
-		// the name field clears it, so reaching Continue with worktreeNaming
-		// still set means they tabbed away rather than accepted.
-		if m.worktreeNaming {
-			m.worktreeNaming = false
-			m.worktreeNewBranch = ""
-		}
+		// Tab and Shift+Tab are handled by handleCreatePaneSetupKey BEFORE the
+		// field dispatch, so they never reach handleWorktreeNameKey — the name
+		// field cannot swallow them. Tabbing away therefore arrives here with
+		// worktreeNaming still set and the branch intact, and the field goes on
+		// RENDERING it: any non-empty name draws the "new branch <name>"
+		// summary once the field is blurred.
+		//
+		// This used to clear the name on that basis ("still being typed is not
+		// a choice"), which contradicted what was on screen — the create fell
+		// through to an ordinary one and the pane spawned in the REPOSITORY
+		// ROOT, with no worktree, no git invocation and no error. That is the
+		// silent relocation the whole feature exists to prevent, reached by
+		// nothing more exotic than Tab.
+		//
+		// Closing the mode is still right; keeping the name is what makes the
+		// dialog do what it shows. A genuinely incomplete name is caught by the
+		// validation below, which refuses the submit and says why.
+		m.worktreeNaming = false
 		// Validated again at submit, not only on the name field's Enter: the
 		// user can change the browsed directory afterwards, and this is the
 		// last point before the pane is created.
@@ -4090,6 +4158,14 @@ func (m Model) worktreeRows() []worktreeRow {
 		return nil
 	}
 	rows := []worktreeRow{{label: "off — use the directory above", path: ""}}
+	// FIRST of the actionable rows, directly under the neutral default.
+	//
+	// It shipped last, to spare stage A's row fixtures an index shift — a
+	// reason about the tests rather than about the dialog, and the wrong trade:
+	// a repository with a dozen worktrees buries the row you reach for most,
+	// and "off" is the only row that earns its place above it by being the
+	// default rather than a choice. The fixtures moved instead.
+	rows = append(rows, worktreeRow{label: "+ new branch…", path: worktreeNewRowPath})
 	for _, w := range m.worktrees.list {
 		if w.Main {
 			continue
@@ -4107,12 +4183,6 @@ func (m Model) worktreeRows() []worktreeRow {
 		}
 		rows = append(rows, row)
 	}
-	// LAST, so every existing worktree keeps the index it had before this row
-	// existed and stage A's row fixtures shift rather than needing a rewrite.
-	// Only for a real repository — the four early-return states above never
-	// reach here, and offering to branch from a non-repository would be a row
-	// that cannot complete.
-	rows = append(rows, worktreeRow{label: "+ new branch…", path: worktreeNewRowPath})
 	return rows
 }
 

--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -28,6 +28,16 @@ type LayoutNode struct {
 	Ratio float64    // fraction allocated to Left child (0.0–1.0)
 	Left  *LayoutNode
 	Right *LayoutNode
+
+	// phW/phH are the cells a PLACEHOLDER leaf occupies, recorded by
+	// resizeNode. A placeholder has no Pane to carry its own size, and
+	// renderNode needs one to draw anything at all — without it a pending
+	// create is a black rectangle, which is what a 16 s `git worktree add`
+	// looked like for its entire duration.
+	//
+	// Runtime-only, and safe to add here because persistence goes through
+	// SerializedNode rather than this struct.
+	phW, phH int
 }
 
 // NewLeaf creates a leaf node wrapping a pane.
@@ -541,8 +551,10 @@ func resizeNode(n *LayoutNode, w, h, fullW, canvasW, canvasH int) {
 	if n == nil {
 		return
 	}
-	// Placeholder node (nil Pane, no children) — skip until filled.
+	// Placeholder node (nil Pane, no children) — nothing to resize, but record
+	// the rect so renderNode can draw the pending-create box at the right size.
 	if n.Pane == nil && n.Left == nil && n.Right == nil {
+		n.phW, n.phH = w, h
 		return
 	}
 	if n.IsLeaf() {
@@ -729,16 +741,28 @@ func UnmarshalLayout(data json.RawMessage) (*SerializedNode, error) {
 }
 
 // renderNode recursively produces the visual output for the layout tree.
-func renderNode(n *LayoutNode) string {
+//
+// creating names the branch of a worktree create in flight for this tab, or is
+// empty. It reaches a PLACEHOLDER leaf, which otherwise renders as nothing:
+// IsLeaf() is `Pane != nil`, so a placeholder falls through to the split arm
+// and joins two empty strings. That was invisible while a create took
+// microseconds and became a black rectangle for 16 seconds once a create could
+// mean `git worktree add` against a large repository — and on the replace path
+// the pane it is standing in for has already gone, so the whole tab is blank
+// with no indication anything is happening.
+func renderNode(n *LayoutNode, creating string) string {
 	if n == nil {
 		return ""
 	}
 	if n.IsLeaf() {
 		return n.Pane.View()
 	}
+	if n.Left == nil && n.Right == nil {
+		return renderPendingPane(creating, n.phW, n.phH)
+	}
 
-	leftView := renderNode(n.Left)
-	rightView := renderNode(n.Right)
+	leftView := renderNode(n.Left, creating)
+	rightView := renderNode(n.Right, creating)
 
 	switch n.Split {
 	case SplitVertical:
@@ -746,4 +770,36 @@ func renderNode(n *LayoutNode) string {
 	default: // SplitHorizontal
 		return lipgloss.JoinHorizontal(lipgloss.Top, leftView, rightView)
 	}
+}
+
+// renderPendingPane draws the box that stands in for a pane being created.
+//
+// Sized from the recorded rect rather than lipgloss.Place against the tab: the
+// placeholder may be one half of a split, and a full-tab box would paint over
+// its sibling. A zero rect (no resize has run yet) renders nothing, which is
+// the pre-existing behaviour and strictly better than a 0-width box.
+func renderPendingPane(branch string, w, h int) string {
+	if w <= 0 || h <= 0 {
+		return ""
+	}
+	msg := "Creating worktree…"
+	if branch != "" {
+		// The branch is the user's own text, but it round-trips through a
+		// remote daemon's listing on the way here, so it is sanitized like any
+		// other rendered remote value — and bounded, because sanitizing does
+		// not shorten and this box has a fixed width.
+		msg = "Creating worktree " + truncateCells(sanitizeRemoteText(branch), w-4)
+	}
+	body := msg
+	// The second line explains the wait rather than leaving the user to guess
+	// whether it has hung: a checkout of a large repository legitimately takes
+	// tens of seconds, which is exactly when it reads as broken.
+	if h >= 4 {
+		body += "\n\n" + restoreDimStyle.Render(truncateCells("checking out — this can take a while on a large repository", w-4))
+	}
+	return lipgloss.NewStyle().
+		Width(w).
+		Height(h).
+		Align(lipgloss.Center, lipgloss.Center).
+		Render(body)
 }

--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"encoding/json"
+	"strings"
 
 	"charm.land/lipgloss/v2"
 )
@@ -782,24 +783,41 @@ func renderPendingPane(branch string, w, h int) string {
 	if w <= 0 || h <= 0 {
 		return ""
 	}
-	msg := "Creating worktree…"
-	if branch != "" {
-		// The branch is the user's own text, but it round-trips through a
-		// remote daemon's listing on the way here, so it is sanitized like any
-		// other rendered remote value — and bounded, because sanitizing does
-		// not shorten and this box has a fixed width.
-		msg = "Creating worktree " + truncateCells(sanitizeRemoteText(branch), w-4)
+	// An ORDINARY split arms a placeholder too, and it has no branch. Saying
+	// "Creating worktree…" there is a confidently wrong answer about what the
+	// pane is waiting for — transient locally, but a create over ssh is not
+	// microseconds. A blank rect is what that placeholder rendered before this
+	// function existed, and it stays that way.
+	if branch == "" {
+		return lipgloss.NewStyle().Width(w).Height(h).Render("")
 	}
-	body := msg
+	// The branch is the user's own text, but it is rendered, so it takes the
+	// same treatment as any other rendered value: sanitized, then bounded.
+	// Sanitizing does not shorten.
+	//
+	// The WHOLE line is budgeted, not just the branch. Granting the branch w-4
+	// while prepending an 18-cell literal produces a line up to w+14 wide, and
+	// lipgloss WRAPS rather than truncates — so the box grew a row for every
+	// wrapped line and, being taller than the rect resizeNode recorded, pushed
+	// every sibling below it down. Measured before the fix: a 10x4 leaf (the
+	// documented minimum) rendered 10x5, and 1x4 rendered 1x18.
+	lines := []string{truncateCells("Creating worktree "+sanitizeRemoteText(branch), w)}
 	// The second line explains the wait rather than leaving the user to guess
 	// whether it has hung: a checkout of a large repository legitimately takes
-	// tens of seconds, which is exactly when it reads as broken.
+	// tens of seconds, which is exactly when it reads as broken. It needs three
+	// rows of its own (message, blank, hint), so it is gated on the height that
+	// actually fits it.
 	if h >= 4 {
-		body += "\n\n" + restoreDimStyle.Render(truncateCells("checking out — this can take a while on a large repository", w-4))
+		lines = append(lines, "", restoreDimStyle.Render(truncateCells("checking out — this can take a while on a large repository", w)))
 	}
+	// MaxWidth/MaxHeight CLAMP where Width/Height only pad: the pair is what
+	// makes the box fit its rect exactly rather than at least. Without them a
+	// one-cell-wide leaf still wrapped the first line into eighteen rows.
 	return lipgloss.NewStyle().
 		Width(w).
 		Height(h).
+		MaxWidth(w).
+		MaxHeight(h).
 		Align(lipgloss.Center, lipgloss.Center).
-		Render(body)
+		Render(strings.Join(lines, "\n"))
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -4208,6 +4208,23 @@ func (m *Model) rebuildTabs(info ProjectInfo, state WorkspaceStateMsg, existingT
 				continue
 			}
 
+			// The pane a worktree REPLACE detached is not new — it is live on
+			// both sides and deliberately absent from the tree while the add
+			// runs, held in worktreeReplaced so a failure can put it back.
+			//
+			// Without this it takes the branch below: existingPanes is built
+			// from tab.Leaves(), which skips the nil-Pane leaf it used to
+			// occupy, so a broadcast landing mid-checkout builds an EMPTY
+			// PaneModel for a live pane, consumes the reserved leaf, and clears
+			// worktreeCreates — after which both settling paths bail on
+			// `worktreeCreates[tabID] == ""` and the held model is leaked for
+			// the session. A `git worktree add` is seconds to minutes wide and
+			// the git-fingerprint ticker alone broadcasts every 5 s, so the
+			// window is not a corner case.
+			if held := m.worktreeReplaced[tab.ID]; held != nil && held.ID == paneID {
+				continue
+			}
+
 			// New pane — reuse model if it existed elsewhere, otherwise create.
 			pane, ok := existingPanes[paneID]
 			info := paneMap[paneID]
@@ -4252,6 +4269,20 @@ func (m *Model) rebuildTabs(info ProjectInfo, state WorkspaceStateMsg, existingT
 					// The next pane created in that tab then lands on an
 					// unreachable leaf — a live PTY with no visible pane.
 					delete(m.worktreeCreates, tab.ID)
+					// A pane really landing in the reserved leaf is what proves
+					// a REPLACE went through, and it is the only proof that
+					// arrives reliably: the daemon broadcasts state BEFORE it
+					// answers the request, so this runs BEFORE
+					// applyCreatePaneResp — which then bails on the
+					// already-cleared worktreeCreates and never reaches its own
+					// dispose. Leaving it to that handler leaked the model on
+					// every SUCCESSFUL replace, and left a stale entry that a
+					// later failure in the same tab would restore into the
+					// layout as a pane the daemon destroyed long ago.
+					if held := m.worktreeReplaced[tab.ID]; held != nil {
+						held.Dispose()
+						delete(m.worktreeReplaced, tab.ID)
+					}
 					// Focus the new pane (it replaced the previously active one)
 					tab.ActivePane = pane.ID
 					continue
@@ -4262,9 +4293,22 @@ func (m *Model) rebuildTabs(info ProjectInfo, state WorkspaceStateMsg, existingT
 			if tab.Root == nil {
 				tab.Root = NewLeaf(pane)
 				tab.invalidateLeaves()
+			} else if leaves := tab.Leaves(); len(leaves) == 0 {
+				// The root is a bare placeholder, which PrunePlaceholders
+				// cannot repair — it only inspects a split node's CHILDREN, so
+				// a placeholder that IS the root is invisible to it. A replace
+				// on a single-pane tab produces exactly that (leaf.Pane = nil
+				// on the root leaf), and `tab.Leaves()[0]` below then panicked
+				// with index out of range.
+				//
+				// Latent until now: the broadcast that consumed the reserved
+				// leaf also refilled the root in the same pass, which masked
+				// it. Skipping the held pane above removes that mask.
+				tab.Root = NewLeaf(pane)
+				tab.invalidateLeaves()
 			} else {
 				// Split the root vertically (stacked) to accommodate the new pane.
-				tab.Root.SplitLeaf(tab.Leaves()[0].ID, SplitVertical)
+				tab.Root.SplitLeaf(leaves[0].ID, SplitVertical)
 				tab.Root.FillPlaceholder(pane)
 				tab.invalidateLeaves()
 			}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -449,7 +449,22 @@ type Model struct {
 	// the second and then cleared, stranding the first tab's placeholder
 	// permanently: every later pane created in that tab is swallowed by the
 	// dead leaf, with no error anywhere.
-	worktreeCreates map[string]bool
+	worktreeCreates map[string]string
+	// worktreeReplaced holds, per tab, the pane a worktree-backed REPLACE
+	// detached but has not destroyed yet.
+	//
+	// An ordinary replace disposes the old pane at send time: the daemon
+	// destroys it the moment it handles the message, so there is nothing to go
+	// back to. A worktree replace is ANSWERED, and the answer can be a failure
+	// seconds later — the daemon creates the worktree BEFORE it touches the
+	// pane, so on failure the old pane is still alive on both sides. Holding
+	// the model here is what lets applyCreatePaneResp put it back rather than
+	// costing the user a live pane over a branch name git refused.
+	//
+	// Cleared on every settling path — success disposes it (the swap really
+	// happened), failure and timeout restore it — so an entry can never outlive
+	// the request that armed it.
+	worktreeReplaced map[string]*PaneModel
 	worktreeCursor    int                     // row cursor in the worktree field's expanded list; row 0 = "off"
 	worktreeScroll    int                     // scroll offset for the visible window of the expanded worktree list
 	reqGen            int                     // monotonic instance id source for repoScan/browse/worktrees; see nextReqGen
@@ -4270,7 +4285,11 @@ func (m *Model) rebuildTabs(info ProjectInfo, state WorkspaceStateMsg, existingT
 		// The create's own response is what retires this placeholder — on
 		// failure, or on timeout. Both delete the map entry, so the exemption
 		// cannot outlive the request that armed it.
-		if tab.Root != nil && !m.worktreeCreates[tab.ID] {
+		// Pushed from the SAME read that decides the exemption, so the
+		// placeholder and the message standing in it can never disagree about
+		// whether a create is in flight.
+		tab.CreatingBranch = m.worktreeCreates[tab.ID]
+		if tab.Root != nil && tab.CreatingBranch == "" {
 			tab.Root.PrunePlaceholders()
 			tab.invalidateLeaves()
 		}

--- a/internal/tui/setup_dialog_test.go
+++ b/internal/tui/setup_dialog_test.go
@@ -2355,7 +2355,10 @@ func TestHandleSetupWorktreeKey_EnterCommitsChoiceAndDropsSession(t *testing.T) 
 	p := &plugin.PanePlugin{}
 	m.worktrees.loaded, m.worktrees.repo = true, true
 	m.worktrees.list = []ipc.WorktreeInfo{{Path: "/repo-worktrees/feat-x", Branch: "feat-x"}}
-	m.worktreeCursor = 1 // row 0 is "off"
+	// Row 0 is "off" and row 1 is "+ new branch…", so the first EXISTING
+	// worktree is row 2. Looked up rather than counted, so the next reorder
+	// touches only the test that asserts the order.
+	m.worktreeCursor = worktreeRowIndex(t, m, "/repo-worktrees/feat-x")
 	m.selectedSessionID = "sess-1"
 
 	updated, _ := m.handleSetupWorktreeKey(p, "enter")

--- a/internal/tui/tab.go
+++ b/internal/tui/tab.go
@@ -26,6 +26,14 @@ type TabModel struct {
 	ChromeW   int
 	focusMode bool // true = active pane fills entire tab
 
+	// CreatingBranch names the branch of a worktree create in flight for this
+	// tab, and is what the placeholder leaf renders while it waits. Pushed by
+	// the Model each frame from worktreeCreates rather than stored here as the
+	// source of truth: the map is what the response handlers settle, and two
+	// copies of "is a create in flight" is how a placeholder outlives its
+	// request.
+	CreatingBranch string
+
 	// overlayPane is the tab's lazygit overlay (never part of the layout
 	// tree). overlayVisible controls rendering; the pane's PTY keeps
 	// running while hidden so re-show is instant with UI state intact.
@@ -379,7 +387,7 @@ func (t *TabModel) View() string {
 			return pane.View()
 		}
 	}
-	return renderNode(t.Root)
+	return renderNode(t.Root, t.CreatingBranch)
 }
 
 // ToggleFocus toggles pane focus mode on/off.

--- a/internal/tui/worktree_client.go
+++ b/internal/tui/worktree_client.go
@@ -171,7 +171,7 @@ func (m *Model) applyCreatePaneResp(p ipc.CreatePaneRespPayload, dest string) {
 		return
 	}
 	tabID := p.TabID
-	if !m.worktreeCreates[tabID] {
+	if m.worktreeCreates[tabID] == "" {
 		return // not ours, or already settled
 	}
 	// The response must describe a tab on the daemon it came FROM. tabByID
@@ -193,12 +193,37 @@ func (m *Model) applyCreatePaneResp(p ipc.CreatePaneRespPayload, dest string) {
 	// without creating a pane cannot get the placeholder pruned out from
 	// under the create. The timeout is the backstop if no pane ever arrives.
 	if p.Error == "" {
+		// The one thing success DOES retire: a replaced pane held back in case
+		// the add failed. The daemon has swapped it out, so the model describes
+		// a pane that no longer exists — keeping it would leak its emulator,
+		// and restoring it later would paint a dead pane.
+		if old := m.worktreeReplaced[tabID]; old != nil {
+			old.Dispose()
+			delete(m.worktreeReplaced, tabID)
+		}
 		return
 	}
 	delete(m.worktreeCreates, tabID)
 	if tab != nil && tab.Root != nil {
+		// A failed REPLACE puts the pane back rather than pruning its leaf: it
+		// was never destroyed daemon-side (the add failed before the swap), so
+		// pruning would drop a live pane out of the layout and leave the user
+		// looking at one fewer pane than they started with — a worse outcome
+		// than the failure they asked about.
+		if old := m.worktreeReplaced[tabID]; old != nil {
+			if leaf := m.pendingSplit[tabID]; leaf != nil && leaf.Pane == nil {
+				leaf.Pane = old
+			} else {
+				old.Dispose()
+			}
+			delete(m.worktreeReplaced, tabID)
+		}
 		tab.Root.PrunePlaceholders()
 		tab.invalidateLeaves()
+	} else if old := m.worktreeReplaced[tabID]; old != nil {
+		// The tab is gone, so there is nowhere to put it back.
+		old.Dispose()
+		delete(m.worktreeReplaced, tabID)
 	}
 	delete(m.pendingSplit, tabID)
 	// git's own stderr, bounded then sanitized. Bounding is separate from
@@ -216,11 +241,25 @@ const createErrFlashCap = 160
 // applyCreatePaneTimeout unwinds a create that never answered, so a wedged or
 // restarted daemon cannot leave the tab holding a placeholder forever.
 func (m *Model) applyCreatePaneTimeout(tabID string) {
-	if !m.worktreeCreates[tabID] {
+	if m.worktreeCreates[tabID] == "" {
 		return // already settled by a response
 	}
 	delete(m.worktreeCreates, tabID)
-	if tab := m.tabByID(tabID); tab != nil && tab.Root != nil {
+	tab := m.tabByID(tabID)
+	// Same restore as the failure path: a create that never answered did not
+	// necessarily fail, but the pane we detached is still ours and still alive,
+	// and putting it back is recoverable where losing it is not. A create that
+	// SUCCEEDED already disposed and cleared this entry, so a late timeout
+	// cannot resurrect a replaced pane.
+	if old := m.worktreeReplaced[tabID]; old != nil {
+		if leaf := m.pendingSplit[tabID]; leaf != nil && leaf.Pane == nil && tab != nil {
+			leaf.Pane = old
+		} else {
+			old.Dispose()
+		}
+		delete(m.worktreeReplaced, tabID)
+	}
+	if tab != nil && tab.Root != nil {
 		tab.Root.PrunePlaceholders()
 		tab.invalidateLeaves()
 	}

--- a/internal/tui/worktree_client.go
+++ b/internal/tui/worktree_client.go
@@ -204,26 +204,21 @@ func (m *Model) applyCreatePaneResp(p ipc.CreatePaneRespPayload, dest string) {
 		return
 	}
 	delete(m.worktreeCreates, tabID)
+	// A failed REPLACE normally puts the pane back rather than pruning its
+	// leaf: the worktree is created BEFORE the swap, so an add git refused
+	// leaves the pane alive on both sides, and pruning would cost the user a
+	// live pane over a branch name.
+	//
+	// Swapped is the exception, and it cannot be inferred from Error. The swap
+	// happens before the new pane's PTY spawns, so a spawn failure reports an
+	// error with the old pane ALREADY DESTROYED daemon-side. Restoring there
+	// would put a pane the daemon no longer has back into the layout, and every
+	// keystroke aimed at it would be dropped until the next broadcast pruned
+	// the leaf. The daemon says which happened; this does not guess.
+	m.settleReplacedPane(tabID, tab, !p.Swapped)
 	if tab != nil && tab.Root != nil {
-		// A failed REPLACE puts the pane back rather than pruning its leaf: it
-		// was never destroyed daemon-side (the add failed before the swap), so
-		// pruning would drop a live pane out of the layout and leave the user
-		// looking at one fewer pane than they started with — a worse outcome
-		// than the failure they asked about.
-		if old := m.worktreeReplaced[tabID]; old != nil {
-			if leaf := m.pendingSplit[tabID]; leaf != nil && leaf.Pane == nil {
-				leaf.Pane = old
-			} else {
-				old.Dispose()
-			}
-			delete(m.worktreeReplaced, tabID)
-		}
 		tab.Root.PrunePlaceholders()
 		tab.invalidateLeaves()
-	} else if old := m.worktreeReplaced[tabID]; old != nil {
-		// The tab is gone, so there is nowhere to put it back.
-		old.Dispose()
-		delete(m.worktreeReplaced, tabID)
 	}
 	delete(m.pendingSplit, tabID)
 	// git's own stderr, bounded then sanitized. Bounding is separate from
@@ -238,6 +233,35 @@ func (m *Model) applyCreatePaneResp(p ipc.CreatePaneRespPayload, dest string) {
 // project form documents applies here.
 const createErrFlashCap = 160
 
+// settleReplacedPane retires the pane a worktree REPLACE detached, putting it
+// back when restore is true and disposing it otherwise.
+//
+// One function because the three settling paths got this subtly different when
+// they were written out separately: the timeout mutated the leaf BEFORE its
+// `tab.Root != nil` guard, so a nil root left the leaf changed and the leaves
+// cache stale. Restoring and invalidating belong in the same place, always in
+// the same order.
+//
+// A no-op when nothing is held, so callers need no guard of their own.
+func (m *Model) settleReplacedPane(tabID string, tab *TabModel, restore bool) {
+	old := m.worktreeReplaced[tabID]
+	if old == nil {
+		return
+	}
+	delete(m.worktreeReplaced, tabID)
+	// Restorable only if the leaf reserved for it is still there and still
+	// empty. A tab closed mid-flight, or a leaf already refilled, leaves
+	// nowhere to put it — and a model with no home is a leaked emulator.
+	if restore && tab != nil && tab.Root != nil {
+		if leaf := m.pendingSplit[tabID]; leaf != nil && leaf.Pane == nil {
+			leaf.Pane = old
+			tab.invalidateLeaves()
+			return
+		}
+	}
+	old.Dispose()
+}
+
 // applyCreatePaneTimeout unwinds a create that never answered, so a wedged or
 // restarted daemon cannot leave the tab holding a placeholder forever.
 func (m *Model) applyCreatePaneTimeout(tabID string) {
@@ -246,19 +270,12 @@ func (m *Model) applyCreatePaneTimeout(tabID string) {
 	}
 	delete(m.worktreeCreates, tabID)
 	tab := m.tabByID(tabID)
-	// Same restore as the failure path: a create that never answered did not
-	// necessarily fail, but the pane we detached is still ours and still alive,
-	// and putting it back is recoverable where losing it is not. A create that
-	// SUCCEEDED already disposed and cleared this entry, so a late timeout
-	// cannot resurrect a replaced pane.
-	if old := m.worktreeReplaced[tabID]; old != nil {
-		if leaf := m.pendingSplit[tabID]; leaf != nil && leaf.Pane == nil && tab != nil {
-			leaf.Pane = old
-		} else {
-			old.Dispose()
-		}
-		delete(m.worktreeReplaced, tabID)
-	}
+	// Restored, like the failure path: nothing proved the swap happened, the
+	// pane we detached is still ours, and putting it back is recoverable where
+	// losing it is not. A create the daemon CONFIRMED already disposed and
+	// cleared this entry — on the broadcast that filled the leaf — so a late
+	// timeout cannot resurrect a replaced pane.
+	m.settleReplacedPane(tabID, tab, true)
 	if tab != nil && tab.Root != nil {
 		tab.Root.PrunePlaceholders()
 		tab.invalidateLeaves()

--- a/internal/tui/worktree_create_resp_test.go
+++ b/internal/tui/worktree_create_resp_test.go
@@ -45,7 +45,7 @@ func armedWorktreeCreate(t *testing.T) (Model, string) {
 
 	updated, _ := m.handleCreatePaneSplit()
 	got := updated.(Model)
-	if !got.worktreeCreates[tabID] {
+	if got.worktreeCreates[tabID] == "" {
 		t.Fatal("the create did not record its tab — nothing could unwind it")
 	}
 	if len(got.pendingSplit) == 0 {
@@ -149,7 +149,7 @@ func TestCreatePaneResp_TwoCreatesUnwindTheirOwnTabs(t *testing.T) {
 	tabB := "tab-second"
 	p := m.cur()
 	p.tabs = append(p.tabs, &TabModel{ID: tabB, Name: "B"})
-	m.worktreeCreates[tabB] = true
+	m.worktreeCreates[tabB] = "feat/b"
 	m.pendingSplit[tabB] = &LayoutNode{}
 
 	// B is rejected immediately and answers FIRST.
@@ -250,7 +250,7 @@ func TestCreatePane_TimeoutIsInertOnceThePaneLands(t *testing.T) {
 		Tabs:      []TabInfo{{ID: tabID, Name: "T", Panes: []string{paneID}}},
 		Panes:     []PaneInfo{{ID: paneID, TabID: tabID, Type: "terminal"}},
 	}, "")
-	if got.worktreeCreates[tabID] {
+	if got.worktreeCreates[tabID] != "" {
 		t.Fatal("the landed pane did not retire the create record")
 	}
 
@@ -267,7 +267,7 @@ func TestCreatePane_TimeoutStillFiresAfterAnEmptySuccess(t *testing.T) {
 
 	updated, _ := m.Update(wtResp(tabID, ""))
 	got := updated.(Model)
-	if !got.worktreeCreates[tabID] {
+	if got.worktreeCreates[tabID] == "" {
 		t.Fatal("success retired the create record before any pane arrived")
 	}
 
@@ -329,7 +329,7 @@ func TestApplyWorkspaceState_KeepsThePlaceholderWhileACreateIsInFlight(t *testin
 		t.Fatal("could not split to create a placeholder")
 	}
 	m.pendingSplit = map[string]*LayoutNode{tabID: placeholder}
-	m.worktreeCreates = map[string]bool{tabID: true}
+	m.worktreeCreates = map[string]string{tabID: "feat/x"}
 	before := countPlaceholders(m.curTabs()[0].Root)
 	if before == 0 {
 		t.Fatal("fixture armed no placeholder")

--- a/internal/tui/worktree_newbranch_test.go
+++ b/internal/tui/worktree_newbranch_test.go
@@ -46,23 +46,45 @@ func newBranchModel(t *testing.T) Model {
 	return m
 }
 
-// The row is LAST so every existing worktree keeps the index it had before
-// this feature, and stage A's fixtures shift rather than needing a rewrite.
-func TestWorktreeRows_NewBranchIsLast(t *testing.T) {
+// worktreeRowIndex finds a row by PATH rather than by position.
+//
+// Every fixture below used a literal index, so moving one row broke eight
+// unrelated tests at once — and the row moved because it was placed last to
+// spare those fixtures in the first place, which is the tail wagging the dog.
+// Looking the row up means the order is free to change and only the test that
+// asserts the order has to care.
+func worktreeRowIndex(t *testing.T, m Model, path string) int {
+	t.Helper()
+	for i, r := range m.worktreeRows() {
+		if r.path == path {
+			return i
+		}
+	}
+	t.Fatalf("no worktree row with path %q", path)
+	return -1
+}
+
+// "+ new branch…" is the FIRST actionable row, directly under "off". A
+// repository with a dozen worktrees would otherwise bury the row reached for
+// most; "off" stays above it because it is the default rather than a choice.
+func TestWorktreeRows_NewBranchIsFirstAction(t *testing.T) {
 	m := newBranchModel(t)
 	rows := m.worktreeRows()
-	if len(rows) == 0 {
+	if len(rows) < 2 {
 		t.Fatal("no worktree rows")
-	}
-	last := rows[len(rows)-1]
-	if !strings.Contains(last.label, "new branch") {
-		t.Errorf("last row is %q, want the new-branch row", last.label)
-	}
-	if last.path != worktreeNewRowPath {
-		t.Errorf("last row path = %q, want the sentinel", last.path)
 	}
 	if rows[0].path != "" {
 		t.Error("the off row is no longer first")
+	}
+	if !strings.Contains(rows[1].label, "new branch") {
+		t.Errorf("row 1 is %q, want the new-branch row", rows[1].label)
+	}
+	if rows[1].path != worktreeNewRowPath {
+		t.Errorf("row 1 path = %q, want the sentinel", rows[1].path)
+	}
+	// The existing worktrees follow it, in listing order.
+	if rows[2].path != "/repo-worktrees/feat-a" {
+		t.Errorf("row 2 = %q, want the first existing worktree", rows[2].path)
 	}
 }
 
@@ -71,7 +93,7 @@ func TestWorktreeRows_NewBranchIsLast(t *testing.T) {
 func TestWorktreeNewBranch_EnterOpensTheNameField(t *testing.T) {
 	m := newBranchModel(t)
 	p := &plugin.PanePlugin{Name: "terminal"}
-	m.worktreeCursor = len(m.worktreeRows()) - 1
+	m.worktreeCursor = worktreeRowIndex(t, m, worktreeNewRowPath)
 
 	updated, _ := m.handleSetupWorktreeKey(p, "enter")
 	got := updated.(Model)
@@ -166,7 +188,7 @@ func TestWorktreeNewBranch_ChoosingAnExistingWorktreeClearsIt(t *testing.T) {
 	m := newBranchModel(t)
 	p := &plugin.PanePlugin{Name: "terminal"}
 	m.worktreeNewBranch = "feat/x"
-	m.worktreeCursor = 1 // the feat-a row
+	m.worktreeCursor = worktreeRowIndex(t, m, "/repo-worktrees/feat-a")
 
 	updated, _ := m.handleSetupWorktreeKey(p, "enter")
 	got := updated.(Model)
@@ -330,29 +352,12 @@ func TestHandleCreatePaneSplit_ClearsTheWorktreeStateAfterwards(t *testing.T) {
 	}
 }
 
-// Replace mode is refused HERE because this is the first moment the
-// combination is known — the worktree field runs before this step, so it
-// cannot gate itself on a choice the user has not made yet. The replace path
-// disposes the old pane before the send, so a later failure costs a live one.
-func TestHandleCreatePaneSplit_RefusesReplaceWithANewBranch(t *testing.T) {
-	m := newBranchModel(t)
-	fake := &fakeSender{}
-	m.client = fake
-	m.selectedPlugin = "terminal"
-	m.selectedCWD = "/repo"
-	m.worktreeNewBranch = "feat/x"
-	m.dialogCursor = 2 // replace
-
-	updated, _ := m.handleCreatePaneSplit()
-	got := updated.(Model)
-
-	if len(fake.sent) != 0 {
-		t.Errorf("a replace-with-new-worktree was sent: %+v", fake.sent)
-	}
-	if got.flashText == "" {
-		t.Error("the refusal was silent")
-	}
-}
+// Replace mode with a new worktree used to be refused here. It is supported
+// now — swapping a scratch shell for an agent in a fresh branch is an ordinary
+// thing to want, and the hazard the refusal named (a failed add costing a live
+// pane) was about WHEN the client disposed the old pane, not about the
+// operation. See worktree_replace_test.go, which pins the send, the restore on
+// failure and on timeout, and the dispose on success.
 
 // The spec must carry the REPOSITORY ROOT the daemon reported, never the
 // browsed directory. `git worktree list` succeeds from any subdirectory, so

--- a/internal/tui/worktree_replace_test.go
+++ b/internal/tui/worktree_replace_test.go
@@ -174,6 +174,10 @@ func TestReplace_WithoutAWorktreeStillDisposesImmediately(t *testing.T) {
 	m.dialogCursor = 2
 
 	tab := m.curTabs()[0]
+	old := tab.ActivePaneModel()
+	if old == nil || old.vt == nil {
+		t.Fatal("fixture: the pane to replace has no VT to observe")
+	}
 	updated, _ := m.handleCreatePaneSplit()
 	got := updated.(Model)
 
@@ -182,6 +186,13 @@ func TestReplace_WithoutAWorktreeStillDisposesImmediately(t *testing.T) {
 	}
 	if got.worktreeCreates[tab.ID] != "" {
 		t.Error("an ordinary replace armed the worktree bookkeeping")
+	}
+	// The DISPOSE itself, not just the bookkeeping around it. Asserting only
+	// the two maps above left this test green with old.Dispose() deleted — the
+	// name promised the dispose and nothing checked it. p.vt is nilled by
+	// closeVT, which is also what stops the drain goroutine.
+	if old.vt != nil {
+		t.Error("an ordinary replace did not Dispose() the pane it detached — its emulator and drain goroutine leak")
 	}
 }
 

--- a/internal/tui/worktree_replace_test.go
+++ b/internal/tui/worktree_replace_test.go
@@ -1,0 +1,243 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+
+	"github.com/artyomsv/quil/internal/ipc"
+)
+
+// armedWorktreeReplace returns a model mid-flight on the REPLACE path: the
+// active pane has been detached from its leaf and held back, and the request
+// carrying the worktree spec has been sent. Returns the tab and the id of the
+// pane being replaced.
+func armedWorktreeReplace(t *testing.T) (Model, string, string) {
+	t.Helper()
+	m := newBranchModel(t)
+	m.client = &fakeSender{}
+	m.selectedPlugin = "terminal"
+	m.selectedCWD = "/repo"
+	m.worktreeNewBranch = "feat/x"
+	m.dialogCursor = 2 // Replace current pane
+
+	tab := m.curTabs()[0]
+	oldPaneID := tab.ActivePaneModel().ID
+
+	updated, _ := m.handleCreatePaneSplit()
+	got := updated.(Model)
+	if got.worktreeCreates[tab.ID] == "" {
+		t.Fatal("the replace did not record its tab — nothing could unwind it")
+	}
+	return got, tab.ID, oldPaneID
+}
+
+// The wire proof that replace carries the spec at all. Without it the daemon
+// runs its ordinary replace and the new pane lands in the browsed directory —
+// silently, which is how the reported failure looked.
+func TestReplace_SendsTheWorktreeSpec(t *testing.T) {
+	m := newBranchModel(t)
+	sender := &fakeSender{}
+	m.client = sender
+	m.selectedPlugin = "terminal"
+	m.selectedCWD = "/repo"
+	m.worktreeNewBranch = "feat/x"
+	m.dialogCursor = 2
+
+	oldPaneID := m.curTabs()[0].ActivePaneModel().ID
+	_, cmd := m.handleCreatePaneSplit()
+	runCmd(cmd)
+
+	var payload *ipc.CreatePanePayload
+	for _, msg := range sender.sent {
+		if msg.Type != ipc.MsgCreatePane {
+			continue
+		}
+		var decoded ipc.CreatePanePayload
+		if err := msg.DecodePayload(&decoded); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		payload = &decoded
+	}
+	if payload == nil {
+		t.Fatal("no create_pane was sent — the replace was refused")
+	}
+	if payload.ReplacePaneID != oldPaneID {
+		t.Errorf("ReplacePaneID = %q, want %q", payload.ReplacePaneID, oldPaneID)
+	}
+	if payload.Worktree == nil {
+		t.Fatal("the replace carried no worktree spec")
+	}
+	if payload.Worktree.Branch != "feat/x" {
+		t.Errorf("branch = %q, want feat/x", payload.Worktree.Branch)
+	}
+	if payload.Worktree.RepoRoot != "/repo" {
+		t.Errorf("repo root = %q, want the main checkout /repo", payload.Worktree.RepoRoot)
+	}
+}
+
+// The ordering fix. An ordinary replace disposes the old pane at send time
+// because the daemon destroys it immediately; a worktree replace is ANSWERED,
+// and the daemon creates the worktree BEFORE touching the pane — so on failure
+// the pane is still alive on both sides and must come back.
+//
+// Disposing at send time is what made this combination look unsafe enough to
+// refuse. It was never the operation that was unsafe, only the timing.
+func TestReplace_FailedAddPutsTheOldPaneBack(t *testing.T) {
+	m, tabID, oldPaneID := armedWorktreeReplace(t)
+
+	// Held, not disposed, while the request is in flight.
+	if m.worktreeReplaced[tabID] == nil {
+		t.Fatal("the replaced pane was not held — a failure could not restore it")
+	}
+
+	updated, _ := m.Update(createPaneRespMsg{Resp: ipc.CreatePaneRespPayload{
+		TabID:    tabID,
+		Error:    "fatal: a branch named 'feat/x' already exists",
+		Worktree: &ipc.WorktreeSpec{RepoRoot: "/repo", Branch: "feat/x"},
+	}})
+	got := updated.(Model)
+
+	tab := got.tabByID(tabID)
+	if tab == nil {
+		t.Fatal("the tab vanished")
+	}
+	if leaf := tab.Root.FindLeaf(oldPaneID); leaf == nil {
+		t.Error("the replaced pane did not come back — a failed git add cost a live pane")
+	}
+	if got.worktreeReplaced[tabID] != nil {
+		t.Error("the held pane outlived the request that armed it")
+	}
+	if _, ok := got.pendingSplit[tabID]; ok {
+		t.Error("the pending split is still armed after a failed replace")
+	}
+	if got.flashText == "" {
+		t.Error("the failure was not reported")
+	}
+}
+
+// A timeout is the same situation: nothing proved the swap happened, and the
+// pane we detached is still ours. Restoring is recoverable; losing it is not.
+func TestReplace_TimeoutPutsTheOldPaneBack(t *testing.T) {
+	m, tabID, oldPaneID := armedWorktreeReplace(t)
+
+	updated, _ := m.Update(createPaneTimeoutMsg{tabID: tabID})
+	got := updated.(Model)
+
+	tab := got.tabByID(tabID)
+	if tab == nil {
+		t.Fatal("the tab vanished")
+	}
+	if leaf := tab.Root.FindLeaf(oldPaneID); leaf == nil {
+		t.Error("a timed-out replace lost the pane it detached")
+	}
+	if got.worktreeReplaced[tabID] != nil {
+		t.Error("the held pane survived the timeout")
+	}
+}
+
+// Success is the one path that must NOT restore: the daemon really did swap the
+// pane out, so the held model describes something that no longer exists.
+// Putting it back would paint a dead pane; keeping it leaks its emulator.
+func TestReplace_SuccessDisposesTheOldPane(t *testing.T) {
+	m, tabID, oldPaneID := armedWorktreeReplace(t)
+
+	updated, _ := m.Update(createPaneRespMsg{Resp: ipc.CreatePaneRespPayload{
+		TabID:    tabID,
+		PaneID:   "pane-new00001",
+		Worktree: &ipc.WorktreeSpec{RepoRoot: "/repo", Branch: "feat/x"},
+	}})
+	got := updated.(Model)
+
+	if got.worktreeReplaced[tabID] != nil {
+		t.Error("the replaced pane is still held after the daemon confirmed the swap")
+	}
+	if tab := got.tabByID(tabID); tab != nil && tab.Root.FindLeaf(oldPaneID) != nil {
+		t.Error("a confirmed swap left the replaced pane in the layout")
+	}
+	// The placeholder must survive: the new pane arrives in the next broadcast
+	// and fills the slot the old one vacated.
+	if _, ok := got.pendingSplit[tabID]; !ok {
+		t.Error("a successful replace unwound its own placeholder")
+	}
+}
+
+// An ordinary replace (no worktree) must keep its old behaviour exactly:
+// disposed at send time, no give-up tick, no held model.
+func TestReplace_WithoutAWorktreeStillDisposesImmediately(t *testing.T) {
+	m := newBranchModel(t)
+	m.client = &fakeSender{}
+	m.selectedPlugin = "terminal"
+	m.selectedCWD = "/repo"
+	m.worktreeNewBranch = "" // no worktree
+	m.dialogCursor = 2
+
+	tab := m.curTabs()[0]
+	updated, _ := m.handleCreatePaneSplit()
+	got := updated.(Model)
+
+	if got.worktreeReplaced[tab.ID] != nil {
+		t.Error("an ordinary replace held its old pane — the daemon destroys it immediately, so there is nothing to restore")
+	}
+	if got.worktreeCreates[tab.ID] != "" {
+		t.Error("an ordinary replace armed the worktree bookkeeping")
+	}
+}
+
+// A placeholder used to render as the empty string: IsLeaf() is `Pane != nil`,
+// so it fell through to the split arm and joined two empty children. That was
+// invisible while a create took microseconds, and became a BLACK RECTANGLE for
+// the 16 s a `git worktree add` takes against a large repository — on the
+// replace path with the old pane already gone, so the whole tab was blank with
+// nothing to say why.
+func TestRenderPendingPane_NamesTheBranchItIsWaitingOn(t *testing.T) {
+	out := renderPendingPane("feat/login", 60, 10)
+	if out == "" {
+		t.Fatal("a pending create rendered nothing at all")
+	}
+	if !strings.Contains(out, "feat/login") {
+		t.Errorf("the pending box does not name the branch:\n%s", out)
+	}
+	if !strings.Contains(out, "Creating worktree") {
+		t.Errorf("the pending box does not say what it is doing:\n%s", out)
+	}
+	if h := lipgloss.Height(out); h != 10 {
+		t.Errorf("pending box is %d rows, want 10 — it must fill its rect exactly", h)
+	}
+	if w := lipgloss.Width(out); w != 60 {
+		t.Errorf("pending box is %d cells wide, want 60", w)
+	}
+}
+
+// The branch reaches here having round-tripped through a remote daemon's
+// listing, so it is sanitized like any other rendered remote value — and
+// bounded, because sanitizing does not shorten and this box has a fixed width.
+func TestRenderPendingPane_SanitizesAndBoundsTheBranch(t *testing.T) {
+	out := renderPendingPane("boom\x1b]52;c;cGF5bG9hZA==\x07"+strings.Repeat("x", 400), 40, 8)
+	if strings.Contains(out, "\x1b]52") {
+		t.Error("an OSC 52 in the branch survived into the pending box")
+	}
+	if w := lipgloss.Width(out); w != 40 {
+		t.Errorf("pending box is %d cells wide, want exactly 40 — an unbounded branch overflowed its rect", w)
+	}
+}
+
+// A zero rect means no resize has run yet. Rendering nothing there is the
+// pre-existing behaviour and strictly better than a zero-width box.
+func TestRenderPendingPane_ZeroRectRendersNothing(t *testing.T) {
+	if out := renderPendingPane("feat/x", 0, 0); out != "" {
+		t.Errorf("a zero rect rendered %q", out)
+	}
+}
+
+// The size comes from resizeNode, which used to skip placeholders entirely —
+// so without this the box would render at 0x0 forever and the fix would be
+// invisible in exactly the case it exists for.
+func TestResizeNode_RecordsThePlaceholderRect(t *testing.T) {
+	ph := &LayoutNode{}
+	resizeNode(ph, 80, 24, 80, 0, 0)
+	if ph.phW != 80 || ph.phH != 24 {
+		t.Errorf("placeholder rect = %dx%d, want 80x24", ph.phW, ph.phH)
+	}
+}

--- a/internal/tui/worktree_review_test.go
+++ b/internal/tui/worktree_review_test.go
@@ -1,0 +1,286 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+
+	"github.com/artyomsv/quil/internal/ipc"
+)
+
+// Regression tests for the defects a code review found in the worktree-replace
+// work. Each one fails against the code as it was reviewed.
+
+// wsBroadcast builds a realistic workspace_state for a tab mid-replace: every
+// pane still in the layout, PLUS whatever extra ids the caller names.
+//
+// Listing only the extras would drop the tab's surviving panes and restructure
+// the tree, which is a different scenario (panes closed elsewhere) and would
+// make these tests fail for a reason that has nothing to do with the bug.
+//
+// A worktree replace runs for SECONDS, so ordinary broadcasts land inside it:
+// the git-fingerprint ticker alone fires every 5 s, and a child toggling mouse
+// modes or another client will do it too.
+func wsBroadcast(tab *TabModel, extra ...string) WorkspaceStateMsg {
+	ids := make([]string, 0, len(extra)+2)
+	for _, leaf := range tab.Leaves() {
+		ids = append(ids, leaf.ID)
+	}
+	ids = append(ids, extra...)
+	panes := make([]PaneInfo, 0, len(ids))
+	for _, id := range ids {
+		panes = append(panes, PaneInfo{ID: id, TabID: tab.ID, Type: "terminal"})
+	}
+	return WorkspaceStateMsg{
+		ActiveTab: tab.ID,
+		Tabs:      []TabInfo{{ID: tab.ID, Name: tab.Name, Panes: ids}},
+		Panes:     panes,
+	}
+}
+
+// The critical one. While the add runs the daemon has NOT swapped yet, so it
+// keeps reporting the old pane id — which is absent from the tree because the
+// client detached it. rebuildTabs read that as a NEW pane: it built an empty
+// PaneModel for a live one, consumed the reserved leaf, and cleared
+// worktreeCreates. Both settling paths gate on that map, so the held model was
+// leaked for the session and the reserved leaf was gone.
+func TestReplace_MidFlightBroadcastKeepsTheBookkeeping(t *testing.T) {
+	m, tabID, oldPaneID := armedWorktreeReplace(t)
+
+	m.applyWorkspaceState(wsBroadcast(m.tabByID(tabID), oldPaneID), "")
+
+	if m.worktreeCreates[tabID] == "" {
+		t.Error("a mid-flight broadcast cleared the create — neither the response nor the timeout can settle it now")
+	}
+	if m.worktreeReplaced[tabID] == nil {
+		t.Error("a mid-flight broadcast dropped the held pane — it can no longer be restored or disposed")
+	}
+	if _, ok := m.pendingSplit[tabID]; !ok {
+		t.Error("a mid-flight broadcast consumed the reserved leaf — the new pane would land elsewhere")
+	}
+
+	// And the failure path must still work afterwards.
+	updated, _ := m.Update(createPaneRespMsg{Resp: ipc.CreatePaneRespPayload{
+		TabID:    tabID,
+		Error:    "fatal: a branch named 'feat/x' already exists",
+		Worktree: &ipc.WorktreeSpec{RepoRoot: "/repo", Branch: "feat/x"},
+	}})
+	got := updated.(Model)
+	if tab := got.tabByID(tabID); tab == nil || tab.Root.FindLeaf(oldPaneID) == nil {
+		t.Error("after a mid-flight broadcast the failure path could no longer restore the pane")
+	}
+}
+
+// Success arrives as a BROADCAST before the response — the daemon calls
+// broadcastState() and then respondTo, and both frames are must-deliver on one
+// serial reader. So the broadcast that fills the leaf is what must dispose the
+// held pane; leaving it to applyCreatePaneResp leaked the model on every
+// successful replace, because that handler bails on the worktreeCreates entry
+// the same broadcast just cleared.
+func TestReplace_BroadcastFillingTheLeafDisposesTheHeldPane(t *testing.T) {
+	m, tabID, _ := armedWorktreeReplace(t)
+	held := m.worktreeReplaced[tabID]
+	if held == nil || held.vt == nil {
+		t.Fatal("fixture: the held pane has no VT to observe")
+	}
+
+	m.applyWorkspaceState(wsBroadcast(m.tabByID(tabID), "pane-brandnew1"), "")
+
+	if m.worktreeReplaced[tabID] != nil {
+		t.Error("the held pane outlived the broadcast that confirmed the swap")
+	}
+	if held.vt != nil {
+		t.Error("the held pane was dropped without Dispose() — its emulator and drain goroutine leak")
+	}
+}
+
+// A replace on a SINGLE-pane tab detaches the root leaf, leaving a bare
+// placeholder as the root. PrunePlaceholders only inspects a split node's
+// CHILDREN, so it cannot repair that, and rebuildTabs' root-insert fallback did
+// tab.Leaves()[0] — index out of range on an empty slice. Masked only because
+// the broadcast used to refill the root in the same pass it consumed the leaf.
+// Reached via the one settling path that leaves the leaf EMPTY: a swapped
+// failure (the add succeeded, the swap happened, the PTY spawn failed). Nothing
+// is restored, pendingSplit is dropped, and the root is left a bare
+// placeholder — so the next new pane takes the root-insert fallback and finds
+// no leaves to split.
+func TestReplace_RootPlaceholderDoesNotPanicOnTheNextBroadcast(t *testing.T) {
+	m := newBranchModel(t)
+	m.client = &fakeSender{}
+	m.selectedPlugin = "terminal"
+	m.selectedCWD = "/repo"
+	m.worktreeNewBranch = "feat/x"
+	m.dialogCursor = 2
+
+	tab := m.curTabs()[0]
+	for _, extra := range tab.Leaves()[1:] {
+		tab.RemovePane(extra.ID)
+	}
+	if got := len(tab.Leaves()); got != 1 {
+		t.Fatalf("fixture has %d leaves, want 1", got)
+	}
+	tabID := tab.ID
+	updated, _ := m.handleCreatePaneSplit()
+	m = updated.(Model)
+
+	// Swapped: the old pane is gone daemon-side, so nothing is put back and the
+	// reserved leaf stays empty.
+	updated, _ = m.Update(createPaneRespMsg{Resp: ipc.CreatePaneRespPayload{
+		TabID:    tabID,
+		Error:    "start PTY (dead pane removed): exec: not found",
+		Swapped:  true,
+		Worktree: &ipc.WorktreeSpec{RepoRoot: "/repo", Branch: "feat/x"},
+	}})
+	m = updated.(Model)
+	if leaves := m.tabByID(tabID).Leaves(); len(leaves) != 0 {
+		t.Fatalf("fixture: tab has %d leaves, want the bare-root-placeholder state", len(leaves))
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("a broadcast after a swapped-failure replace panicked: %v", r)
+		}
+	}()
+	m.applyWorkspaceState(wsBroadcast(m.tabByID(tabID), "pane-brandnew1"), "")
+
+	if leaves := m.tabByID(tabID).Leaves(); len(leaves) != 1 {
+		t.Errorf("the tab has %d leaves after the broadcast, want the new pane to have landed", len(leaves))
+	}
+}
+
+// A second create on the same tab overwrote worktreeCreates, worktreeReplaced
+// and pendingSplit at once — leaking the first held pane and pointing the
+// first's response at the second's leaf. Reachable from the keyboard: the
+// dialog closes on submit, and ActivePaneModel falls back to another leaf once
+// the first replace detaches its pane.
+func TestCreatePaneSplit_RefusesASecondCreateWhileOneIsInFlight(t *testing.T) {
+	m, tabID, _ := armedWorktreeReplace(t)
+	firstHeld := m.worktreeReplaced[tabID]
+	firstLeaf := m.pendingSplit[tabID]
+
+	m.selectedPlugin = "terminal"
+	m.selectedCWD = "/repo"
+	m.worktreeNewBranch = "feat/second"
+	m.dialogCursor = 0 // a SPLIT, so this cannot be read as a replace-only guard
+	sender := &fakeSender{}
+	m.client = sender
+	// handleCreatePaneSplit TEARS DOWN the worktree listing on submit, so the
+	// first create left worktrees.root empty. Restoring it is what makes the
+	// second create reach the in-flight guard instead of being turned away by
+	// the repository-root-unknown one — which refuses too, and would let this
+	// test pass without the guard it exists to pin.
+	m.worktrees = worktreeState{loaded: true, repo: true, root: "/repo"}
+
+	updated, _ := m.handleCreatePaneSplit()
+	got := updated.(Model)
+
+	if len(sender.sent) != 0 {
+		t.Error("a second worktree create was sent while one was in flight")
+	}
+	if !strings.Contains(got.flashText, "feat/x") {
+		t.Errorf("flash %q does not name the create already running", got.flashText)
+	}
+	if got.worktreeCreates[tabID] != "feat/x" {
+		t.Errorf("worktreeCreates = %q, want the FIRST create's branch", got.worktreeCreates[tabID])
+	}
+	if got.worktreeReplaced[tabID] != firstHeld {
+		t.Error("the second create replaced the first held pane — the first is now leaked")
+	}
+	if got.pendingSplit[tabID] != firstLeaf {
+		t.Error("the second create stole the first reserved leaf")
+	}
+}
+
+// Swapped is a statement about what happened and cannot be inferred from Error:
+// the swap precedes the new pane's PTY spawn, so a spawn failure is an error
+// with the old pane already destroyed. Restoring there puts a pane the daemon
+// no longer has back into the layout, and keystrokes aimed at it are dropped
+// until a later broadcast prunes the leaf.
+func TestCreatePaneResp_SwappedFailureDoesNotRestoreADeadPane(t *testing.T) {
+	m, tabID, oldPaneID := armedWorktreeReplace(t)
+	held := m.worktreeReplaced[tabID]
+
+	updated, _ := m.Update(createPaneRespMsg{Resp: ipc.CreatePaneRespPayload{
+		TabID:    tabID,
+		Error:    `start PTY (dead pane removed): exec: "claude": not found`,
+		Swapped:  true,
+		Worktree: &ipc.WorktreeSpec{RepoRoot: "/repo", Branch: "feat/x"},
+	}})
+	got := updated.(Model)
+
+	if tab := got.tabByID(tabID); tab != nil && tab.Root.FindLeaf(oldPaneID) != nil {
+		t.Error("a pane the daemon had already destroyed was restored into the layout")
+	}
+	if got.worktreeReplaced[tabID] != nil {
+		t.Error("the held pane is still held after a swapped failure")
+	}
+	if held != nil && held.vt != nil {
+		t.Error("the held pane was neither restored nor disposed — it leaks")
+	}
+}
+
+// An UNSWAPPED failure is the ordinary one — git refused the branch before the
+// daemon touched anything — and must still restore. Stated separately so a fix
+// that simply stopped restoring would not pass.
+func TestCreatePaneResp_UnswappedFailureStillRestores(t *testing.T) {
+	m, tabID, oldPaneID := armedWorktreeReplace(t)
+
+	updated, _ := m.Update(createPaneRespMsg{Resp: ipc.CreatePaneRespPayload{
+		TabID:    tabID,
+		Error:    "fatal: a branch named 'feat/x' already exists",
+		Worktree: &ipc.WorktreeSpec{RepoRoot: "/repo", Branch: "feat/x"},
+	}})
+	got := updated.(Model)
+
+	if tab := got.tabByID(tabID); tab == nil || tab.Root.FindLeaf(oldPaneID) == nil {
+		t.Error("a branch git refused cost the user a live pane")
+	}
+}
+
+// renderPendingPane must FIT its rect. lipgloss Width/Height pad but do not
+// truncate, and the 18-cell "Creating worktree " prefix was never counted —
+// only the branch was. A box taller than the rect resizeNode recorded pushes
+// every sibling below it down, the row-shifting family of bug this codebase has
+// shipped before.
+func TestRenderPendingPane_FitsItsRectAtEverySize(t *testing.T) {
+	for _, tc := range []struct{ w, h int }{
+		{10, 4}, // the documented minimum leaf size
+		{8, 4}, {6, 4}, {3, 4}, {1, 4},
+		{12, 2}, {12, 1}, {20, 3}, {80, 24},
+	} {
+		out := renderPendingPane("feat/some-quite-long-branch-name", tc.w, tc.h)
+		if w := lipgloss.Width(out); w > tc.w {
+			t.Errorf("%dx%d: rendered %d cells wide, want <= %d", tc.w, tc.h, w, tc.w)
+		}
+		if h := lipgloss.Height(out); h > tc.h {
+			t.Errorf("%dx%d: rendered %d rows, want <= %d", tc.w, tc.h, h, tc.h)
+		}
+	}
+}
+
+// An ORDINARY split arms a placeholder too, and renderNode reaches this for any
+// childless nil-Pane node. Claiming a worktree is being created there is a
+// confidently wrong answer about what the pane is waiting for — and an ordinary
+// create over ssh is not microseconds.
+func TestRenderPendingPane_OrdinarySplitSaysNothingAboutWorktrees(t *testing.T) {
+	out := renderPendingPane("", 60, 10)
+	if strings.Contains(out, "Creating worktree") {
+		t.Errorf("an ordinary split placeholder claims a worktree is being created:\n%q", out)
+	}
+	if lipgloss.Width(out) != 60 || lipgloss.Height(out) != 10 {
+		t.Errorf("the blank placeholder is %dx%d, want 60x10", lipgloss.Width(out), lipgloss.Height(out))
+	}
+}
+
+// The same thing through the real render path rather than the helper alone.
+func TestTabView_OrdinarySplitPlaceholderSaysNothingAboutWorktrees(t *testing.T) {
+	m := newBranchModel(t)
+	tab := m.curTabs()[0]
+	tab.SplitAtPane(tab.Leaves()[0].ID, SplitHorizontal)
+	tab.Resize(100, 38)
+
+	if strings.Contains(tab.View(), "Creating worktree") {
+		t.Error("an ordinary split rendered a worktree-creation message")
+	}
+}

--- a/internal/tui/worktree_tabaway_test.go
+++ b/internal/tui/worktree_tabaway_test.go
@@ -1,0 +1,196 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/artyomsv/quil/internal/ipc"
+	"github.com/artyomsv/quil/internal/plugin"
+)
+
+// worktreeFieldCursor returns the setup-dialog field index of the worktree
+// field, so these tests survive a field being inserted ahead of it.
+func worktreeFieldCursor(t *testing.T, m Model, p *plugin.PanePlugin) int {
+	t.Helper()
+	for i := 0; i < m.setupFieldCount(p); i++ {
+		if kind, _ := m.setupFieldKind(p, i); kind == "worktree" {
+			return i
+		}
+	}
+	t.Fatal("the setup dialog has no worktree field")
+	return -1
+}
+
+// namingViaKeys drives the REAL key path into naming mode with a typed branch:
+// focus the worktree field, Enter on the trailing "+ new branch…" row, then
+// type. Every key goes through handleCreatePaneSetupKey, never through
+// handleSetupWorktreeKey directly — the whole class of bug here is that the
+// dispatcher intercepts keys before the field handler sees them, which a test
+// calling the field handler cannot observe.
+func namingViaKeys(t *testing.T, branch string) (Model, *plugin.PanePlugin) {
+	t.Helper()
+	m := newBranchModel(t)
+	m.client = &fakeSender{}
+	// Loaded through the real TOML loader rather than hand-built, so the
+	// worktree field appears for the same reason it does in production —
+	// prompts_cwd — and not because a struct literal set a flag.
+	dir := t.TempDir()
+	const def = `
+[plugin]
+name = "wt-probe"
+display_name = "WT Probe"
+category = "tools"
+schema_version = 2
+
+[command]
+cmd = "sh"
+prompts_cwd = true
+`
+	if err := os.WriteFile(filepath.Join(dir, "wt-probe.toml"), []byte(def), 0o644); err != nil {
+		t.Fatalf("write plugin: %v", err)
+	}
+	if err := m.pluginRegistry.LoadFromDir(dir); err != nil {
+		t.Fatalf("load plugin: %v", err)
+	}
+	m.selectedPlugin = "wt-probe"
+	p := m.pluginRegistry.Get(m.selectedPlugin)
+	if p == nil {
+		t.Fatal("the probe plugin is not in the registry")
+	}
+	if !p.Command.PromptsCWD {
+		t.Fatal("the probe plugin lost prompts_cwd — the worktree field would not exist")
+	}
+	m.dialog = dialogCreatePaneSetup
+	m.setupFieldCursor = worktreeFieldCursor(t, m, p)
+
+	m.worktreeCursor = worktreeRowIndex(t, m, worktreeNewRowPath)
+
+	updated, _ := m.handleCreatePaneSetupKey(tea.KeyPressMsg{Code: 'x', Text: "enter"})
+	m = updated.(Model)
+	if !m.worktreeNaming {
+		t.Fatal("Enter on the new-branch row did not open the name field")
+	}
+	for _, r := range branch {
+		updated, _ := m.handleCreatePaneSetupKey(tea.KeyPressMsg{Code: r, Text: string(r)})
+		m = updated.(Model)
+	}
+	if m.worktreeNewBranch != branch {
+		t.Fatalf("typing produced %q, want %q", m.worktreeNewBranch, branch)
+	}
+	return m, p
+}
+
+// Tab is handled by handleCreatePaneSetupKey BEFORE the field dispatch, so it
+// never reaches handleWorktreeNameKey — the name field cannot swallow it. This
+// pins the precondition for the bug below; if a future change routes Tab
+// through the field handler, this test says so rather than the next one going
+// quietly vacuous.
+func TestWorktreeNaming_TabLeavesTheFieldWithoutAccepting(t *testing.T) {
+	m, _ := namingViaKeys(t, "feat/x")
+
+	updated, _ := m.handleCreatePaneSetupKey(tea.KeyPressMsg{Text: "tab"})
+	got := updated.(Model)
+
+	if !got.worktreeNaming {
+		t.Error("Tab closed the name field — it is expected to bypass the field handler entirely")
+	}
+	if got.worktreeNewBranch != "feat/x" {
+		t.Errorf("worktreeNewBranch = %q after Tab, want it still held", got.worktreeNewBranch)
+	}
+}
+
+// The reported failure: type a branch, Tab away, press Continue. The dialog
+// still SHOWS "new branch feat/x" (the summary renders whenever the name is
+// non-empty), and submitting must honour what is on screen.
+//
+// Discarding it here is what made a worktree pane spawn in the repository root
+// with no worktree, no git invocation and no error — the exact silent
+// relocation the feature exists to prevent.
+func TestSubmitSetup_KeepsABranchTypedBeforeTabbingAway(t *testing.T) {
+	m, p := namingViaKeys(t, "feat/x")
+
+	updated, _ := m.handleCreatePaneSetupKey(tea.KeyPressMsg{Text: "tab"})
+	m = updated.(Model)
+
+	updated, _ = m.submitSetupDialog(p)
+	got := updated.(Model)
+
+	if got.worktreeNewBranch != "feat/x" {
+		t.Errorf("worktreeNewBranch = %q after Continue, want the typed branch kept", got.worktreeNewBranch)
+	}
+}
+
+// handleWorktreeNameKey documents Esc as "abandons the new-branch row entirely
+// rather than merely closing the input" — but handleCreatePaneSetupKey takes
+// Esc unconditionally, ahead of the field dispatch, so that branch is
+// unreachable from the keyboard and Esc backs out of the WHOLE setup dialog
+// instead. The existing coverage passes only because it calls the field handler
+// directly, which is the one caller production never uses.
+//
+// It matters more now that tabbing away commits the name: backspacing to empty
+// would otherwise be the only way to undo one.
+func TestWorktreeNaming_EscAbandonsTheRowNotTheDialog(t *testing.T) {
+	m, _ := namingViaKeys(t, "feat/x")
+
+	updated, _ := m.handleCreatePaneSetupKey(tea.KeyPressMsg{Text: "esc"})
+	got := updated.(Model)
+
+	if got.dialog != dialogCreatePaneSetup {
+		t.Errorf("Esc left the setup dialog (now %v) — it should abandon the name field only", got.dialog)
+	}
+	if got.worktreeNaming {
+		t.Error("Esc left the name field open")
+	}
+	if got.worktreeNewBranch != "" {
+		t.Errorf("worktreeNewBranch = %q after Esc, want it abandoned", got.worktreeNewBranch)
+	}
+}
+
+// The wire proof. A create whose branch was dropped is indistinguishable on
+// screen from an ordinary create, so the assertion has to be the payload: no
+// spec means the daemon runs its ordinary path and spawns in the browsed
+// directory, which for this fixture is inside the repository.
+func TestCreatePane_SendsTheSpecForABranchTypedBeforeTabbingAway(t *testing.T) {
+	m, p := namingViaKeys(t, "feat/x")
+
+	updated, _ := m.handleCreatePaneSetupKey(tea.KeyPressMsg{Text: "tab"})
+	m = updated.(Model)
+	updated, _ = m.submitSetupDialog(p)
+	m = updated.(Model)
+
+	m.selectedCWD = "/repo/internal/tui"
+	m.dialogCursor = 0 // split horizontally
+	sender := &fakeSender{}
+	m.client = sender
+
+	updated, cmd := m.handleCreatePaneSplit()
+	_ = updated.(Model)
+	runCmd(cmd)
+
+	var payload *ipc.CreatePanePayload
+	for _, msg := range sender.sent {
+		if msg.Type != ipc.MsgCreatePane {
+			continue
+		}
+		var decoded ipc.CreatePanePayload
+		if err := msg.DecodePayload(&decoded); err != nil {
+			t.Fatalf("decode create_pane: %v", err)
+		}
+		payload = &decoded
+	}
+	if payload == nil {
+		t.Fatal("no create_pane was sent")
+	}
+	if payload.Worktree == nil {
+		t.Fatal("create_pane carried no worktree spec — the pane would spawn in the repository root")
+	}
+	if payload.Worktree.Branch != "feat/x" {
+		t.Errorf("spec branch = %q, want %q", payload.Worktree.Branch, "feat/x")
+	}
+	if payload.Worktree.RepoRoot != "/repo" {
+		t.Errorf("spec repo root = %q, want the main checkout %q", payload.Worktree.RepoRoot, "/repo")
+	}
+}


### PR DESCRIPTION
Worktree pane creation had two failures that both ended with the user not getting what the dialog said they would. A four-agent code review then found nine more defects in the fix itself; all are addressed here.

## A typed branch was discarded by pressing Tab

`Tab` moves between setup-dialog fields and is handled by `handleCreatePaneSetupKey` **before** the field dispatch, so it never reaches the branch-name box — leaving `worktreeNaming` set with the name intact. `submitSetupDialog` then cleared it, on the theory that arriving that way meant the user had abandoned the name.

But a blurred field renders `new branch <name>` for any non-empty name, so the dialog displayed the branch right up to the moment Continue dropped it. With no branch the payload carried no worktree spec, and the pane spawned in the browsed directory — the repository root — with no worktree, no `git` invocation and no error. That is the silent relocation the feature exists to prevent.

Two things fell out of tracing it:

- **`Esc` in the name box never did what it documented.** The shared Esc branch returns unconditionally ahead of the field dispatch, so Esc backed out of pane creation entirely. Its existing test passed only because it called the field handler directly — the one caller production never uses.
- **Three paths could close the dialog and create nothing**, one with no message anywhere, while the debug log recorded `sending IPC` *before* deciding whether to send. That line cost a full investigation: the daemon had no `create_pane`, the client insisted it had sent one.

## Replace mode is now supported

Replacing a pane with one in a new worktree was refused in both client and daemon, because the client disposed the old pane **before** the send — so a failed add cost a live pane. That is a property of *when the client disposes*, not of the operation.

- **Daemon:** `worktreeAddAndCreate` creates the worktree before any pane work, then routes through `replacePaneAt`, extracted from `handleReplacePane` so it can report failure instead of logging it.
- **Client:** the detached pane is held in `worktreeReplaced` and restored on failure or timeout.

## A pending create was invisible

`renderNode`'s `IsLeaf()` is `Pane != nil`, so a placeholder fell through to the split arm and rendered the empty string. Once a create can mean `git worktree add` against a large repository that is a black rectangle for its whole duration — **16.3 seconds measured** on a real monorepo — and on the replace path the *entire tab* is blank. `resizeNode` records the placeholder rect and `renderPendingPane` draws a box naming the branch.

`+ new branch…` also moved to the top of the Worktree field, under `off`. It shipped last to spare test fixtures an index shift; the fixtures now look rows up by path.

---

# Review findings (round 1) — all fixed

Four agents in parallel. Three independently found the same critical defect, and one confirmed it with a probe.

| Severity | Finding | Fix |
|---|---|---|
| **Critical** | `worktreeReplaced` leaked permanently when any broadcast landed mid-flight — both settling paths gate on `worktreeCreates`, which `rebuildTabs` cleared | dispose moved to the leaf-fill; `rebuildTabs` skips the held pane |
| **Critical** | that fix exposed a latent panic: `PrunePlaceholders` cannot repair a *root* placeholder, so the root-insert fallback indexed `tab.Leaves()[0]` on an empty slice | guarded |
| High | `renderPendingPane` overflowed its rect — the 18-cell prefix was never budgeted and lipgloss pads rather than truncates (10×4 rendered 10×**5**, 1×4 rendered 1×**18**) | whole line budgeted + `MaxWidth`/`MaxHeight` |
| High | an **ordinary** split's placeholder rendered "Creating worktree…" | empty branch renders blank |
| High | a second create on the same tab overwrote all three tab-keyed maps | refused, with a reason |
| High | the post-add re-check covered the tab but not the replace target → orphaned worktree | re-checked; every abandonment after a successful add now removes the worktree + branch |
| Medium | restore premise false when the spawn failed *after* the swap → restored a dead pane | `CreatePaneRespPayload.Swapped`; `settleReplacedPane` is the single choke point |
| Medium | `TestReplace_WithoutAWorktreeStillDisposesImmediately` was **vacuous** — deleting `old.Dispose()` kept the suite green | asserts the dispose itself |
| Low | `p.TabID` validated but `ReplacePane` resolves ids globally → a mismatched pair destroyed another tab's pane | validated before *and* after the add |

Rules compliance: **0 violations** across both rounds.

The ordering that makes all of this correct is worth stating once: the daemon calls `broadcastState()` and **then** `respondTo`, both must-deliver on one serial reader. So the broadcast that fills the reserved leaf is processed *before* the response — which is why success has to settle there, and why the response handler could never reach its own dispose.

## Testing

`gitworktree.Add` and the daemon's create/replace paths had **only ever run against stubs**, and in production the branch was dropped before the daemon saw a spec — so `git worktree add` had never executed at all. Real-git coverage was added for both, run natively on Windows because the build container has no `git` (a suspicious 10 ms "ok" turned out to be a silent skip):

- sibling placement asserted by path containment rather than string shape
- branch slashes flattened for the directory, preserved for the branch
- duplicate branch refused with no directory left behind
- replace lands in the worktree; a failed add leaves the pane being replaced alive
- `Remove` undoes an add completely, including a dirty worktree

Every review finding has a regression test, and **each was mutation-verified against the code as reviewed**. Two mutations initially reported "still passes" because they had broken the *build* — the harness now checks compilation before trusting a green result. Two tests turned out to pass for the wrong reason and were corrected: one broadcast fixture omitted the tab's surviving panes, and one second-create test was being turned away by the repo-root guard rather than the in-flight guard it existed to pin.

Full suite green, `vet` clean, `docs-size` clean.

### Noted, not fixed here

Running the daemon suite natively surfaced **5 pre-existing Windows-only failures**, all fixtures using Unix paths (`/repo`, `/data/quil`) which `filepath.IsAbs` correctly rejects on Windows. The production code is right on both platforms; this is concrete evidence for `techdebt/3-3-derivepath-windows-shapes-untested.md`, which predicted precisely this.

One review suggestion was dismissed rather than fixed — the timeout's "worktree not created" wording after a success whose pane never landed. It is unreachable as stated now that success settles on the broadcast. Recorded with the reasoning in `.claude/reviews/global/worktree-replace-and-branch-capture.md`.
