### PR TITLE
fix(release): allow the Windows-only helper's uneven binary count

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -80,6 +80,20 @@ archives:
       # tarballs are unchanged. Naming it here is what puts it in the Windows
       # zip BESIDE quil.exe, which is where `quil notify setup` looks for it.
       - quil-activate
+    # Required BECAUSE of the line above, and releases were broken for two
+    # versions without it. quil-activate is windows/amd64 only, so this archive
+    # holds three binaries on Windows and two everywhere else — and goreleaser
+    # treats an uneven count as a mistake by default ("may cause your users
+    # confusion") and refuses to build ANY archive, failing the whole release
+    # at the archives step, after the binaries have already cross-compiled.
+    #
+    # The failure is invisible from the release job: the bump/tag half runs
+    # first and succeeds, so master gets a version bump, a CHANGELOG section
+    # and a tag, and only the publish half dies. v1.56.0 and v1.57.0 are both
+    # tagged with no GitHub Release behind them, which is why `quil update` and
+    # scripts/install.sh — which read the releases API, not tags — kept
+    # offering v1.55.2.
+    allow_different_binary_count: true
     name_template: "quil_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     formats:
       - tar.gz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Releases publish again.** Since v1.56.0 the release pipeline tagged a new
+  version and then failed before publishing anything, so `quil update` and the
+  install script — which read published releases, not tags — kept offering
+  v1.55.2 while the repository claimed two newer versions. The cause was the
+  Windows-only click-handler added alongside desktop notifications: it shares
+  one archive definition with `quil` and `quild`, so that archive holds three
+  binaries on Windows and two elsewhere, and the packaging step rejects an
+  uneven count unless it is told the difference is deliberate. v1.56.0 and
+  v1.57.0 remain tagged without a published release; this version carries
+  their contents.
+
 ## [1.57.0] - 2026-08-14
 
 ### Added


### PR DESCRIPTION
## The symptom

Releases have not published since **v1.56.0**. `VERSION` on master says `1.57.0`, tags `v1.56.0` and `v1.57.0` both exist — and neither has a GitHub Release behind it. The newest published release is `v1.55.2`.

Because `quil update` and `scripts/install.sh` read the **releases API rather than tags**, every user has been offered v1.55.2 since desktop notifications landed. Two versions of work (the toasts, and the hunk integration) are tagged and invisible.

## The cause

`cmd/quil-activate` — the windowless toast click-handler added in #154 — is built for `windows/amd64` only, but is listed in the single shared archive alongside `quil` and `quild`. That archive therefore holds **three** binaries on Windows and **two** on every other platform, and GoReleaser refuses that by default:

```
invalid archive: 0: archive has different count of binaries for each platform,
which may cause your users confusion.
```

The config's comment predicted the opposite:

> *"Present in every archive, including the Unix ones, where it builds to nothing: goreleaser simply has no artifact for those platforms, so the tarballs are unchanged."*

The tarballs *are* unchanged — that part was right. What was missed is that GoReleaser treats the uneven count itself as an error and refuses to build **any** archive, so the release dies at the archives step after all five platforms have already cross-compiled.

`allow_different_binary_count: true` is the documented opt-in for exactly this shape.

## Why it looked like nothing was wrong

The pipeline's two halves fail independently. The `release` job runs first and succeeds — it bumps the version, writes the CHANGELOG section, commits, and tags. Only the `goreleaser` job dies. So master looks released: new version, new tag, new changelog entry, and no download.

## Verification

- **`goreleaser check` is not evidence here** — I ran it against the *broken* config and it reported `1 configuration file(s) validated`. The conflict only materializes when the archives step compares real artifact lists.
- Ran a full `goreleaser release --snapshot` instead. The archives step — the one that was failing — now completes, and the contents are what the original design intended:
  - `quil_..._windows_amd64.zip` → `quil.exe`, `quild.exe`, **`quil-activate.exe`** (beside `quil.exe`, which is where `quil notify setup` looks for it)
  - `quil_..._linux_amd64.tar.gz` / `..._darwin_arm64.tar.gz` → `quil`, `quild` — unchanged, no stray artifact

## About the two stranded tags

They cannot be recovered with the workflow's `publish_tag` input: that path checks out `ref: v<version>`, which carries the same broken config, so it would fail identically. They stay tagged without releases. Merging this cuts the next version, which ships their content — the CHANGELOG entry says so, since otherwise the gap in the download list is unexplainable from the outside.

## Note on the PR title

`fix(release):` is deliberate — it drives the squash subject, and `.goreleaser.yml` is inside the release gate's "reaches the binary" denylist, so this will itself cut and publish a release. That is the point: the fix has to ship to prove itself.
