### PR TITLE
fix(tui): stop idle nudges from marking working panes blocked

### DIFF
--- a/.claude/rules/hooks-and-sessions.md
+++ b/.claude/rules/hooks-and-sessions.md
@@ -77,27 +77,58 @@ for however long the agent was already back at work.
 **`hook.claude.Notification` is a DIFFERENT `WorkEventKind` (`WorkEventNotify`
 / `workNotify`), not a synonym for `PermissionRequest` — because it is
 AMBIGUOUS in a way `PermissionRequest` is not.** Claude reuses the same hook
-event for two situations with nothing in the payload to tell them apart: a
-permission prompt (arrives mid-turn, `turnActive` still true) and Claude's own
-idle nudge, "Claude is waiting for your input" (arrives AFTER the turn's own
-`Stop` already cleared `turnActive`, often while background subagents are
-still draining). The classifier (`hookevents.ClassifyWorkEvent`) cannot
-resolve the ambiguity — it has no access to `turnActive` — so it hands the
-consumer a distinct kind instead of guessing. `tui.applyWorkTransition`'s
-`workNotify` case is where the guess is made, and it is the only place that
-CAN make it: `turnActive` true → behaves exactly like `workPark`
-(`blockedSince`/`blockedReason` stamped, spinner untouched); `turnActive` false
-→ changes nothing at all, leaving the pane exactly as `Stop` left it (`unseen`
-if nothing was outstanding, still `working` if subagents are). Collapsing both
-into one `WorkEventPark` was the bug: a production pane ran
-`UserPromptSubmit` → 4×`SubagentStart` → `Stop` → `Notification`, and the
-unconditional park painted its tab amber and hid the `◐ ⋯3` a still-working
-pane should show, because `paneRow`'s blocked-outranks-working precedence
-picked the stale `▲` over the live subagent count. The split does not touch
+event for a permission prompt (arrives mid-turn, `turnActive` still true) and
+for its own idle nudge, "Claude is waiting for your input" (arrives AFTER the
+turn's own `Stop` already cleared `turnActive`, often while background
+subagents are still draining). Collapsing both into one `WorkEventPark` was
+the bug: a production pane ran `UserPromptSubmit` → 4×`SubagentStart` →
+`Stop` → `Notification` → `SubagentStop` → `Stop` → `Stop` → `Notification`,
+and the unconditional park painted its tab amber and hid the `◐ ⋯3` a
+still-working pane should show, because `paneRow`'s blocked-outranks-working
+precedence picked the stale `▲` over the live subagent count.
+
+**The ambiguity is resolved at the two ENDS, not by the classifier, and the
+match runs in ONE direction on purpose.** `hookevents.ClassifyWorkEvent` is
+handed the event type and nothing else — neither the hook's `message` text nor
+`turnActive` — so it reports the ambiguity as its own kind. The PRODUCER
+(`internal/claudehook`'s `notifyKindData`) is the one place holding the message
+and marks the idle nudge it recognises as
+`data["notify_kind"]="idle"` (`hookevents.DataNotifyKind`/`NotifyKindIdle`,
+declared next to the kind so the two halves cannot drift apart quietly).
+`tui.applyWorkTransition`'s `workNotify` case then parks **unless** the event
+is marked idle AND `turnActive` is false. Matched positively — idle recognised,
+everything else parked — because upstream English prose is not ours to depend
+on, and the direction decides which way a reworded, unknown, or unmarked
+message fails.
+
+**`turnActive` alone is a LOSSY discriminator, which is why it is the second
+condition and not the only one.** It is false in several states where a
+permission prompt is genuinely outstanding: a background subagent asking for
+permission after the main turn's `Stop` (the subagent ledger exists precisely
+because subagents outlive it), a TUI restart or remote reattach
+(`resetWorkStateForReattach` zeroes it on every pane of a destination), and a
+replay truncated past its `UserPromptSubmit`. `PermissionRequest` is
+documented as "when available" — on the Claude version that produced the trace
+above it never fired at all, so `Notification` was the ONLY permission signal
+and this gate the only guard on it. The failure modes are not symmetric: a
+wrong park is a visible amber tab that the next `Stop` or a keystroke
+(`answerBlockedByInput`) clears, while a missed park is silent and terminal —
+`tabBlocked` false, uncounted in `counts()`, not offered by `Alt+Shift+A`, and
+a parked agent emits no further hook to recover it. So the unmarked case parks,
+which is also what makes an OLD hook binary beside a new TUI safe: it marks
+nothing, and every `Notification` behaves exactly as it did before the split.
+
+Once the mark says idle and the turn is over, the case changes NOTHING —
+leaving the pane exactly as `Stop` left it (`unseen` if nothing was
+outstanding, still `working` if subagents are). Marked idle but mid-turn parks
+anyway; only `Stop`-then-nudge is unambiguous. The split does not touch
 `PermissionRequest`/`permission.ask`, which stay unconditional — they are
 never ambiguous, so gating them on `turnActive` would be a regression, not a
 fix (a permission prompt firing after a pane's own `Stop`, from a hook whose
-event name says exactly what it is, must still block).
+event name says exactly what it is, must still block). Both park arms write
+`blockedReason` only when `data["tool"]` is non-empty: `Notification` carries
+no tool, and an unguarded assignment would erase the `▲ Bash` a
+`PermissionRequest` for the same prompt had just given the sidebar.
 
 Because `working` no longer falls on a park, the falling edge no longer sets
 `unseen`. `tabBlocked` (`workstate.go`) + `blockedTabStyle` carry a parked

--- a/.claude/rules/hooks-and-sessions.md
+++ b/.claude/rules/hooks-and-sessions.md
@@ -67,14 +67,37 @@ Subagent edges: `hook.claude.SubagentStart` adds to the ledger (spinner on), `ho
 
 **`agent_type` is part of the ingester's coalesce key for exactly this reason** (`internal/hookevents/ingest.go` — `coalesceKey(paneID, hook_event, agent_type)`, appended only when non-empty so every other event keys as before). Coalescing is last-wins, so merging two DIFFERENT agents' starts would erase the loser's identity: its own stop would then match nothing while the winner's count never drained, wedging the spinner until `SessionEnd` — the ledger's identity guarantee only holds because the wire preserves it. A burst of the SAME agent still collapses to one emit with the burst count, which is what the count exists for. **The key's two free-form components are escaped** (`keyFieldEscaper`): `paneID` is NUL-free by `safePaneID` and stays first (so `Cancel`'s prefix match is unaffected), but `hook_event` and `agent_type` are arbitrary payload strings and JSON admits U+0000 in either — two variable fields joined by a separator either may contain is not injective, and `("SubagentStart", "\x00X")` would otherwise key identically to `("SubagentStart\x00", "X")`, coalescing them last-wins and erasing an identity. The escape is identity for every value a real producer emits. Claude Code runs subagents detached by default, so the main turn's `Stop` routinely fires while they still run: stop edges only end the spinner once the counter is drained, and the unseen mark is deferred to the drain edge (the LAST `SubagentStop` becomes the completion edge). Stop edges (→ persistent green unseen mark on the pane): `hook.claude.Stop`, `hook.opencode.session.idle`/`session.error`. `hook.claude.SessionEnd` is a *terminal* stop (`WorkEventStopFinal`): it also clears the subagent ledger (no subagent outlives its session — a lost SubagentStop must not wedge the spinner). `TaskCreated`/`TaskCompleted` are deliberately unmapped (task-list bookkeeping, not execution). Resume edge: `hook.claude.PostToolUse` (registered with a tool-name matcher `AskUserQuestion|ExitPlanMode` in `internal/claudehook` so it fires only for interactive-prompt tools — the user just answered → re-arm spinner; `workStart` clears the pane's unseen mark; suppressed from the notification sidebar as work-state-only). `process_exit` clears `working` AND the subagent ledger WITHOUT marking unseen (a crash is not a completed turn). A single shared 100 ms `workSpinnerTickMsg` animates the braille `spinnerFrames` on both the tab label (`tabLabel` prefix when `tabHasWorkingPane`) and each working pane's top-left border (left segment of `buildTopBorder`, reserved so the CWD truncation never eats the glyph); the loop self-stops via `workTickRunning` when no pane is working. `unseen` lives on `PaneModel` (set on workStop unless the pane is the focused pane of the active tab; cleared by `ackFocusedPane` at the single `Update` entry choke point — focusing the pane is the acknowledgement, no timer). Marked panes render a green border (precedence below active/ghost/MCP-highlight); background tabs derive a green label via `tabUnseen` + `unseenTabStyle` — `tabStyle(idx)` precedence is `blockedTabStyle` (amber, includes the active tab: the parked pane may be in an unfocused split) > `unseenTabStyle` (green, covers `tabUnseen` and a pinned-for-attention pane alike) > custom tab color > active/inactive default, and is shared by `renderTabBar` + `hitTestTab` so rendered widths and click hit-testing never diverge. The active tab label never shows green (you're already looking at it); an unfocused split sibling still shows its green border. OpenCode's start edge is produced by the `chat.message` handler in `internal/opencodehook/scripts/quil-session-tracker.js`; Claude needs no producer change (both edges already arrive). State is not persisted — panes start idle on restart and the next hook event corrects them.
 
-Park-for-input edges (`hook.claude.Notification` / `PermissionRequest`,
+Park-for-input edges (`hook.claude.PermissionRequest`,
 `hook.opencode.permission.ask`) set `blockedSince` and do **NOT** clear
-`turnActive`. `Notification` covers two situations — a permission prompt
-(arrives mid-turn) and an idle-wait nudge (arrives after `Stop` already cleared
-`turnActive`) — so clearing it was a no-op exactly when it was right and wrong
-exactly when it was not: approving a Bash/Edit/Write prompt fires no hook of
-its own, so the pane read as blocked-not-working until the turn's `Stop`, for
-however long the agent was already back at work.
+`turnActive` — a permission prompt arrives mid-turn, and approving a
+Bash/Edit/Write prompt fires no hook of its own, so clearing `turnActive` on
+the park left the pane reading blocked-not-working until the turn's `Stop`,
+for however long the agent was already back at work.
+
+**`hook.claude.Notification` is a DIFFERENT `WorkEventKind` (`WorkEventNotify`
+/ `workNotify`), not a synonym for `PermissionRequest` — because it is
+AMBIGUOUS in a way `PermissionRequest` is not.** Claude reuses the same hook
+event for two situations with nothing in the payload to tell them apart: a
+permission prompt (arrives mid-turn, `turnActive` still true) and Claude's own
+idle nudge, "Claude is waiting for your input" (arrives AFTER the turn's own
+`Stop` already cleared `turnActive`, often while background subagents are
+still draining). The classifier (`hookevents.ClassifyWorkEvent`) cannot
+resolve the ambiguity — it has no access to `turnActive` — so it hands the
+consumer a distinct kind instead of guessing. `tui.applyWorkTransition`'s
+`workNotify` case is where the guess is made, and it is the only place that
+CAN make it: `turnActive` true → behaves exactly like `workPark`
+(`blockedSince`/`blockedReason` stamped, spinner untouched); `turnActive` false
+→ changes nothing at all, leaving the pane exactly as `Stop` left it (`unseen`
+if nothing was outstanding, still `working` if subagents are). Collapsing both
+into one `WorkEventPark` was the bug: a production pane ran
+`UserPromptSubmit` → 4×`SubagentStart` → `Stop` → `Notification`, and the
+unconditional park painted its tab amber and hid the `◐ ⋯3` a still-working
+pane should show, because `paneRow`'s blocked-outranks-working precedence
+picked the stale `▲` over the live subagent count. The split does not touch
+`PermissionRequest`/`permission.ask`, which stay unconditional — they are
+never ambiguous, so gating them on `turnActive` would be a regression, not a
+fix (a permission prompt firing after a pane's own `Stop`, from a hook whose
+event name says exactly what it is, must still block).
 
 Because `working` no longer falls on a park, the falling edge no longer sets
 `unseen`. `tabBlocked` (`workstate.go`) + `blockedTabStyle` carry a parked

--- a/.claude/rules/projects.md
+++ b/.claude/rules/projects.md
@@ -503,6 +503,16 @@ load-bearing: the falling edge no longer fires, so a park does not set
 bar. The two must not be separated. See `hooks-and-sessions.md`'s Work state
 section for the hook side of this.
 
+**`Notification` no longer parks unconditionally, so the paragraph above
+describes the `PermissionRequest` path exactly and the `Notification` path only
+in part.** `Notification` is its own kind now (`hookevents.WorkEventNotify` /
+`workNotify`): the claude hook marks the idle nudge it can recognise from the
+message text, and the consumer parks on everything else — so an idle nudge
+arriving after `Stop` sets nothing at all, and a still-working pane keeps its
+`◐ ⋯N` instead of being outranked by a stale `▲`. Every sidebar reader here is
+unchanged; there is simply one fewer event that sets `blockedSince`. See
+`hooks-and-sessions.md`'s Work state section for the split.
+
 **`paneRow` suppresses the blocked glyph for the FOCUSED pane, and that is the
 only place a sidebar row does more than report state.** `blockedSince` is not
 cleared by focus (`ackFocusedPane` clears `unseen` alone — it runs on every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   same notification for a permission prompt and for its own idle nudge, and
   the idle nudge — arriving after the turn already finished — was
   misclassified as a fresh block, hiding the pane's working indicator behind
-  the "needs you" marker.
+  the "needs you" marker. Only Claude's idle nudge is exempted, and only once
+  the turn has ended: any other notification still marks the tab, so a
+  permission prompt is never swallowed.
 
 ## [1.53.0] - 2026-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- A tab was marked amber ("blocked on you") while its agent was still
+  demonstrably working with background subagents running. Claude reuses the
+  same notification for a permission prompt and for its own idle nudge, and
+  the idle nudge — arriving after the turn already finished — was
+  misclassified as a fresh block, hiding the pane's working indicator behind
+  the "needs you" marker.
+
 ## [1.53.0] - 2026-08-09
 
 ### Added

--- a/internal/claudehook/runhook.go
+++ b/internal/claudehook/runhook.go
@@ -121,8 +121,14 @@ func dispatchHookEvent(env HookEnv, in claudeStdin, nowMs int64) error {
 			truncate("Working on: "+preview, hookevents.MaxTitleBytes), hookevents.SeverityInfo,
 			map[string]string{"prompt_preview": preview})
 	case "Notification":
+		// Claude fires this for a permission prompt AND for its own idle
+		// nudge; only the message text tells them apart, and this is the only
+		// place that text is in hand. notifyKindData marks the idle case so
+		// the TUI can leave a still-working pane alone — see its comment for
+		// why the mark is positive.
 		return spoolEvent(env, nowMs, "Notification", in.SessionID,
-			truncate(in.Message, hookevents.MaxTitleBytes), hookevents.SeverityWarning, nil)
+			truncate(in.Message, hookevents.MaxTitleBytes), hookevents.SeverityWarning,
+			notifyKindData(in.Message))
 	case "PermissionRequest":
 		return spoolEvent(env, nowMs, "PermissionRequest", in.SessionID,
 			truncate("Needs approval: "+in.ToolName, hookevents.MaxTitleBytes), hookevents.SeverityWarning,
@@ -238,6 +244,34 @@ func modelUsageData(env HookEnv, transcriptPath string) map[string]string {
 		"model":          truncate(model, hookevents.MaxDataValueBytes),
 		"context_tokens": strconv.FormatInt(tokens, 10),
 	}
+}
+
+// idleNudgePhrase identifies Claude's idle notification, observed verbatim as
+// "Claude is waiting for your input". Matched as a substring, case-folded,
+// because the sentence around it is not ours to depend on.
+const idleNudgePhrase = "waiting for your input"
+
+// notifyKindData marks a Notification the TUI may safely ignore on a pane
+// whose turn is already over: Claude's idle nudge, which fires once the user
+// has been idle at the prompt and reports nothing the agent is waiting for.
+// Every other message — a permission prompt, a rewording, anything new
+// upstream adds — returns nil and is parked by the consumer.
+//
+// Only the idle case is matched, and that direction is the whole point.
+// Recognising upstream English prose is fragile, so the unrecognised message
+// must fall toward the visible amber tab the next Stop clears, never toward a
+// permission prompt that never surfaces at all (a parked agent emits no
+// further hook to recover it). The "permission" exclusion covers the one
+// overlap that is not upstream's wording: the permission message embeds a TOOL
+// NAME, and an MCP server may call its tool anything it likes.
+//
+// Runs in the per-event hook process, so it stays two substring scans.
+func notifyKindData(message string) map[string]string {
+	lower := strings.ToLower(message)
+	if !strings.Contains(lower, idleNudgePhrase) || strings.Contains(lower, "permission") {
+		return nil
+	}
+	return map[string]string{hookevents.DataNotifyKind: hookevents.NotifyKindIdle}
 }
 
 // isPromptTool reports whether tool is an interactive-prompt tool whose

--- a/internal/claudehook/runhook_test.go
+++ b/internal/claudehook/runhook_test.go
@@ -338,6 +338,20 @@ func TestRunHook_AllSpoolBranches(t *testing.T) {
 			hookEvt: "Notification", wantTit: "Claude is waiting", wantSev: "warning",
 		},
 		{
+			// The idle nudge is marked so the TUI can leave a still-working
+			// pane alone; every other Notification stays unmarked and parks.
+			name:    "Notification idle nudge is marked",
+			stdin:   `{"hook_event_name":"Notification","message":"Claude is waiting for your input"}`,
+			hookEvt: "Notification", wantTit: "Claude is waiting for your input", wantSev: "warning",
+			dataKey: "notify_kind", dataWant: "idle",
+		},
+		{
+			name:    "Notification permission prompt is not marked",
+			stdin:   `{"hook_event_name":"Notification","message":"Claude needs your permission to use Bash"}`,
+			hookEvt: "Notification", wantTit: "Claude needs your permission to use Bash", wantSev: "warning",
+			dataKey: "notify_kind", dataWant: "",
+		},
+		{
 			name:    "PermissionRequest",
 			stdin:   `{"hook_event_name":"PermissionRequest","tool_name":"Bash"}`,
 			hookEvt: "PermissionRequest", wantTit: "Needs approval: Bash", wantSev: "warning",
@@ -416,6 +430,47 @@ func TestRunHook_AllSpoolBranches(t *testing.T) {
 			}
 			if tt.dataKey != "" && p.Data[tt.dataKey] != tt.dataWant {
 				t.Errorf("data[%q] = %q, want %q", tt.dataKey, p.Data[tt.dataKey], tt.dataWant)
+			}
+		})
+	}
+}
+
+// TestNotifyKindData_MarksTheIdleNudgeOnly pins the producer half of the
+// Notification split. The match is deliberately one-directional: the idle
+// phrase is recognised positively, and EVERYTHING else — a permission prompt,
+// a future rewording, an empty message — is left unmarked so the consumer
+// parks it. A false "idle" is a permission prompt that never surfaces; a false
+// park is an amber tab the next Stop clears.
+func TestNotifyKindData_MarksTheIdleNudgeOnly(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		message string
+		want    string // "" means "not marked"
+	}{
+		{"observed idle nudge", "Claude is waiting for your input", hookevents.NotifyKindIdle},
+		{"idle nudge, upstream case change", "CLAUDE IS WAITING FOR YOUR INPUT", hookevents.NotifyKindIdle},
+		{"permission prompt", "Claude needs your permission to use Bash", ""},
+		{"unknown future message", "Claude has something else to say", ""},
+		{"empty message", "", ""},
+		// The permission message embeds a tool name, and an MCP server names
+		// its own tools — the idle phrase must not be reachable that way.
+		{"permission prompt for a tool named after the phrase",
+			"Claude needs your permission to use waiting for your input", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := notifyKindData(tt.message)
+			if tt.want == "" {
+				if got != nil {
+					t.Errorf("notifyKindData(%q) = %v, want nil — only the idle nudge is marked", tt.message, got)
+				}
+				return
+			}
+			if got[hookevents.DataNotifyKind] != tt.want {
+				t.Errorf("notifyKindData(%q)[%q] = %q, want %q",
+					tt.message, hookevents.DataNotifyKind, got[hookevents.DataNotifyKind], tt.want)
 			}
 		})
 	}

--- a/internal/hookevents/workstate.go
+++ b/internal/hookevents/workstate.go
@@ -40,20 +40,41 @@ const (
 	// it fires no hook of its own. Park means "this needs you", which is what
 	// the sidebar's ▲ renders.
 	WorkEventPark
-	// WorkEventNotify: the agent MAY be blocked waiting on the user — the
-	// classifier cannot tell, because Claude reuses hook.claude.Notification
-	// for two different situations and only the consumer's turn state
-	// distinguishes them. It fires for a permission prompt (mid-turn, while
-	// turnActive is still true — behaviourally identical to WorkEventPark)
-	// AND for Claude's own idle nudge, "Claude is waiting for your input"
-	// (fired AFTER the turn's own Stop already cleared turnActive, often
-	// while background subagents are still draining). Collapsing both into
-	// WorkEventPark painted a tab's amber "blocked on you" marker while its
-	// agent was demonstrably still working (production sequence: Stop, then
-	// Notification, with 3 SubagentStops still to come). The consumer gates
-	// on turnActive: true behaves exactly like WorkEventPark; false leaves
-	// the pane's state exactly as Stop left it.
+	// WorkEventNotify: the agent MAY be blocked waiting on the user. Claude
+	// reuses hook.claude.Notification for a permission prompt (mid-turn,
+	// while turnActive is still true — behaviourally identical to
+	// WorkEventPark) AND for its own idle nudge, "Claude is waiting for your
+	// input" (fired AFTER the turn's own Stop already cleared turnActive,
+	// often while background subagents are still draining). Collapsing both
+	// into WorkEventPark painted a tab's amber "blocked on you" marker while
+	// its agent was demonstrably still working (production sequence: Stop,
+	// then Notification, with 3 SubagentStops still to come).
+	//
+	// ClassifyWorkEvent cannot tell them apart — it is handed the event TYPE
+	// and nothing else — so the split is resolved by the two ends instead:
+	// the PRODUCER recognises the idle nudge from the hook's message text and
+	// says so in Data[DataNotifyKind], and the consumer parks unless it was
+	// told this is the idle case AND the turn is already over. See
+	// DataNotifyKind for why the mark is positive rather than negative.
 	WorkEventNotify
+)
+
+// DataNotifyKind is the Payload Data key a Notification producer uses to say
+// WHICH of Claude's two notifications a spool line carries, and NotifyKindIdle
+// is the only value it ever holds: the idle "waiting for your input" nudge.
+// Producer: internal/claudehook (notifyKindData). Consumer:
+// internal/tui/workstate.go's workNotify case.
+//
+// The mark is POSITIVE — "this one is the idle nudge" — and its absence means
+// "park", deliberately. Recognising upstream English prose is fragile, so the
+// direction of the match decides which way a reworded, unknown, or unmarked
+// message fails: toward the amber tab the next Stop clears (visible, and what
+// shipped for months), never toward a permission prompt that never surfaces at
+// all. It also makes an OLD hook binary beside a new TUI safe by construction —
+// it marks nothing, so every Notification parks, exactly as it used to.
+const (
+	DataNotifyKind = "notify_kind"
+	NotifyKindIdle = "idle"
 )
 
 // ClassifyWorkEvent maps a composed PaneEvent Type to a work-state transition.
@@ -95,11 +116,13 @@ func ClassifyWorkEvent(eventType string) WorkEventKind {
 	//
 	// hook.claude.Notification is NOT unambiguous: Claude reuses it for both
 	// that mid-turn permission prompt AND an idle-wait nudge fired once the
-	// turn is already over, and nothing in the payload tells them apart — only
-	// turnActive does, which is TUI-side state the classifier here does not
-	// have. It gets its own kind, WorkEventNotify, so the consumer can make
-	// that call instead of the classifier guessing wrong in one direction or
-	// the other. Tagged distinctly from WorkEventStop either way, so the
+	// turn is already over. THIS function cannot tell them apart — it is
+	// handed the event type and nothing else, neither the hook's message text
+	// (which the producer reads) nor turnActive (which the consumer holds).
+	// So it reports the ambiguity as its own kind, WorkEventNotify, and the
+	// two ends resolve it: the producer marks the idle nudge in
+	// Data[DataNotifyKind], the consumer parks whenever that mark is absent.
+	// Tagged distinctly from WorkEventStop either way, so the
 	// sidebar can tell "blocked on you" apart from "turn finished" — a
 	// genuine park no longer sets unseen; tabBlocked + blockedTabStyle carry
 	// it to the tab bar instead.

--- a/internal/hookevents/workstate.go
+++ b/internal/hookevents/workstate.go
@@ -31,14 +31,29 @@ const (
 	WorkEventSubagentStart // a subagent spawned → spinner on
 	WorkEventSubagentStop  // a subagent finished → spinner off once drained AND turn over
 	WorkEventStopFinal     // terminal stop (session end) → also clears the outstanding count
-	// WorkEventPark: the agent is blocked waiting on the USER — a permission
-	// prompt or an idle wait. Distinct from WorkEventStop, which means the turn
+	// WorkEventPark: the agent is blocked waiting on the USER, UNAMBIGUOUSLY —
+	// a permission prompt (hook.claude.PermissionRequest) or opencode's
+	// permission.ask. Distinct from WorkEventStop, which means the turn
 	// finished. Unlike Stop, this does NOT clear the spinner: the consumer
 	// (internal/tui/workstate.go) sets blockedSince without touching
 	// turnActive, because a permission prompt arrives mid-turn and approving
 	// it fires no hook of its own. Park means "this needs you", which is what
 	// the sidebar's ▲ renders.
 	WorkEventPark
+	// WorkEventNotify: the agent MAY be blocked waiting on the user — the
+	// classifier cannot tell, because Claude reuses hook.claude.Notification
+	// for two different situations and only the consumer's turn state
+	// distinguishes them. It fires for a permission prompt (mid-turn, while
+	// turnActive is still true — behaviourally identical to WorkEventPark)
+	// AND for Claude's own idle nudge, "Claude is waiting for your input"
+	// (fired AFTER the turn's own Stop already cleared turnActive, often
+	// while background subagents are still draining). Collapsing both into
+	// WorkEventPark painted a tab's amber "blocked on you" marker while its
+	// agent was demonstrably still working (production sequence: Stop, then
+	// Notification, with 3 SubagentStops still to come). The consumer gates
+	// on turnActive: true behaves exactly like WorkEventPark; false leaves
+	// the pane's state exactly as Stop left it.
+	WorkEventNotify
 )
 
 // ClassifyWorkEvent maps a composed PaneEvent Type to a work-state transition.
@@ -70,23 +85,28 @@ func ClassifyWorkEvent(eventType string) WorkEventKind {
 	case "hook.claude.SubagentStop":
 		return WorkEventSubagentStop
 	// Park-for-input edges: the agent is blocked waiting on the user (permission
-	// prompt, option select, idle-input nudge). The classification here is
-	// unchanged — what changed is the consumer: internal/tui/workstate.go's
+	// prompt, option select, idle-input nudge). internal/tui/workstate.go's
 	// workPark case sets blockedSince WITHOUT clearing turnActive, so a
 	// permission prompt that arrives mid-turn keeps the spinner running across
 	// it (approving a Bash/Edit/Write prompt fires no hook of its own, so the
 	// pane used to read as blocked-not-working until the eventual Stop).
-	// Notification covers both that mid-turn prompt and an idle-wait nudge
-	// (Stop already cleared turnActive by then), which is why one edge handles
-	// both. Tagged distinctly from WorkEventStop so the sidebar can tell
-	// "blocked on you" apart from "turn finished" — a park no longer sets
-	// unseen; tabBlocked + blockedTabStyle carry it to the tab bar instead.
-	// Both Claude (Notification fires for permission + idle-wait;
-	// PermissionRequest when available) and opencode (permission.ask) are
-	// covered.
-	case "hook.claude.Notification", "hook.claude.PermissionRequest",
-		"hook.opencode.permission.ask":
+	// PermissionRequest (Claude, when available) and permission.ask (opencode)
+	// are unambiguous — always a real block — and stay WorkEventPark.
+	//
+	// hook.claude.Notification is NOT unambiguous: Claude reuses it for both
+	// that mid-turn permission prompt AND an idle-wait nudge fired once the
+	// turn is already over, and nothing in the payload tells them apart — only
+	// turnActive does, which is TUI-side state the classifier here does not
+	// have. It gets its own kind, WorkEventNotify, so the consumer can make
+	// that call instead of the classifier guessing wrong in one direction or
+	// the other. Tagged distinctly from WorkEventStop either way, so the
+	// sidebar can tell "blocked on you" apart from "turn finished" — a
+	// genuine park no longer sets unseen; tabBlocked + blockedTabStyle carry
+	// it to the tab bar instead.
+	case "hook.claude.PermissionRequest", "hook.opencode.permission.ask":
 		return WorkEventPark
+	case "hook.claude.Notification":
+		return WorkEventNotify
 	case "process_exit":
 		return WorkEventAbort
 	}

--- a/internal/hookevents/workstate_test.go
+++ b/internal/hookevents/workstate_test.go
@@ -19,7 +19,7 @@ func TestClassifyWorkEvent(t *testing.T) {
 		{"hook.claude.SessionEnd", WorkEventStopFinal},
 		{"hook.opencode.session.idle", WorkEventStop},
 		{"hook.opencode.session.error", WorkEventStop},
-		{"hook.claude.Notification", WorkEventPark},
+		{"hook.claude.Notification", WorkEventNotify},
 		{"hook.claude.PermissionRequest", WorkEventPark},
 		{"hook.opencode.permission.ask", WorkEventPark},
 		{"hook.claude.SubagentStart", WorkEventSubagentStart},
@@ -50,7 +50,6 @@ func TestClassifyWorkEvent(t *testing.T) {
 func TestParkEventsAreDistinctFromStop(t *testing.T) {
 	t.Parallel()
 	for _, evt := range []string{
-		"hook.claude.Notification",
 		"hook.claude.PermissionRequest",
 		"hook.opencode.permission.ask",
 	} {
@@ -60,5 +59,15 @@ func TestParkEventsAreDistinctFromStop(t *testing.T) {
 	}
 	if got := ClassifyWorkEvent("hook.claude.Stop"); got != WorkEventStop {
 		t.Errorf("a turn completing is Stop, not Park: got %v", got)
+	}
+
+	// Notification is ambiguous — Claude fires it for both a permission
+	// prompt (mid-turn) and an idle nudge (after Stop) — so it gets its own
+	// kind rather than collapsing into the unambiguous Park signal. The
+	// consumer (tui.applyWorkTransition) tells the two apart using
+	// turnActive; this classifier only records that the signal is distinct
+	// from both Park and Stop.
+	if got := ClassifyWorkEvent("hook.claude.Notification"); got != WorkEventNotify {
+		t.Errorf("Notification must classify as WorkEventNotify, got %v", got)
 	}
 }

--- a/internal/hookevents/workstate_test.go
+++ b/internal/hookevents/workstate_test.go
@@ -63,10 +63,10 @@ func TestParkEventsAreDistinctFromStop(t *testing.T) {
 
 	// Notification is ambiguous — Claude fires it for both a permission
 	// prompt (mid-turn) and an idle nudge (after Stop) — so it gets its own
-	// kind rather than collapsing into the unambiguous Park signal. The
-	// consumer (tui.applyWorkTransition) tells the two apart using
-	// turnActive; this classifier only records that the signal is distinct
-	// from both Park and Stop.
+	// kind rather than collapsing into the unambiguous Park signal. This
+	// classifier only records that the signal is distinct from both Park and
+	// Stop; the producer marks the idle nudge it recognises (DataNotifyKind)
+	// and tui.applyWorkTransition parks everything else.
 	if got := ClassifyWorkEvent("hook.claude.Notification"); got != WorkEventNotify {
 		t.Errorf("Notification must classify as WorkEventNotify, got %v", got)
 	}

--- a/internal/tui/pane.go
+++ b/internal/tui/pane.go
@@ -108,7 +108,7 @@ type PaneModel struct {
 	unseen             bool           // work finished while this pane was not focused (a park no longer sets this — see workPark); cleared on focus
 	pinnedAttention    bool           // context-menu "Mark attention" pin — green border that SURVIVES focus; cleared only by Unmark. TUI-session state, never persisted
 	workFrame          int            // shared spinner frame index, mirrored here for top-border render
-	blockedSince       time.Time      // set when the agent parks waiting on the user (permission prompt/idle-wait); zero when not blocked. Cleared on workStart/workAbort/workStop/workStopFinal (a completed turn is by definition not blocked) — focus does NOT clear it (see ackFocusedPane); paneRow suppresses the glyph for the focused pane instead
+	blockedSince       time.Time      // set when the agent parks waiting on the user — workPark always, workNotify unless the producer marked the event as Claude's idle nudge AND the turn is already over; zero when not blocked. Cleared on workStart/workAbort/workStop/workStopFinal (a completed turn is by definition not blocked) — focus does NOT clear it (see ackFocusedPane); paneRow suppresses the glyph for the focused pane instead
 	blockedReason      string         // optional tool name from the hook's Data["tool"]; genuinely absent for Notification/permission.ask, so left empty rather than invented
 
 	// Mouse-tracking state, updated by the VT EnableMode/DisableMode callbacks

--- a/internal/tui/workstate.go
+++ b/internal/tui/workstate.go
@@ -163,15 +163,16 @@ func (m *Model) notifyTabSwitch(tab *TabModel) {
 // than from unseen; the two must not be separated.
 //
 // workNotify is the ambiguous twin (see hookevents.WorkEventNotify): Claude's
-// Notification fires for a mid-turn permission prompt (turnActive true —
-// parks exactly like workPark above) AND for its own idle nudge once the
-// turn is already over (turnActive false — Stop already ran its own falling
-// edge, if any). The idle-nudge case changes NOTHING here: no blockedSince,
-// no touch to turnActive, so `working` recomputes to the same value it
-// already had and neither edge below fires. Collapsing the two into workPark
-// painted a tab amber and hid a still-working pane's ◐/⋯N behind ▲ while its
-// background subagents were still draining (production sequence: Stop, then
-// Notification, with 3 SubagentStops still to come).
+// Notification fires for a mid-turn permission prompt AND for its own idle
+// nudge once the turn is already over. Only ONE case is exempted from the
+// park — the nudge the producer positively recognised (Data[DataNotifyKind])
+// arriving with the turn already closed — and it changes NOTHING here: no
+// blockedSince, no touch to turnActive, so `working` recomputes to the same
+// value it already had and neither edge below fires. Everything else parks,
+// including an unmarked Notification from an older hook binary. Parking the
+// idle nudge too painted a tab amber and hid a still-working pane's ◐/⋯N
+// behind ▲ while its background subagents were still draining (production
+// sequence: Stop, then Notification, with 3 SubagentStops still to come).
 //
 // `working` is DERIVED — recomputed at a single point below as
 // turnActive || len(subagents) > 0 || subagentsOverflow — never assigned by
@@ -196,9 +197,14 @@ func (m *Model) notifyTabSwitch(tab *TabModel) {
 //
 // Replay safety: the daemon replays the queued event history on attach, and
 // the ordered replay reconstructs the live state PROVIDED the ledger starts
-// empty. The ring's oldest-first eviction can only ever orphan a
-// SubagentStop (never strand a start behind its stop), and a stop naming no
-// live agent is ignored below.
+// empty. Oldest-first eviction drops START edges, never the stops that follow
+// them, so for the ledger it can only ever orphan a SubagentStop — and a stop
+// naming no live agent is ignored below. The turn has the same exposure with
+// a different owner: an evicted UserPromptSubmit leaves turnActive false under
+// events that assumed it true, which is why workNotify may not rest on
+// turnActive alone. It parks on an ABSENT idle mark whatever the turn state
+// says, so a truncated replay can cost a spinner frame but never a permission
+// prompt.
 //
 // That zero-start premise used to be free: attach happened exactly once per
 // TUI process, guarded by Model.attached. Remote reconnect (RD-011) broke
@@ -329,22 +335,40 @@ func (m *Model) applyWorkTransition(paneID, eventType string, data map[string]st
 		// Data["tool"] is set by the claude hook only for PermissionRequest
 		// and PostToolUse. Notification and opencode's permission.ask may
 		// carry no tool, so the reason is genuinely optional — render a bare
-		// marker rather than inventing one.
-		pane.blockedReason = data["tool"]
+		// marker rather than inventing one. Guarded rather than assigned:
+		// a second park for the SAME prompt that carries no tool must not
+		// erase the name the first one gave the sidebar (▲ Bash → bare ▲).
+		if tool := data["tool"]; tool != "" {
+			pane.blockedReason = tool
+		}
 	case workNotify:
 		// Notification is Claude's idle nudge as well as its permission
-		// prompt, and nothing in the payload tells them apart — only
-		// turnActive can. turnActive true: the turn is still open, so this
-		// IS a permission prompt; treat exactly like workPark above
-		// (blockedSince/blockedReason, spinner and turnActive untouched).
-		// turnActive false: Stop already ended the turn, so this is the idle
-		// nudge alone — leave every field exactly as Stop left it (unseen if
-		// nothing was outstanding, still working if subagents are). Setting
-		// blockedSince unconditionally here was the bug: it painted a tab
-		// amber and hid the ◐ ⋯N a pane with live subagents should show.
-		if pane.turnActive {
+		// prompt. The classifier is handed the event type alone, so the
+		// PRODUCER (internal/claudehook) marks the idle case it can recognise
+		// from the message text, and this is where the two facts meet:
+		//
+		//   - not marked idle → park. An unrecognised, reworded or unmarked
+		//     message (an older hook binary marks nothing) may be a permission
+		//     prompt, and turnActive is a LOSSY discriminator for that — it is
+		//     false for a background subagent's prompt after the main turn's
+		//     Stop, after a reattach zeroed it, and after a replay truncated
+		//     past its UserPromptSubmit. Wrong-on is an amber tab the next
+		//     Stop clears; wrong-off is a prompt that never surfaces and no
+		//     later hook recovers, since a parked agent emits nothing.
+		//   - marked idle AND turnActive → park anyway. Only Stop-then-nudge
+		//     is unambiguous, and keeping the gate is what makes the
+		//     production sequence resolve correctly against a hook binary
+		//     that predates the mark.
+		//   - marked idle, turn already over → change NOTHING. Leave every
+		//     field as Stop left it (unseen if nothing was outstanding, still
+		//     working if subagents are). Stamping blockedSince here was the
+		//     bug: it painted a tab amber and hid the ◐ ⋯N a pane with live
+		//     subagents should show.
+		if data[hookevents.DataNotifyKind] != hookevents.NotifyKindIdle || pane.turnActive {
 			pane.blockedSince = time.Now()
-			pane.blockedReason = data["tool"]
+			if tool := data["tool"]; tool != "" {
+				pane.blockedReason = tool
+			}
 		}
 	case workAbort:
 		pane.turnActive = false

--- a/internal/tui/workstate.go
+++ b/internal/tui/workstate.go
@@ -36,7 +36,8 @@ const (
 	workSubagentStart = hookevents.WorkEventSubagentStart // subagent spawned → spinner on
 	workSubagentStop  = hookevents.WorkEventSubagentStop  // subagent finished → spinner off once drained AND turn over
 	workStopFinal     = hookevents.WorkEventStopFinal     // terminal stop → also clears the outstanding count
-	workPark          = hookevents.WorkEventPark          // agent blocked on the user (permission/idle) → stamps blockedSince/blockedReason; does NOT clear turnActive (see the workPark case)
+	workPark          = hookevents.WorkEventPark          // agent blocked on the user, UNAMBIGUOUSLY (PermissionRequest/permission.ask) → stamps blockedSince/blockedReason; does NOT clear turnActive (see the workPark case)
+	workNotify        = hookevents.WorkEventNotify        // agent blocked on the user, AMBIGUOUSLY (Notification: permission prompt mid-turn OR idle nudge after Stop) → stamps blockedSince only while turnActive is true (see the workNotify case)
 )
 
 // workEventKind maps a PaneEvent Type (the daemon encodes hook events as
@@ -160,6 +161,17 @@ func (m *Model) notifyTabSwitch(tab *TabModel) {
 // not. tabBlocked (read by tabStyle, model.go) is what carries a parked
 // BACKGROUND pane to the tab bar instead, deriving from blockedSince rather
 // than from unseen; the two must not be separated.
+//
+// workNotify is the ambiguous twin (see hookevents.WorkEventNotify): Claude's
+// Notification fires for a mid-turn permission prompt (turnActive true —
+// parks exactly like workPark above) AND for its own idle nudge once the
+// turn is already over (turnActive false — Stop already ran its own falling
+// edge, if any). The idle-nudge case changes NOTHING here: no blockedSince,
+// no touch to turnActive, so `working` recomputes to the same value it
+// already had and neither edge below fires. Collapsing the two into workPark
+// painted a tab amber and hid a still-working pane's ◐/⋯N behind ▲ while its
+// background subagents were still draining (production sequence: Stop, then
+// Notification, with 3 SubagentStops still to come).
 //
 // `working` is DERIVED — recomputed at a single point below as
 // turnActive || len(subagents) > 0 || subagentsOverflow — never assigned by
@@ -319,6 +331,21 @@ func (m *Model) applyWorkTransition(paneID, eventType string, data map[string]st
 		// carry no tool, so the reason is genuinely optional — render a bare
 		// marker rather than inventing one.
 		pane.blockedReason = data["tool"]
+	case workNotify:
+		// Notification is Claude's idle nudge as well as its permission
+		// prompt, and nothing in the payload tells them apart — only
+		// turnActive can. turnActive true: the turn is still open, so this
+		// IS a permission prompt; treat exactly like workPark above
+		// (blockedSince/blockedReason, spinner and turnActive untouched).
+		// turnActive false: Stop already ended the turn, so this is the idle
+		// nudge alone — leave every field exactly as Stop left it (unseen if
+		// nothing was outstanding, still working if subagents are). Setting
+		// blockedSince unconditionally here was the bug: it painted a tab
+		// amber and hid the ◐ ⋯N a pane with live subagents should show.
+		if pane.turnActive {
+			pane.blockedSince = time.Now()
+			pane.blockedReason = data["tool"]
+		}
 	case workAbort:
 		pane.turnActive = false
 		clear(pane.subagents)

--- a/internal/tui/workstate_test.go
+++ b/internal/tui/workstate_test.go
@@ -6,8 +6,18 @@ import (
 	"testing"
 
 	"github.com/artyomsv/quil/internal/config"
+	"github.com/artyomsv/quil/internal/hookevents"
 	"github.com/artyomsv/quil/internal/ipc"
 )
+
+// idleNudge is the Data map the claude hook attaches to Claude's idle
+// "waiting for your input" notification, and only to that one. Every test that
+// replays a real idle nudge uses it, because it is the shape the producer
+// emits — a Notification WITHOUT it is a message the producer did not
+// recognise, which the consumer must treat as a park.
+func idleNudge() map[string]string {
+	return map[string]string{hookevents.DataNotifyKind: hookevents.NotifyKindIdle}
+}
 
 func TestWorkEventKind(t *testing.T) {
 	t.Parallel()
@@ -219,12 +229,13 @@ func TestApplyWorkTransition_ParkSetsBlockedFields(t *testing.T) {
 }
 
 // TestApplyWorkTransition_IdleNudgeAfterStopWithSubagents_ProductionSequence
-// is the exact production sequence that painted a tab amber ("blocked on
-// you") while its agent was demonstrably still working with three background
-// subagents running: UserPromptSubmit, 4×SubagentStart, Stop, then a trailing
-// Notification — Claude's idle nudge, arriving AFTER Stop already cleared
-// turnActive. It must not set blockedSince: the pane is genuinely working,
-// not parked, and the tab must not read as blocked.
+// replays the incident event-for-event: UserPromptSubmit, 4×SubagentStart,
+// Stop, Notification, one SubagentStop, two further Stops, a second
+// Notification. Both Notifications are Claude's idle nudge, arriving after the
+// turn's own Stop already cleared turnActive, and one subagent has drained by
+// the end — so the pane the user was actually looking at should have shown
+// ◐ ⋯3 and instead showed the amber "blocked on you" marker, because the
+// unconditional park outranks a live subagent count in paneRow.
 func TestApplyWorkTransition_IdleNudgeAfterStopWithSubagents_ProductionSequence(t *testing.T) {
 	t.Parallel()
 	m := modelForWorkTest()
@@ -233,17 +244,21 @@ func TestApplyWorkTransition_IdleNudgeAfterStopWithSubagents_ProductionSequence(
 		m.applyWorkTransition("p1", "hook.claude.SubagentStart", map[string]string{"agent_type": agent})
 	}
 	m.applyWorkTransition("p1", "hook.claude.Stop", nil)
-	m.applyWorkTransition("p1", "hook.claude.Notification", nil)
+	m.applyWorkTransition("p1", "hook.claude.Notification", idleNudge())
+	m.applyWorkTransition("p1", "hook.claude.SubagentStop", map[string]string{"agent_type": "agent-a"})
+	m.applyWorkTransition("p1", "hook.claude.Stop", nil)
+	m.applyWorkTransition("p1", "hook.claude.Stop", nil)
+	m.applyWorkTransition("p1", "hook.claude.Notification", idleNudge())
 
 	pane := m.curTabs()[0].Root.Leaves()[0]
 	if !pane.blockedSince.IsZero() {
 		t.Error("an idle nudge after Stop, with subagents outstanding, must not set blockedSince")
 	}
 	if !pane.working {
-		t.Error("pane should still read as working — 4 subagents are outstanding")
+		t.Error("pane should still read as working — 3 subagents are outstanding")
 	}
-	if n := pane.outstandingSubagents(); n != 4 {
-		t.Errorf("outstandingSubagents() = %d, want 4", n)
+	if n := pane.outstandingSubagents(); n != 3 {
+		t.Errorf("outstandingSubagents() = %d, want 3 — 4 spawned, 1 drained", n)
 	}
 	if m.tabBlocked(0) {
 		t.Error("tab must not read as blocked — the pane is genuinely working, not parked")
@@ -282,6 +297,95 @@ func TestApplyWorkTransition_PermissionRequestAfterStop_StillBlocks(t *testing.T
 	}
 }
 
+// TestApplyWorkTransition_UnmarkedNotificationAfterStop_StillBlocks is the case
+// a bare turnActive gate drops SILENTLY, which is why the producer's idle mark
+// exists. turnActive is false in several states where a permission prompt is
+// genuinely outstanding — a background subagent asking for permission after the
+// main turn's Stop, a reattach that zeroed the flag (resetWorkStateForReattach),
+// a replay truncated past its UserPromptSubmit — and on the Claude version that
+// produced this bug's trace, Notification is the ONLY permission signal that
+// fires at all. A Notification the producer did not positively identify as the
+// idle nudge must therefore park regardless of turn state: wrong-on is an amber
+// tab the next Stop clears, wrong-off is a prompt that never surfaces and no
+// later hook recovers, because a parked agent emits nothing.
+func TestApplyWorkTransition_UnmarkedNotificationAfterStop_StillBlocks(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		data       map[string]string
+		wantReason string
+	}{
+		// An older hook binary beside a newer TUI marks nothing at all — it
+		// must keep the behaviour it shipped with rather than lose the park.
+		{"old hook binary sends no data", nil, ""},
+		{"producer recognised nothing", map[string]string{}, ""},
+		{"notify_kind names something else", map[string]string{hookevents.DataNotifyKind: "permission"}, ""},
+		{"carries a tool name", map[string]string{"tool": "Bash"}, "Bash"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			m := modelForWorkTest()
+			m.applyWorkTransition("p1", "hook.claude.UserPromptSubmit", nil)
+			m.applyWorkTransition("p1", "hook.claude.Stop", nil)
+			m.applyWorkTransition("p1", "hook.claude.Notification", tt.data)
+
+			pane := m.curTabs()[0].Root.Leaves()[0]
+			if pane.blockedSince.IsZero() {
+				t.Fatal("a Notification not marked as the idle nudge must block even after Stop")
+			}
+			if pane.blockedReason != tt.wantReason {
+				t.Errorf("blockedReason = %q, want %q", pane.blockedReason, tt.wantReason)
+			}
+			if !m.tabBlocked(0) {
+				t.Error("the tab must read as blocked — the pane may be waiting on a permission prompt")
+			}
+		})
+	}
+}
+
+// TestApplyWorkTransition_IdleMarkedNotificationMidTurn_StillBlocks keeps
+// turnActive as the second condition. The mark alone must not be enough to
+// skip the park while a turn is open: only the sequence Stop-then-Notification
+// makes the nudge unambiguous, and keeping the gate is also what makes the
+// production sequence resolve correctly against a hook binary that predates
+// the mark.
+func TestApplyWorkTransition_IdleMarkedNotificationMidTurn_StillBlocks(t *testing.T) {
+	t.Parallel()
+	m := modelForWorkTest()
+	m.applyWorkTransition("p1", "hook.claude.UserPromptSubmit", nil)
+	m.applyWorkTransition("p1", "hook.claude.Notification", idleNudge())
+
+	pane := m.curTabs()[0].Root.Leaves()[0]
+	if pane.blockedSince.IsZero() {
+		t.Fatal("a Notification arriving mid-turn must block whatever the producer called it")
+	}
+}
+
+// TestApplyWorkTransition_ParkKeepsAToolNameALaterEventLacks guards both park
+// arms against overwriting blockedReason with an empty string. Claude's
+// Notification carries no tool, so a Notification for the same prompt a
+// PermissionRequest already named would otherwise cost the sidebar its
+// "▲ Bash" and leave a bare "▲".
+func TestApplyWorkTransition_ParkKeepsAToolNameALaterEventLacks(t *testing.T) {
+	t.Parallel()
+	m := modelForWorkTest()
+	m.applyWorkTransition("p1", "hook.claude.UserPromptSubmit", nil)
+	m.applyWorkTransition("p1", "hook.claude.PermissionRequest", map[string]string{"tool": "Bash"})
+	pane := m.curTabs()[0].Root.Leaves()[0]
+
+	// The ambiguous arm: same prompt, Claude's Notification, no tool field.
+	m.applyWorkTransition("p1", "hook.claude.Notification", nil)
+	if pane.blockedReason != "Bash" {
+		t.Errorf("after a toolless Notification blockedReason = %q, want %q", pane.blockedReason, "Bash")
+	}
+	// The unambiguous arm carries the same guard.
+	m.applyWorkTransition("p1", "hook.claude.PermissionRequest", nil)
+	if pane.blockedReason != "Bash" {
+		t.Errorf("after a toolless park blockedReason = %q, want %q", pane.blockedReason, "Bash")
+	}
+}
+
 // TestApplyWorkTransition_IdleNudgeAfterStopNoSubagents_LeavesUnseenMark
 // covers the idle nudge with nothing outstanding: the pane must stay exactly
 // as Stop left it (unseen, not blocked, not working).
@@ -295,7 +399,7 @@ func TestApplyWorkTransition_IdleNudgeAfterStopNoSubagents_LeavesUnseenMark(t *t
 		t.Fatal("precondition: Stop with nothing outstanding should mark the background pane unseen")
 	}
 
-	m.applyWorkTransition("p2", "hook.claude.Notification", nil)
+	m.applyWorkTransition("p2", "hook.claude.Notification", idleNudge())
 	if !pane.blockedSince.IsZero() {
 		t.Error("an idle nudge after Stop with nothing outstanding must not set blockedSince")
 	}
@@ -361,36 +465,45 @@ func TestTurnCompletionClearsTheBlockedMark(t *testing.T) {
 	}
 }
 
-// TestWorkPark_PermissionPromptKeepsTurnActive pins item 1. Claude fires no
+// TestWorkNotify_PermissionPromptKeepsTurnActive pins item 1. Claude fires no
 // hook when the user APPROVES a Bash/Edit/Write prompt — the pane's next
 // event is the turn's Stop — so a park that cleared turnActive left the pane
 // reading "blocked" for the entire time the agent was actually working.
 //
+// It is named for workNotify, not workPark: the event it drives is
+// Notification, which is workNotify's job now. (workPark's own coverage is
+// TestWorkPark_SetsBlockedRegardlessOfTurnState and
+// TestApplyWorkTransition_PermissionRequestAfterStop_StillBlocks.)
 // Notification covers two situations and the distinction is the whole fix:
-// a permission prompt arrives mid-turn (turnActive true), an idle-wait nudge
-// arrives after Stop already cleared it (turnActive false).
-func TestWorkPark_PermissionPromptKeepsTurnActive(t *testing.T) {
+// a permission prompt arrives mid-turn (turnActive true), an idle nudge
+// arrives after Stop already cleared it, carrying the producer's idle mark.
+func TestWorkNotify_PermissionPromptKeepsTurnActive(t *testing.T) {
 	t.Parallel()
 	const (
-		start = "hook.claude.UserPromptSubmit"
-		park  = "hook.claude.Notification"
-		stop  = "hook.claude.Stop"
+		start  = "hook.claude.UserPromptSubmit"
+		notify = "hook.claude.Notification"
+		stop   = "hook.claude.Stop"
 	)
 	tests := []struct {
 		name        string
 		events      []string
+		notifyData  map[string]string // Data on the notify event only
 		wantWorking bool
 	}{
-		{"permission park mid-turn", []string{start, park}, true},
-		{"idle-wait park after stop", []string{start, stop, park}, false},
-		{"stop after a park ends the turn", []string{start, park, stop}, false},
+		{"permission prompt mid-turn", []string{start, notify}, nil, true},
+		{"idle nudge after stop", []string{start, stop, notify}, idleNudge(), false},
+		{"stop after a park ends the turn", []string{start, notify, stop}, nil, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			m := newTestModelWithTabs(t, 1, 1)
 			pane := m.curTabs()[0].Leaves()[0]
 			for _, ev := range tt.events {
-				m.applyWorkTransition(pane.ID, ev, nil)
+				var data map[string]string
+				if ev == notify {
+					data = tt.notifyData
+				}
+				m.applyWorkTransition(pane.ID, ev, data)
 			}
 			if pane.working != tt.wantWorking {
 				t.Errorf("working = %v, want %v", pane.working, tt.wantWorking)
@@ -857,13 +970,13 @@ func TestApplyWorkTransition_ProductionPhantomSequence_KeepsSpinnerLit(t *testin
 	m.applyWorkTransition("p2", "hook.claude.SubagentStop", phantom)
 	m.applyWorkTransition("p2", "hook.claude.Stop", nil)
 	m.applyWorkTransition("p2", "hook.claude.SubagentStop", phantom)
-	m.applyWorkTransition("p2", "hook.claude.Notification", nil)
+	m.applyWorkTransition("p2", "hook.claude.Notification", idleNudge())
 	// Several further turns run to completion while impl-task7 keeps working.
 	for i := 0; i < 3; i++ {
 		m.applyWorkTransition("p2", "hook.claude.UserPromptSubmit", nil)
 		m.applyWorkTransition("p2", "hook.claude.Stop", nil)
 		m.applyWorkTransition("p2", "hook.claude.SubagentStop", phantom)
-		m.applyWorkTransition("p2", "hook.claude.Notification", nil)
+		m.applyWorkTransition("p2", "hook.claude.Notification", idleNudge())
 	}
 
 	if !pane.working {
@@ -1476,15 +1589,18 @@ func TestHandleNotificationKey_Navigate_FailedJumpDoesNotGrowHistory(t *testing.
 // rather than `blockedSince` for this particular history.
 func TestApplyWorkTransition_ReplayOrderDecidesTheFinalState(t *testing.T) {
 	t.Parallel()
-	history := []string{
-		"hook.claude.PostToolUse",  // resumed after AskUserQuestion
-		"hook.claude.Stop",         // reply ready
-		"hook.claude.Notification", // idle nudge — turnActive already false
+	history := []struct {
+		evt  string
+		data map[string]string
+	}{
+		{evt: "hook.claude.PostToolUse"},                     // resumed after AskUserQuestion
+		{evt: "hook.claude.Stop"},                            // reply ready
+		{evt: "hook.claude.Notification", data: idleNudge()}, // idle nudge — turnActive already false
 	}
 
 	forwards := modelForWorkTest()
-	for _, evt := range history {
-		forwards.applyWorkTransition("p1", evt, nil)
+	for _, e := range history {
+		forwards.applyWorkTransition("p1", e.evt, e.data)
 	}
 	pane := forwards.curTabs()[0].Root.Leaves()[0]
 	if pane.working {
@@ -1496,14 +1612,15 @@ func TestApplyWorkTransition_ReplayOrderDecidesTheFinalState(t *testing.T) {
 
 	// The failing direction, asserted so the daemon-side ordering fix has a
 	// stated reason to exist rather than looking like a cosmetic reversal.
+	// `working` is the discriminating field here — blockedSince is zero in
+	// both directions now that the idle nudge parks nothing.
 	backwards := modelForWorkTest()
 	for i := len(history) - 1; i >= 0; i-- {
-		backwards.applyWorkTransition("p1", history[i], nil)
+		backwards.applyWorkTransition("p1", history[i].evt, history[i].data)
 	}
-	if got := backwards.curTabs()[0].Root.Leaves()[0]; !got.working || !got.blockedSince.IsZero() {
-		t.Errorf("reverse replay produced working=%v blocked=%v; the bug this "+
-			"pins is that it reports working with nothing to justify it — if this "+
-			"changed, the daemon's replay order may no longer be load-bearing",
-			got.working, !got.blockedSince.IsZero())
+	if got := backwards.curTabs()[0].Root.Leaves()[0]; !got.working {
+		t.Errorf("reverse replay produced working=%v; the bug this pins is that it "+
+			"reports working with nothing to justify it — if this changed, the "+
+			"daemon's replay order may no longer be load-bearing", got.working)
 	}
 }

--- a/internal/tui/workstate_test.go
+++ b/internal/tui/workstate_test.go
@@ -29,7 +29,10 @@ func TestWorkEventKind(t *testing.T) {
 		// from a completed turn. Unlike workStop, this does NOT by itself stop
 		// the spinner: a permission prompt commonly arrives mid-turn, and the
 		// pane keeps working until the turn's own Stop (see TestWorkPark_*).
-		{"hook.claude.Notification", workPark},
+		// Notification is the ambiguous twin of Park (see TestWorkNotify_*):
+		// Claude reuses it for both a mid-turn prompt and an idle nudge fired
+		// after the turn already ended, so it gets its own kind.
+		{"hook.claude.Notification", workNotify},
 		{"hook.claude.PermissionRequest", workPark},
 		{"hook.opencode.permission.ask", workPark},
 		// Subagent lifecycle: background subagents outlive the main turn's
@@ -212,6 +215,95 @@ func TestApplyWorkTransition_ParkSetsBlockedFields(t *testing.T) {
 	}
 	if pane2.blockedReason != "" {
 		t.Errorf("blockedReason = %q, want empty — Notification carries no tool", pane2.blockedReason)
+	}
+}
+
+// TestApplyWorkTransition_IdleNudgeAfterStopWithSubagents_ProductionSequence
+// is the exact production sequence that painted a tab amber ("blocked on
+// you") while its agent was demonstrably still working with three background
+// subagents running: UserPromptSubmit, 4×SubagentStart, Stop, then a trailing
+// Notification — Claude's idle nudge, arriving AFTER Stop already cleared
+// turnActive. It must not set blockedSince: the pane is genuinely working,
+// not parked, and the tab must not read as blocked.
+func TestApplyWorkTransition_IdleNudgeAfterStopWithSubagents_ProductionSequence(t *testing.T) {
+	t.Parallel()
+	m := modelForWorkTest()
+	m.applyWorkTransition("p1", "hook.claude.UserPromptSubmit", nil)
+	for _, agent := range []string{"agent-a", "agent-b", "agent-c", "agent-d"} {
+		m.applyWorkTransition("p1", "hook.claude.SubagentStart", map[string]string{"agent_type": agent})
+	}
+	m.applyWorkTransition("p1", "hook.claude.Stop", nil)
+	m.applyWorkTransition("p1", "hook.claude.Notification", nil)
+
+	pane := m.curTabs()[0].Root.Leaves()[0]
+	if !pane.blockedSince.IsZero() {
+		t.Error("an idle nudge after Stop, with subagents outstanding, must not set blockedSince")
+	}
+	if !pane.working {
+		t.Error("pane should still read as working — 4 subagents are outstanding")
+	}
+	if n := pane.outstandingSubagents(); n != 4 {
+		t.Errorf("outstandingSubagents() = %d, want 4", n)
+	}
+	if m.tabBlocked(0) {
+		t.Error("tab must not read as blocked — the pane is genuinely working, not parked")
+	}
+}
+
+// TestApplyWorkTransition_NotificationMidTurn_StillBlocks is the case that
+// must NOT regress: a Notification arriving mid-turn (turnActive true, no
+// Stop yet) is a genuine permission prompt and must still block.
+func TestApplyWorkTransition_NotificationMidTurn_StillBlocks(t *testing.T) {
+	t.Parallel()
+	m := modelForWorkTest()
+	m.applyWorkTransition("p1", "hook.claude.UserPromptSubmit", nil)
+	m.applyWorkTransition("p1", "hook.claude.Notification", nil)
+
+	pane := m.curTabs()[0].Root.Leaves()[0]
+	if pane.blockedSince.IsZero() {
+		t.Fatal("a Notification arriving mid-turn (turnActive true) must set blockedSince")
+	}
+}
+
+// TestApplyWorkTransition_PermissionRequestAfterStop_StillBlocks pins that
+// only the AMBIGUOUS Notification signal is gated on turnActive.
+// PermissionRequest is unambiguous and must set blockedSince regardless of
+// turn state.
+func TestApplyWorkTransition_PermissionRequestAfterStop_StillBlocks(t *testing.T) {
+	t.Parallel()
+	m := modelForWorkTest()
+	m.applyWorkTransition("p1", "hook.claude.UserPromptSubmit", nil)
+	m.applyWorkTransition("p1", "hook.claude.Stop", nil)
+	m.applyWorkTransition("p1", "hook.claude.PermissionRequest", map[string]string{"tool": "Bash"})
+
+	pane := m.curTabs()[0].Root.Leaves()[0]
+	if pane.blockedSince.IsZero() {
+		t.Fatal("PermissionRequest must set blockedSince even after turnActive is false — it is not gated")
+	}
+}
+
+// TestApplyWorkTransition_IdleNudgeAfterStopNoSubagents_LeavesUnseenMark
+// covers the idle nudge with nothing outstanding: the pane must stay exactly
+// as Stop left it (unseen, not blocked, not working).
+func TestApplyWorkTransition_IdleNudgeAfterStopNoSubagents_LeavesUnseenMark(t *testing.T) {
+	t.Parallel()
+	m := modelWithBackgroundTab()
+	m.applyWorkTransition("p2", "hook.claude.UserPromptSubmit", nil)
+	m.applyWorkTransition("p2", "hook.claude.Stop", nil)
+	pane := m.curTabs()[1].Root.Leaves()[0]
+	if !pane.unseen {
+		t.Fatal("precondition: Stop with nothing outstanding should mark the background pane unseen")
+	}
+
+	m.applyWorkTransition("p2", "hook.claude.Notification", nil)
+	if !pane.blockedSince.IsZero() {
+		t.Error("an idle nudge after Stop with nothing outstanding must not set blockedSince")
+	}
+	if !pane.unseen {
+		t.Error("the unseen mark Stop set must survive the trailing idle nudge")
+	}
+	if pane.working {
+		t.Error("pane must not read as working")
 	}
 }
 
@@ -1372,16 +1464,22 @@ func TestHandleNotificationKey_Navigate_FailedJumpDoesNotGrowHistory(t *testing.
 // history backwards reports the state implied by its oldest event.
 //
 // The sequence below is the one logged for pane-fa75ba78 on 2026-08-03: a turn
-// resumed, replied, then parked waiting for the user. Played forwards the pane
-// is blocked, which is where it really was. Played backwards it is working,
-// which is what the user saw after restarting the TUI — a spinner with nothing
-// behind it.
+// resumed, replied, then a Notification fired. It was originally read as "then
+// parked waiting for the user" — but under the Notification/Park split (this
+// package's workNotify, see hookevents.WorkEventNotify) that reading was
+// exactly the bug the split exists to fix: the turn's own Stop had already run
+// (turnActive false) before Notification arrived, so this is Claude's idle
+// nudge, not a fresh park, and chronological replay now correctly leaves the
+// pane unblocked — the same state Stop alone left it in. Reversed, PostToolUse
+// lands LAST and opens a turn nothing after it closes, which is still the
+// wrong answer: order remains load-bearing, it now just decides `working`
+// rather than `blockedSince` for this particular history.
 func TestApplyWorkTransition_ReplayOrderDecidesTheFinalState(t *testing.T) {
 	t.Parallel()
 	history := []string{
-		"hook.claude.PostToolUse",   // resumed after AskUserQuestion
-		"hook.claude.Stop",          // reply ready
-		"hook.claude.Notification",  // parked: waiting for input
+		"hook.claude.PostToolUse",  // resumed after AskUserQuestion
+		"hook.claude.Stop",         // reply ready
+		"hook.claude.Notification", // idle nudge — turnActive already false
 	}
 
 	forwards := modelForWorkTest()
@@ -1390,10 +1488,10 @@ func TestApplyWorkTransition_ReplayOrderDecidesTheFinalState(t *testing.T) {
 	}
 	pane := forwards.curTabs()[0].Root.Leaves()[0]
 	if pane.working {
-		t.Error("chronological replay left the pane working; its last event was a park")
+		t.Error("chronological replay left the pane working; its last event was a completed turn")
 	}
-	if pane.blockedSince.IsZero() {
-		t.Error("chronological replay did not mark the pane blocked")
+	if !pane.blockedSince.IsZero() {
+		t.Error("chronological replay marked the pane blocked; the turn had already ended when Notification fired")
 	}
 
 	// The failing direction, asserted so the daemon-side ordering fix has a
@@ -1404,8 +1502,8 @@ func TestApplyWorkTransition_ReplayOrderDecidesTheFinalState(t *testing.T) {
 	}
 	if got := backwards.curTabs()[0].Root.Leaves()[0]; !got.working || !got.blockedSince.IsZero() {
 		t.Errorf("reverse replay produced working=%v blocked=%v; the bug this "+
-			"pins is that it reports working with no park — if this changed, the "+
-			"daemon's replay order may no longer be load-bearing",
+			"pins is that it reports working with nothing to justify it — if this "+
+			"changed, the daemon's replay order may no longer be load-bearing",
 			got.working, !got.blockedSince.IsZero())
 	}
 }


### PR DESCRIPTION
## Summary

A tab was painted amber ("blocked on you") while its agent was still working with three background subagents running. Reported from a live v1.53.0 session; the pane's own hook spool shows why:

```
UserPromptSubmit          → turn starts
SubagentStart ×4          → 4 background agents
Stop            "Reply ready"
Notification    "Claude is waiting for your input"   ← sets blockedSince
SubagentStop    "cr-rules done"                       → 3 remain
Stop, Stop      "Reply ready"
Notification    "Claude is waiting for your input"   ← re-sets it
```

That `Notification` is Claude's **idle nudge** — its own message says so — arriving *after* `Stop`, while subagents still run. `ClassifyWorkEvent` mapped every `Notification` to `WorkEventPark`, so `blockedSince` was set; `tabBlocked` then painted the tab amber and `paneRow`'s blocked-outranks-working precedence hid the `◐ ⋯3` the row should have shown.

**Root cause:** `Notification` is ambiguous. Claude fires it both for a permission prompt and for an idle nudge, and the classifier collapsed both into one kind.

## The fix

The hook already knows which is which — `runhook.go` decodes Claude's `message` field and forwards it as the event Title. So the disambiguation happens at the **producer**, where the information exists, and the consumer defaults to the safe answer:

- **Producer** (`internal/claudehook/runhook.go`): positively identifies the idle nudge from the message and marks it with `data[hookevents.DataNotifyKind] = NotifyKindIdle`. Nothing is emitted for a message it does not recognise.
- **Classifier** (`internal/hookevents/workstate.go`): `hook.claude.Notification` becomes `WorkEventNotify`. `PermissionRequest` and opencode `permission.ask` stay `WorkEventPark` — unambiguous, always a real block.
- **Consumer** (`internal/tui/workstate.go`): parks **unless** the event is positively marked idle *and* the turn is inactive.

**The direction of the match is the point.** Matching upstream English prose is fragile, so the idle phrase is matched positively and everything unrecognised is treated as a park. If Claude rewords the nudge, the regression is the old visible amber tab — not a permission prompt that never surfaces. The `turnActive` condition is retained as the second gate so the sequence above still resolves correctly against an older hook binary that doesn't yet emit the marker (mixed-version daemon/TUI, and the `off`/`verbose` hook-mode paths).

| Situation | Before | After |
|---|---|---|
| Permission prompt mid-turn | `▲` blocked | `▲` blocked (unchanged) |
| `PermissionRequest` after `Stop` | `▲` blocked | `▲` blocked (unchanged — unambiguous) |
| Idle nudge after `Stop`, subagents outstanding | `▲` blocked, **tab amber** | `◐ ⋯N` working, tab clean |
| Idle nudge after `Stop`, nothing outstanding | `▲` blocked | `✓` unseen (what `Stop` set) |
| Unrecognised `Notification` message, any turn state | `▲` blocked | `▲` blocked (safe default) |

The wrong state predates #137 — what #137 added was `tabBlocked`, which made it loud: an idle nudge now repainted the whole tab.

## Review history

The first iteration gated purely on `turnActive`. Both the security and code-quality reviewers independently found that this trades a **visible, self-clearing false positive** for a **silent, terminal false negative**: `turnActive` is false whenever a background subagent raises a prompt after the main turn's `Stop`, after a reattach (`resetWorkStateForReattach` zeroes it), or when ring eviction drops the start edge — and a parked agent emits no further hook to recover the mark. Notably the production trace contains no `PermissionRequest` at all, so on that Claude version `Notification` is the sole permission signal and that gate was the only guard on it. Hence the producer-side marker and the park-by-default.

Ten findings were fixed in the follow-up commits, including two rule files left contradicting each other and a replay-safety comment that understated eviction risk once a second edge began depending on a preceding start edge.

## Test plan

- `./scripts/dev.sh test` — 28/28 packages
- `./scripts/dev.sh vet` — clean
- `./scripts/dev.sh docs-size` — within limits

New tests, RED before GREEN, covering both directions of the gap:

1. The full production incident replayed, including the `SubagentStop` — not blocked, still working, `tabBlocked` false.
2. `Notification` mid-turn still blocks (must not regress).
3. `PermissionRequest` after `Stop` still blocks (unambiguous signal stays ungated).
4. A `Notification` whose message is **not** the idle phrasing, with `turnActive` false → blocks. This is the case the first iteration silently dropped.
5. A `Notification` carrying **no marker at all** (older producer) → blocks. Pins mixed-version safety.
6. Producer-side classification in `runhook.go`, plus the `ClassifyWorkEvent` table.

Manual, against a dev build (confirm `[dev]` in the status bar):

1. Let an agent's main turn finish while background subagents run, then leave the pane until Claude's "waiting for your input" nudge fires. Expect `◐ ⋯N` and no amber tab.
2. Trigger a real Bash permission prompt mid-turn — expect `▲` and an amber tab exactly as today.
