### PR TITLE
fix(daemon): copy tabs out of SnapshotState so callers cannot race

### DIFF
--- a/changelog.d/fixed-snapshotstate-tab-race.md
+++ b/changelog.d/fixed-snapshotstate-tab-race.md
@@ -1,0 +1,13 @@
+---
+headline: Two clients attaching at once can no longer race the daemon
+---
+- **The daemon no longer races itself when two clients attach at the same moment.**
+  `SnapshotState` promises callers a consistent view of the session taken under one lock,
+  and delivered that for projects but not for tabs — those came back as live pointers, so
+  anything reading a tab's pane list after the lock was released raced a concurrent pane
+  creation.
+
+  Each connection is dispatched on its own goroutine, so two clients attaching together was
+  enough to hit it: one builds the default workspace while the other builds the workspace
+  state it is about to be sent. Tabs are now copied on the way out, exactly as projects
+  already were.

--- a/internal/daemon/session.go
+++ b/internal/daemon/session.go
@@ -711,7 +711,27 @@ func (sm *SessionManager) SnapshotState() (activeTab string, tabs []*Tab, panesB
 
 	for _, id := range sm.tabOrder {
 		tab := sm.tabs[id]
-		tabs = append(tabs, tab)
+		// COPY, for the same reason the projects loop below copies — and this
+		// one was missing it, which made the doc comment above a promise this
+		// function did not keep.
+		//
+		// Returning the live *Tab lets every caller read tab.Panes AFTER the
+		// unlock (workspaceStateFromSnapshot, snapshot, search, the memory
+		// report, list_tabs all do), racing any concurrent CreatePane doing
+		// `tab.Panes = append(...)`. Two clients attaching at once is enough:
+		// each conn dispatches on its own goroutine, so one attach builds the
+		// default workspace while the other builds workspace state. Caught by
+		// CI's race detector, reproduced by
+		// TestSnapshotState_TabPanesDoNotRaceConcurrentCreatePane.
+		//
+		// Panes and Layout are the reference fields; Layout is an opaque
+		// json.RawMessage that handleUpdateLayout REPLACES rather than edits in
+		// place, so aliasing it is safe, but it is copied anyway so the
+		// returned Tab shares nothing at all.
+		cp := *tab
+		cp.Panes = append([]string(nil), tab.Panes...)
+		cp.Layout = append(json.RawMessage(nil), tab.Layout...)
+		tabs = append(tabs, &cp)
 
 		tabPanes := make([]*Pane, 0, len(tab.Panes))
 		for _, pid := range tab.Panes {

--- a/internal/daemon/snapshotstate_race_test.go
+++ b/internal/daemon/snapshotstate_race_test.go
@@ -1,0 +1,62 @@
+package daemon
+
+import (
+	"sync"
+	"testing"
+)
+
+// SnapshotState promises "a consistent view of the entire session state under a
+// single RLock hold... prevents torn reads when tabs/panes are created or
+// destroyed concurrently". It delivers that for projects — which are DEEP
+// COPIED, with a comment saying why — and not for tabs, which are returned as
+// live *Tab pointers.
+//
+// So every caller that reads tab.Panes after the unlock (workspaceStateFromSnapshot,
+// snapshot, search, the memory report, list_tabs) races any concurrent
+// CreatePane doing `tab.Panes = append(...)`. Two clients attaching at once is
+// enough, because each conn is dispatched on its own goroutine: one attach
+// creates the default workspace while the other builds workspace state.
+//
+// Caught by CI's race detector on the release build of #167, from
+// TestHandleSubscribe_DispatchArmStopsPaneOutputForThatClientOnly attaching two
+// clients — the first test in the package to do so concurrently. A local
+// `go test -race ./...` had passed: the window is narrow enough that it needs
+// load to hit, which is exactly why this reproducer drives it deliberately
+// rather than relying on an incidental one.
+//
+// Run under -race, this fails without the fix.
+func TestSnapshotState_TabPanesDoNotRaceConcurrentCreatePane(t *testing.T) {
+	sm := NewSessionManager(1024)
+	tab := sm.CreateTab("race")
+
+	const rounds = 200
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Writer: the CreatePane path an attach takes when it builds the default
+	// workspace.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < rounds; i++ {
+			if _, err := sm.CreatePane(tab.ID, ""); err != nil {
+				return
+			}
+		}
+	}()
+
+	// Reader: what every SnapshotState consumer does with the tabs it gets
+	// back — read tab.Panes AFTER the lock has been released.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < rounds; i++ {
+			_, tabs, _, _, _ := sm.SnapshotState()
+			for _, tb := range tabs {
+				for _, pid := range tb.Panes {
+					_ = pid
+				}
+			}
+		}
+	}()
+
+	wg.Wait()
+}


### PR DESCRIPTION
## Why this is urgent

**master's Release workflow is currently failing**, from the race detector on the
build of #167. This fixes the cause.

## The bug

`SnapshotState` documents itself as:

> "a consistent view of the entire session state under a single RLock hold. This
> prevents torn reads when tabs/panes are created or destroyed concurrently."

It applies that discipline to **projects** — deep-copied, with a comment
explaining precisely why a caller holding the slice past the unlock must not race
a concurrent mutation — and returns **tabs as live `*Tab` pointers**.

So every caller that reads `tab.Panes` after the unlock races a concurrent
`CreatePane` doing `tab.Panes = append(...)`. That is five of them:
`workspaceStateFromSnapshot`, `snapshot`, `search`, the memory report, and
`list_tabs`.

Two clients attaching at the same moment is enough to reach it — each connection
dispatches on its own goroutine, so one attach builds the default workspace while
the other builds the workspace state it is about to be sent.

## Why it surfaced now, not before

It is pre-existing, and nothing in #167 touched this code. What #167 added was the
first test in the package to attach **two clients concurrently**
(`TestHandleSubscribe_DispatchArmStopsPaneOutputForThatClientOnly`, verifying the
per-connection pane-output opt-out). That made the existing window observable.

A local `go test -race ./...` passed before the merge — the window is narrow
enough to need load. So the regression test drives the two goroutines
deliberately instead of relying on an incidental collision, and fails at the same
`session.go:469` CI reported.

## The fix

Tabs are copied on the way out, exactly as projects already were. `Layout` is
copied too — `handleUpdateLayout` replaces rather than edits it, so aliasing was
safe, but the returned `Tab` now shares nothing at all.

Verified no caller mutates through the returned pointers (all seven call sites
are read-only; the two apparent hits are field assignments in a different struct
literal).

## Testing

- `TestSnapshotState_TabPanesDoNotRaceConcurrentCreatePane` — fails under `-race`
  without the fix, at the line CI named.
- `internal/daemon` under `-race -count=2`: clean.
- Full `go test -race ./...`: clean. `go vet ./...`: clean.
