### PR TITLE
feat(remote): offer the remote upgrade instead of parking the host

### DIFF
--- a/.claude/rules/projects.md
+++ b/.claude/rules/projects.md
@@ -359,12 +359,31 @@ downgrades a machine other clients may share and does not fix this session
 either. Both sentinels share `installOffer`, `installedDests` and the retry
 dial; the once-per-host guard covers the upgrade for its own reason, since a
 daemon still reporting the old version after one did not restart and pushing
-the same archive again cannot change that. The LAUNCH path deliberately does
-not act on the sentinel — a background destination is dropped with a log line,
-because installing software on another machine must not be a side effect of
-opening the client. Shipped as the raw gate message plus `run quil remote
-setup <host>`: the machinery to fix it had existed since the auto-install
-work and was reachable only from `--remote`.
+the same archive again cannot change that.
+
+**The launch and reconnect paths ASK; only the New Project dialog acts without
+asking.** "Installing software on another machine must not be a side effect of
+opening the client" is the right rule and it was read one step too far: it
+argues against provisioning unprompted, not against offering. So for a year the
+two paths a RESTART goes through — the launch dial and the reconnect ladder —
+each classified the mismatch, seeded a parked row, and stopped. The user got ⚡
+and a `Detail` string nothing rendered, and the remedy lived in a shell command
+the tool already knew how to run. The reconnect arm even carried the comment
+"let the sidebar offer the upgrade instead", describing an affordance that was
+never built.
+
+`enqueueUpgradePrompt`/`promptNextUpgrade` (`offline.go`) close it with a
+`confirmKindUpgradeDest` dialog. A QUEUE, because a client update leaves every
+configured host stale at once and one dialog shows at a time; deduped, because
+the launch dial and the ladder can classify the same host. It drains from the
+FIRST-`WindowSizeMsg` branch — that arm returns early, so the later drain never
+runs on an unresized session, the same trap `wakeOfflineDests` documents — and
+again whenever a dialog closes, so an offer deferred behind the disclaimer or
+the plugin migration arrives rather than being dropped. `y` is required, not
+Enter: this dialog opens BY ITSELF, so a reflexive Enter would restart a remote
+daemon and kill what its panes were running. Declining does NOT arm
+`installedDests` — "not now" is not "never" — while accepting does, sharing the
+dialog's guard against the install/retry/same-error loop.
 
 **The RECONNECT ladder has the same config constraint as the dial, and got it
 later.** `SetRedialFactory` captured the value while `SetDialFunc` beside it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **A remote host running an older Quil now offers to upgrade itself.** After
+  updating this client, a configured host still on the previous version cannot
+  be attached to — client and daemon must match. Quil showed that as a parked
+  row with a lightning bolt and nothing else, and the only way forward was
+  `quil remote setup <host>` in a shell. It now asks, at startup and whenever a
+  live link drifts out of version, and performs the same push itself when you
+  press `y`. It says which versions are involved and that the remote daemon
+  restarts, since panes there respawn.
+
 ## [1.54.1] - 2026-08-11
 
 ### Fixed

--- a/internal/tui/dialog.go
+++ b/internal/tui/dialog.go
@@ -358,6 +358,19 @@ const confirmKindApplyUpdate = "apply-update"
 // confirmDestroyProject in projectdialog.go.
 const confirmKindDestroyProject = "destroy-project"
 
+// confirmKindUpgradeDest is the discriminator on confirmKind for the
+// "this host runs an older quil" prompt. confirmID carries the DEST.
+//
+// The offer itself is not new — installOffer and installDest have handled both
+// ErrRemoteQuilMissing and ErrRemoteVersionMismatch since the runtime-connect
+// work. What was missing is an entry point for the two paths a RESTART goes
+// through: the launch dial and the reconnect ladder both classified the
+// mismatch, seeded an offline row, and stopped. The launch path is right not to
+// install unprompted — that would make provisioning another machine a side
+// effect of opening the client — but a prompt is not a side effect, and without
+// one the user got a parked row and no way to act on it inside the tool.
+const confirmKindUpgradeDest = "upgrade-dest"
+
 func shortcutsList(m *Model) []struct{ key, desc string } {
 	kb := m.cfg.Keybindings
 	// kbDisplay renders comma-separated multi-bindings as "a / b" so the
@@ -765,6 +778,15 @@ func (m Model) handleConfirmKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.dialog = dialogNone
+		if m.confirmKind == confirmKindUpgradeDest {
+			// Declining leaves the host parked — the row keeps saying what is
+			// wrong — and does NOT mark it installed, so a later reconnect may
+			// ask again. What it must not do is swallow the rest of the queue:
+			// a client update leaves every configured host stale at once, and
+			// dismissing the first would otherwise hide the others entirely.
+			m.confirmDetail = ""
+			m.promptNextUpgrade()
+		}
 		return m, nil
 	case "enter", "y":
 		kind := m.confirmKind
@@ -777,6 +799,34 @@ func (m Model) handleConfirmKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		// keystroke a user does not press accidentally.
 		if kind == confirmKindShutdown && msg.String() != "y" {
 			return m, nil
+		}
+
+		// Upgrade a host: the same push `quil remote setup` performs, run from
+		// inside the tool so the user never leaves it for a shell.
+		//
+		// Requires explicit `y` for the reason shutdown does, and more so here:
+		// this dialog opens BY ITSELF at launch, so it can be on screen when
+		// the user's hands are already moving. Enter is the universal commit
+		// key, and accepting it would let one reflex restart a remote daemon and
+		// kill whatever was running in its panes.
+		if kind == confirmKindUpgradeDest {
+			if msg.String() != "y" {
+				return m, nil
+			}
+			m.dialog = dialogNone
+			m.confirmDetail = ""
+			// The once-per-host guard is shared with the New Project dialog's
+			// offer: a daemon still reporting the old version after an upgrade
+			// did not restart, and pushing the same archive again cannot change
+			// that — install, retry, same error, install.
+			if m.installedDests == nil {
+				m.installedDests = map[string]bool{}
+			}
+			m.installedDests[id] = true
+			if p := m.projectForDest(id); p != nil && p.Offline != nil {
+				p.Offline.Detail = "upgrading — the daemon on that host restarts…"
+			}
+			return m, m.installDest(id)
 		}
 
 		// Stop-daemon: fire MsgShutdown and quit the TUI. The daemon's
@@ -1331,6 +1381,28 @@ func (m Model) renderConfirmDialog() string {
 		b.WriteString("  " + dialogNormal.Render(fmt.Sprintf("Destroy project %q?", sanitizeRemoteText(m.confirmName))))
 		b.WriteString("\n\n")
 		b.WriteString("  " + dialogSubtle.Render("Every tab and pane in this project is destroyed too."))
+	case confirmKindUpgradeDest:
+		b.WriteString("  " + dialogNormal.Render(fmt.Sprintf("Upgrade quil on %s?", sanitizeRemoteText(m.confirmName))))
+		b.WriteString("\n\n")
+		// The version pair comes from the daemon's own handshake and is the
+		// answer to "why can I not reach it" — the reason the row parked. It is
+		// remote-influenced text, so it is sanitized AND bounded at render like
+		// every other value from a host the user may not control.
+		if d := m.confirmDetail; d != "" {
+			b.WriteString("  " + dialogSubtle.Render(truncateToWidth(sanitizeRemoteText(d), confirmDetailCap)))
+			b.WriteString("\n\n")
+		}
+		b.WriteString("  " + dialogSubtle.Render("Quil pushes this build over ssh."))
+		b.WriteString("\n")
+		// Named explicitly because an upgrade is not free the way a first
+		// install is: the push stops the remote daemon, so panes over there
+		// respawn and whatever was running in their shells is killed. The CLI
+		// says the same before asking; this is the same warning in the place
+		// the user is actually being asked.
+		b.WriteString("  " + dialogSubtle.Render("Its daemon RESTARTS: panes there respawn and"))
+		b.WriteString("\n")
+		b.WriteString("  " + dialogSubtle.Render("anything running in their shells is killed."))
+		footer = "y upgrade    Esc not now"
 	case confirmKindDisconnectHost:
 		b.WriteString("  " + dialogNormal.Render(fmt.Sprintf("Disconnect %q?", sanitizeRemoteText(m.confirmName))))
 		b.WriteString("\n\n")

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -404,6 +404,8 @@ type Model struct {
 	confirmKind          string                 // "pane" or "tab"
 	confirmID            string                 // ID of pane/tab to delete
 	confirmName          string                 // display name for confirmation
+	confirmDetail        string                 // extra remote-sourced line (upgrade confirm); sanitized+bounded at render
+	upgradeQueue         []upgradePrompt        // hosts waiting to be ASKED about provisioning; see enqueueUpgradePrompt
 	devMode              bool                   // true when QUIL_HOME is set
 	pluginRegistry       *plugin.Registry       // plugin registry (shared with daemon)
 	lastWidth            int                    // last known window width (for persistence)
@@ -994,6 +996,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// launch never redials until the user actually resizes the window.
 			// This branch runs exactly once, unconditionally, which is what a
 			// launch-time wake-up needs.
+			// The launch drain, on THIS branch for the same reason
+			// wakeOfflineDests is here: it runs exactly once, unconditionally,
+			// and an unresized session never reaches the subsequent-resize code
+			// below — so a host stale at launch would never be offered.
+			//
+			// A STATEMENT, not an operand of the return: promptNextUpgrade has
+			// a pointer receiver and mutates dialog state, and Go says nothing
+			// about the order of a plain `m` against calls in the same
+			// statement. The same hazard the ledger comment above documents.
+			m.promptNextUpgrade()
 			resize, attach, wake := m.resizeAllPanes(), m.attachAllDests(), m.wakeOfflineDests()
 			return m, tea.Batch(resize, attach, wake)
 		}
@@ -1016,6 +1028,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.height = msg.Height
 			return m, attach
 		}
+		// The launch path's drain point. SeedOfflineDest runs before the
+		// program starts, so the queue it fills has to be opened from inside
+		// Update — and a WindowSizeMsg always arrives, which makes this the one
+		// arm guaranteed to run on every startup. A no-op once the queue is
+		// empty, and gated on dialogNone so it never displaces a dialog the
+		// user is already answering.
+		m.promptNextUpgrade()
 
 		// Debounce subsequent resizes
 		seq := m.resizeSeq
@@ -1125,6 +1144,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			ls := m.linkFor(msg.dest)
 			ls.active, ls.parked = false, false
+			// The offer this comment used to promise. Until now "let the
+			// sidebar offer the upgrade instead" described nothing: the sidebar
+			// had no such affordance, so a link that drifted out of version
+			// mid-session went quiet with no way to act on it in the tool.
+			m.enqueueUpgradePrompt(msg.dest, msg.err.Error())
+			m.promptNextUpgrade()
 			return m, nil
 		}
 		// msg.client == nil with no error is not a success. A dialer returning

--- a/internal/tui/offline.go
+++ b/internal/tui/offline.go
@@ -52,6 +52,66 @@ type OfflineState struct {
 // ceremony; production never reassigns it.
 var offlineNow = time.Now
 
+// confirmDetailCap bounds the version pair on the upgrade confirm. The string
+// is built from what the far side reported, and sanitizing does not shorten —
+// the same pairing every other remote-influenced render in this package makes.
+const confirmDetailCap = 60
+
+// enqueueUpgradePrompt records a destination whose only remedy is provisioning,
+// so the user can be ASKED rather than left with a parked row.
+//
+// A queue rather than a flag: several configured hosts can be stale at once
+// after a client update, and one confirm dialog is on screen at a time. Deduped
+// because both the launch dial and the reconnect ladder can classify the same
+// destination, and asking twice about one host reads as the first answer having
+// been ignored.
+//
+// installedDests is consulted here as well as at the point of action: a host
+// already provisioned this session that STILL reports a mismatch did not
+// restart its daemon, and pushing the same archive again cannot change that —
+// the loop that guard exists to break is install, retry, same error, install.
+func (m *Model) enqueueUpgradePrompt(dest, detail string) {
+	if dest == "" || m.installDestFn == nil || m.installedDests[dest] {
+		return
+	}
+	for _, q := range m.upgradeQueue {
+		if q.dest == dest {
+			return
+		}
+	}
+	m.upgradeQueue = append(m.upgradeQueue, upgradePrompt{dest: dest, detail: detail})
+}
+
+// upgradePrompt is one queued ask: which host, and the version pair to show.
+type upgradePrompt struct{ dest, detail string }
+
+// promptNextUpgrade opens the confirm for the next queued host, if the screen
+// is free to show it.
+//
+// Gated on dialogNone so it cannot displace the disclaimer or the plugin
+// migration at startup — both of which the user is already answering, and the
+// migration deliberately blocks until resolved. Every dialog dismissal calls
+// this again, so a deferred prompt arrives as soon as the screen is free
+// rather than being dropped.
+func (m *Model) promptNextUpgrade() {
+	if m.dialog != dialogNone || len(m.upgradeQueue) == 0 {
+		return
+	}
+	next := m.upgradeQueue[0]
+	m.upgradeQueue = m.upgradeQueue[1:]
+	// The destination may have been disconnected, or provisioned through the
+	// New Project dialog, between queueing and now.
+	if m.installedDests[next.dest] || m.projectForDest(next.dest) == nil {
+		m.promptNextUpgrade()
+		return
+	}
+	m.dialog = dialogConfirm
+	m.confirmKind = confirmKindUpgradeDest
+	m.confirmID = next.dest
+	m.confirmName = next.dest
+	m.confirmDetail = next.detail
+}
+
 // SeedOfflineDest installs (or replaces) the stand-in rows for one destination.
 //
 // Called from the launch path for a destination whose dial failed, and again
@@ -75,6 +135,14 @@ func (m *Model) SeedOfflineDest(dest, label string, kind OfflineKind, detail str
 	}
 
 	state := &OfflineState{Kind: kind, Detail: detail, Since: offlineNow()}
+
+	// Queue the ask for a host whose only remedy is provisioning. Queued rather
+	// than opened here because SeedOfflineDest runs BEFORE tea.Program starts —
+	// and because the disclaimer or the plugin migration may own the screen at
+	// that point. promptNextUpgrade drains it once the screen is free.
+	if kind == offlineNeedsInstall || kind == offlineNeedsUpgrade {
+		m.enqueueUpgradePrompt(dest, detail)
+	}
 
 	rows := make([]*ProjectModel, 0, len(cached))
 	for _, c := range cached {

--- a/internal/tui/upgrade_prompt_test.go
+++ b/internal/tui/upgrade_prompt_test.go
@@ -1,0 +1,235 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// The agreement these tests pin: a remote running an OLDER quil than this
+// client must be OFFERED an upgrade inside the tool. The machinery existed
+// (installOffer, installDest, the once-per-host guard) but only the New Project
+// dialog reached it, so the two paths a restart goes through — the launch dial
+// and the reconnect ladder — left the user a parked row and a shell command.
+
+// upgradeModel returns a model wired with an install seam that records the
+// hosts it was asked to provision.
+func upgradeModel(t *testing.T) (Model, *[]string) {
+	t.Helper()
+	m := *newSplitDragTestModel(t)
+	m.width, m.height = 120, 44
+	var installed []string
+	m.SetInstallFunc(func(dest string) error {
+		installed = append(installed, dest)
+		return nil
+	})
+	return m, &installed
+}
+
+const mismatchDetail = "artyom@host runs 1.54.0, this client runs 1.54.1; run `quil remote setup artyom@host`"
+
+// The launch path. SeedOfflineDest runs before the program starts, so the ask
+// has to survive until Update can show it — a WindowSizeMsg always arrives.
+func TestUpgradePrompt_LaunchSeedRaisesTheConfirm(t *testing.T) {
+	m, _ := upgradeModel(t)
+	m.SeedOfflineDest("artyom@host", "artyom@host", OfflineNeedsUpgrade, mismatchDetail, nil)
+
+	if m.dialog == dialogConfirm {
+		t.Fatal("the confirm opened at seed time — the program has not started yet")
+	}
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 44})
+	got := updated.(Model)
+
+	if got.dialog != dialogConfirm || got.confirmKind != confirmKindUpgradeDest {
+		t.Fatalf("no upgrade confirm after launch: dialog=%v kind=%q", got.dialog, got.confirmKind)
+	}
+	if got.confirmID != "artyom@host" {
+		t.Errorf("confirmID = %q, want the destination", got.confirmID)
+	}
+	if !strings.Contains(got.confirmDetail, "1.54.0") {
+		t.Errorf("the confirm does not carry the version pair: %q", got.confirmDetail)
+	}
+}
+
+// The rendered dialog has to say what is wrong and what it costs — the whole
+// complaint was a lightning bolt with no explanation.
+func TestUpgradePrompt_ConfirmExplainsItself(t *testing.T) {
+	m, _ := upgradeModel(t)
+	m.SeedOfflineDest("artyom@host", "artyom@host", OfflineNeedsUpgrade, mismatchDetail, nil)
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 44})
+	out := updated.(Model).renderConfirmDialog()
+
+	for _, want := range []string{"Upgrade quil on", "artyom@host", "1.54.0", "RESTARTS", "y upgrade"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("the confirm does not mention %q:\n%s", want, out)
+		}
+	}
+}
+
+// `y` runs the same push `quil remote setup` does — no shell required.
+func TestUpgradePrompt_YRunsTheInstall(t *testing.T) {
+	m, installed := upgradeModel(t)
+	m.SeedOfflineDest("artyom@host", "artyom@host", OfflineNeedsUpgrade, mismatchDetail, nil)
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 44})
+	m = updated.(Model)
+
+	updated, cmd := m.Update(tea.KeyPressMsg{Code: 'y', Text: "y"})
+	got := updated.(Model)
+	if cmd == nil {
+		t.Fatal("accepting the upgrade produced no command")
+	}
+	runCmd(cmd)
+
+	if len(*installed) != 1 || (*installed)[0] != "artyom@host" {
+		t.Errorf("install ran for %v, want [artyom@host]", *installed)
+	}
+	if got.dialog != dialogNone {
+		t.Error("the confirm stayed open after accepting")
+	}
+	if !got.installedDests["artyom@host"] {
+		t.Error("the once-per-host guard was not armed — a daemon that fails to restart would loop")
+	}
+}
+
+// Enter must NOT accept. This dialog opens by itself at launch, so a reflexive
+// Enter would restart a remote daemon and kill whatever its panes were running.
+func TestUpgradePrompt_EnterDoesNotAccept(t *testing.T) {
+	m, installed := upgradeModel(t)
+	m.SeedOfflineDest("artyom@host", "artyom@host", OfflineNeedsUpgrade, mismatchDetail, nil)
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 44})
+	m = updated.(Model)
+
+	updated, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter, Text: "enter"})
+	if cmd != nil {
+		runCmd(cmd)
+	}
+	if len(*installed) != 0 {
+		t.Errorf("Enter provisioned %v — only `y` may accept", *installed)
+	}
+	if updated.(Model).dialog != dialogConfirm {
+		t.Error("Enter closed the confirm")
+	}
+}
+
+// A client update leaves EVERY configured host stale at once. Dismissing the
+// first must not hide the rest.
+func TestUpgradePrompt_QueueDrainsAcrossHosts(t *testing.T) {
+	m, _ := upgradeModel(t)
+	m.SeedOfflineDest("a@one", "a@one", OfflineNeedsUpgrade, mismatchDetail, nil)
+	m.SeedOfflineDest("b@two", "b@two", OfflineNeedsUpgrade, mismatchDetail, nil)
+
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 44})
+	m = updated.(Model)
+	if m.confirmID != "a@one" {
+		t.Fatalf("first prompt is for %q, want a@one", m.confirmID)
+	}
+
+	updated, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEscape, Text: "esc"})
+	got := updated.(Model)
+	if got.dialog != dialogConfirm || got.confirmID != "b@two" {
+		t.Errorf("after declining the first, dialog=%v id=%q — want the second host offered", got.dialog, got.confirmID)
+	}
+}
+
+// Declining must not mark the host installed: the user said "not now", not
+// "never", and a later reconnect is entitled to ask again.
+func TestUpgradePrompt_DecliningDoesNotArmTheGuard(t *testing.T) {
+	m, _ := upgradeModel(t)
+	m.SeedOfflineDest("artyom@host", "artyom@host", OfflineNeedsUpgrade, mismatchDetail, nil)
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 44})
+	m = updated.(Model)
+
+	updated, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEscape, Text: "esc"})
+	if updated.(Model).installedDests["artyom@host"] {
+		t.Error("declining armed the once-per-host guard — the host could never be offered again")
+	}
+}
+
+// The reconnect ladder's own comment promised this and delivered nothing: a
+// link that drifts out of version mid-session must raise the same offer.
+func TestUpgradePrompt_ReconnectMismatchRaisesTheConfirm(t *testing.T) {
+	m, _ := upgradeModel(t)
+	m.SeedOfflineDest("artyom@host", "artyom@host", OfflineRetrying, "unreachable", nil)
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 44})
+	m = updated.(Model)
+	if m.dialog != dialogNone {
+		t.Fatalf("fixture opened a dialog for a merely-unreachable host: %v", m.dialog)
+	}
+
+	// The arm drops a result for a superseded generation or an inactive link,
+	// so the ladder has to be genuinely mid-attempt for this to be reached —
+	// which is the only state a real mismatch can arrive in.
+	ls := m.linkFor("artyom@host")
+	ls.active = true
+	updated, _ = m.Update(redialResultMsg{
+		dest: "artyom@host",
+		gen:  ls.gen,
+		err:  fmt.Errorf("dial: %w", ErrRemoteVersionMismatch),
+	})
+	got := updated.(Model)
+
+	if got.dialog != dialogConfirm || got.confirmKind != confirmKindUpgradeDest {
+		t.Errorf("a mid-session version drift raised no offer: dialog=%v kind=%q", got.dialog, got.confirmKind)
+	}
+}
+
+// A merely-unreachable host must NOT be offered an upgrade — it enters the
+// reconnect ladder and heals itself. Offering to reinstall over a flaky link
+// would be the confidently-wrong answer this feature exists to remove.
+func TestUpgradePrompt_RetryingHostIsNotOffered(t *testing.T) {
+	m, _ := upgradeModel(t)
+	m.SeedOfflineDest("artyom@host", "artyom@host", OfflineRetrying, "ssh: connect: no route to host", nil)
+
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 44})
+	if got := updated.(Model); got.dialog == dialogConfirm {
+		t.Errorf("an unreachable host was offered an upgrade: %q", got.confirmID)
+	}
+}
+
+// Without a provisioner there is nothing to offer, and a dialog whose only
+// action cannot run is worse than the parked row.
+func TestUpgradePrompt_NoInstallFuncRaisesNothing(t *testing.T) {
+	m := *newSplitDragTestModel(t)
+	m.width, m.height = 120, 44
+	m.SeedOfflineDest("artyom@host", "artyom@host", OfflineNeedsUpgrade, mismatchDetail, nil)
+
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 44})
+	if updated.(Model).dialog == dialogConfirm {
+		t.Error("an upgrade was offered with no provisioner wired")
+	}
+}
+
+// The startup disclaimer and the plugin migration are dialogs the user is
+// already answering; the migration deliberately blocks until resolved. The
+// offer waits rather than displacing them.
+func TestUpgradePrompt_WaitsForAStartupDialog(t *testing.T) {
+	m, _ := upgradeModel(t)
+	m.dialog = dialogDisclaimer
+	m.SeedOfflineDest("artyom@host", "artyom@host", OfflineNeedsUpgrade, mismatchDetail, nil)
+
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 44})
+	m = updated.(Model)
+	if m.dialog != dialogDisclaimer {
+		t.Fatalf("the upgrade offer displaced the disclaimer: %v", m.dialog)
+	}
+	// And it is not lost — closing the disclaimer surfaces it.
+	if len(m.upgradeQueue) != 1 {
+		t.Errorf("the queued offer was dropped: %+v", m.upgradeQueue)
+	}
+}
+
+// A host already provisioned this session that still reports a mismatch did not
+// restart its daemon; pushing the same archive again cannot change that. The
+// guard is shared with the New Project dialog's offer for exactly this loop.
+func TestUpgradePrompt_AlreadyInstalledHostIsNotOfferedAgain(t *testing.T) {
+	m, _ := upgradeModel(t)
+	m.installedDests = map[string]bool{"artyom@host": true}
+	m.SeedOfflineDest("artyom@host", "artyom@host", OfflineNeedsUpgrade, mismatchDetail, nil)
+
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 44})
+	if got := updated.(Model); got.dialog == dialogConfirm {
+		t.Error("a host provisioned this session was offered again — install, retry, same error, install")
+	}
+}


### PR DESCRIPTION
## What you see today

Update the client, restart, and a configured remote parks with ⚡ and nothing else:

```
PROJECTS
  artyom@192.168.6.12                    ⚡
```

Measured on a real host: client **1.54.1**, remote **1.54.0**. ssh is fine, the remote `quild` is running. `gateExtraVersion` refuses any version difference — client and daemon must speak the same protocol or not talk at all — so the row parks and stays parked, because `OfflineNeedsUpgrade` deliberately never enters the reconnect ladder.

The only way forward was `quil remote setup <host>` in a shell.

## The offer already existed

`installOffer` has handled `ErrRemoteVersionMismatch` since the runtime-connect work, `installDest` performs the push, `installedDests` guards the install→retry→same-error loop. **One entry point reached them**: `model.go`'s `destDialedMsg` arm, gated on `msg.dest == m.projectFormDialing` — the New Project dialog's Host row.

Neither path a restart goes through did:

- **Launch** (`dialall.go:113`) classifies to `OfflineNeedsUpgrade`, seeds an offline row, returns.
- **Reconnect** (`model.go:1139`) sets the kind and comments *"let the sidebar offer the upgrade instead."* The sidebar had no such affordance.

And `OfflineState.Detail` — which carries the version pair **and** the remedy — had exactly one reference in the package: the line that writes it.

The rationale on the launch path is *"installing software on another machine must not be a side effect of opening the client."* That is right, and was read one step too far: it argues against provisioning **unprompted**, not against **asking**.

## What this adds

Both paths now raise a confirm:

```
┌─ Confirm ──────────────────────────────────────┐
│  Upgrade quil on artyom@192.168.6.12?          │
│                                                │
│  runs 1.54.0, this client runs 1.54.1          │
│                                                │
│  Quil pushes this build over ssh.              │
│  Its daemon RESTARTS: panes there respawn and  │
│  anything running in their shells is killed.   │
│                                                │
│  y upgrade    Esc not now                      │
└────────────────────────────────────────────────┘
```

`y` runs the same push `quil remote setup` does.

Design points, each with a test:

- **A queue, not a flag.** A client update leaves every configured host stale at once and one dialog shows at a time. Deduped, because the launch dial and the ladder can classify the same host — asking twice reads as the first answer having been ignored.
- **Drained from the FIRST `WindowSizeMsg`.** That branch returns early, so the later drain never runs on a session nobody resizes — the same trap `wakeOfflineDests` documents, and the reason my first attempt failed its own test.
- **Drained again when a dialog closes**, so an offer deferred behind the disclaimer or the plugin migration arrives rather than being dropped.
- **`y`, not Enter.** This dialog opens *by itself*, so a reflexive Enter would restart a remote daemon and kill what its panes were running. Same reasoning as the stop-daemon confirm, with more force.
- **Declining does not arm the guard** — "not now" is not "never", and a later reconnect may ask again. Accepting does arm it, sharing the New Project dialog's protection against a daemon that fails to restart.
- **A merely-unreachable host is never offered** — it enters the ladder and heals itself.

## Testing

11 tests driving the real paths through `Update`: launch seed → confirm, the rendered dialog naming versions and the restart, `y` running the install, Enter refusing, the queue draining across hosts, declining not arming the guard, reconnect drift raising the offer, retrying hosts *not* offered, no-provisioner raising nothing, waiting behind a startup dialog, and an already-provisioned host not re-offered.

Mutation-verified: removing the launch drain, the seed enqueue, or the `y`-only guard each fails its own test, with a compile check first so a broken mutation cannot read as a pass.

Full suite green, `vet` clean, `docs-size` clean. `.claude/rules/projects.md` updated — it documented the old launch behaviour as deliberate.
