### PR TITLE
fix(claude): stop non-prompts becoming session titles

### DIFF
--- a/changelog.d/fixed-claudesessions-fallback-gaps.md
+++ b/changelog.d/fixed-claudesessions-fallback-gaps.md
@@ -14,5 +14,5 @@ headline: Session titles no longer show tool output or slash commands
   shows the session id rather than inventing a label from whatever came first.
 
   The same entries were being counted as prompts in the detail panel, so its
-  prompt count and first/last prompt were wrong in the same sessions. Both now
-  agree with the title.
+  prompt count and first/last prompt were wrong in the same sessions. Those are
+  corrected by the same check.

--- a/changelog.d/fixed-claudesessions-fallback-gaps.md
+++ b/changelog.d/fixed-claudesessions-fallback-gaps.md
@@ -1,0 +1,18 @@
+---
+headline: Session titles no longer show tool output or slash commands
+---
+- **The Claude session picker no longer titles a session from something you did not
+  type.** Sessions were showing tool output, slash-command markup, injected hook
+  notices, and in a few cases a single letter or a directory path, because the check
+  meant to keep those out tested one entry at a time while describing itself as a
+  property of the whole transcript.
+
+  A session's title is now taken only from an entry that is actually a prompt.
+  Anything Claude wrote into the conversation itself — a tool result, a
+  `/command` expansion, a system reminder — is passed over, and the next real
+  prompt is used instead. Where a transcript holds no prompt at all, the picker
+  shows the session id rather than inventing a label from whatever came first.
+
+  The same entries were being counted as prompts in the detail panel, so its
+  prompt count and first/last prompt were wrong in the same sessions. Both now
+  agree with the title.

--- a/docs/superpowers/specs/2026-08-19-claude-session-seam-design.md
+++ b/docs/superpowers/specs/2026-08-19-claude-session-seam-design.md
@@ -24,6 +24,16 @@ Delivered as a single PR on `fix/claude-session-seam` — see "Delivery".
 > from a transcript anyone here has inspected. It is a *fallback reached only when
 > the current schema produced nothing*, so being wrong about it costs an untitled
 > session — the status quo — rather than a wrong title.
+>
+> **AMENDED 2026-08-20 — the caveat above is discharged, and the inference drawn
+> from it was wrong.** Real transcripts were measured. The shape is exactly as
+> transcribed, so §6's parser is correct. But "old schema" was never established:
+> current Claude builds emit `ai-title` entries *alongside* `promptSource`, so the
+> pass is not restricted to old transcripts and this PR's claim that an install
+> carrying both is unaffected is false. The fork's fixtures proved the field *can*
+> appear on an older build; they never showed it absent from newer ones, and it is
+> not. See `2026-08-20-claudesessions-fallback-gaps-design.md` §2, which corrects
+> the comment this note produced.
 
 Nothing here adds a plugin. The fork that prompted this work added a second
 Claude-family plugin (`tclaude`, Tencent's wrapper) and a 1,014-line parallel

--- a/docs/superpowers/specs/2026-08-20-claudesessions-fallback-gaps-design.md
+++ b/docs/superpowers/specs/2026-08-20-claudesessions-fallback-gaps-design.md
@@ -486,13 +486,31 @@ rows and three more were unreachable (see *Evidence*).
 `transcriptLine` gains two fields:
 
 ```go
-	IsMeta        bool            `json:"isMeta"`
-	ToolUseResult json.RawMessage `json:"toolUseResult"`
+	IsMeta        bool        `json:"isMeta"`
+	ToolUseResult jsonPresent `json:"toolUseResult"`
 ```
 
-`ToolUseResult` is decoded as `json.RawMessage` and tested with `len(...) > 0` —
-a presence check, not a value check. Its shape varies by tool and none of it is
-needed. Both are top-level keys, siblings of `message`, not nested inside it.
+Both are top-level keys, siblings of `message`, not nested inside it.
+
+`ToolUseResult` answers **whether the key appeared**, never what it held — its
+shape varies by tool and none of it is needed. `jsonPresent` is a `bool` with an
+`UnmarshalJSON` that sets true unconditionally: `encoding/json` calls it only
+for a key that is present, so any call means present, and an absent key leaves
+the zero value untouched.
+
+**Not `json.RawMessage`**, which an earlier draft specified. It answers the same
+question but retains a copy of the whole blob, and the blob is entire command
+outputs — a copy per line on the rescan path, over a transcript that can reach
+tens of MB.
+
+**An explicit `null` counts as PRESENT.** `encoding/json` routes `null` to a
+custom unmarshaler rather than skipping it, so the type has to answer for
+itself, and the answer is that a tool returning nothing has not stopped being a
+tool. Measured: `toolUseResult` takes only object, string or array across 84,218
+occurrences — `null` does not occur, so the strict reading costs nothing today
+and stays conservative if it ever does. The permissive reading would let tool
+output reach the title passes with only `isMeta` and the tag denylist behind it,
+and untagged tool output is the case §4 exists to reject.
 
 ### The existing guards SURVIVE — the filters are additive
 

--- a/docs/superpowers/specs/2026-08-20-claudesessions-fallback-gaps-design.md
+++ b/docs/superpowers/specs/2026-08-20-claudesessions-fallback-gaps-design.md
@@ -1,0 +1,733 @@
+# claudesessions fallback gaps — design
+
+**Date:** 2026-08-20
+**Status:** Draft, awaiting review
+**Branch:** `fix/claudesessions-fallback-gaps` (off `775576f`, v1.62.5)
+**Origin:** Three findings deferred at #174's merge, plus one defect #174 introduced
+**Supersedes:** the first draft of this file, whose evidence section was measured on
+the wrong population and is retracted in full — see *Retractions*.
+
+## Summary
+
+Four changes in `internal/claudesessions`, all consequences of the transcript
+fallbacks added in #174 (`9e6d4a9`, shipped in v1.62.5):
+
+1. `TranscriptPath` became dead exported production code when `ReadDetailIn`
+   inlined the join it used to own.
+2. The `ai-title` title pass carries a comment that is measurably false, and the
+   guard a reviewer proposed for it would make the pass dead code.
+3. `readDetail`'s second pass is gated on "found no typed prompt" rather than on
+   the transcript's schema, so a recording transcript with no typed prompt
+   re-reads the whole file to find nothing.
+4. **The `promptSource == ""` guard in both fallback paths is a per-LINE check
+   documented as a per-FILE claim.** On transcripts that record the field, it
+   admits entries that are not typed prompts at all. Three sessions on this
+   machine are titled `a`, `main-agent`, and a directory path *today*.
+
+§4 is a live user-visible defect introduced in #174. §1–§3 are corrections to
+code and prose from the same PR.
+
+## Retractions
+
+The first draft of this spec drew its evidence from 25 transcripts selected with
+`ls -S` (largest first). Both halves of that were wrong:
+
+- **Wrong sort.** Transcript size correlates almost perfectly with how much the
+  user typed, so sampling the largest files drew from the population *least*
+  likely to exhibit "no typed prompt" — the exact variable under test. The draft
+  concluded §3 had zero incidence. It has four.
+- **Wrong population, in the opposite direction.** A reviewer re-measured over
+  6,029 files and concluded §3's target case never occurs. That corpus is
+  `find`-recursive; 5,836 of those files are subagent transcripts (see
+  *Population*) that this package never opens.
+
+Every rate in the first draft is retracted. The mechanism arguments survived; the
+frequencies did not. Rates below are stated with their population, and all come
+from one machine and one user — see *Risks*.
+
+## Population
+
+`ListIn` resolves a project directory and calls **`os.ReadDir`**
+(`internal/claudesessions/claudesessions.go:212`), filtering on a `.jsonl` suffix
+(`:240`) behind a regular-file guard. It does not descend. So the population this
+package can ever see is exactly the files one level under a project directory:
+
+```
+~/.claude/projects/*/*.jsonl                      →   193   ← the population
+~/.claude/projects/**/subagents/agent-*.jsonl     → 5,836   ← never opened
+```
+
+The nested files are subagent and workflow transcripts
+(`<project>/<session-uuid>/subagents/…`). They have no typed human prompts by
+construction, so including them biases every measurement in this document's
+subject area. **All figures below are over the 193.**
+
+## Evidence
+
+Field-presence and leading-token greps only; no transcript body was read beyond
+the first 40 characters of entries quoted as defects.
+
+**`promptSource` takes five values.**
+
+| value | lines | value | lines |
+|---|---|---|---|
+| `system` | 3735 | `queued` | 47 |
+| `typed` | 2892 | `sdk` | 3 |
+| `suggestion_accepted` | 429 | | |
+
+**24 of 193 transcripts have zero `"promptSource":"typed"` file-wide** — these are
+the ones where `readDetail`'s second pass runs and `readTitle` falls past its
+first pass. They split:
+
+- **20 record no `promptSource` at all.** These do NOT, as an earlier draft
+  claimed, give the second pass real work. Broken down:
+  - **5 contain no `"type":"user"` entry at all** — their types are
+    `attachment`, `last-prompt`, `mode`, `permission-mode`. They are not
+    conversation transcripts; `ListIn` lists them as sessions regardless, which
+    is a separate matter recorded under *Non-goals*.
+  - **15 have user entries whose first string-content entry is machinery** —
+    `<local-command-caveat>` ×13, `<bash-input>` ×2.
+
+  **Zero of the 20 contains a real user prompt.** The second pass recovers
+  nothing on this machine; it only ever counts machinery. The two transcripts
+  that do gain a correct title from the fallback path (`fc8e3889`, `fd72815d`)
+  are *recording* files with old-schema heads — a different population.
+- **4 record `promptSource`** — §3's target case. Named, with sizes:
+
+  | transcript | size | `promptSource` in head? |
+  |---|---|---|
+  | `E--Projects-Stukans-monorepo/332fec5d…` | 108,167 B | yes |
+  | `…-fix-running-indicator/47acfe01…` | 56,550 B | yes |
+  | `…-fix-running-indicator/b384c502…` | 54,134 B | yes |
+  | `…-fix-running-indicator/87eb2ea8…` | 41,363 B | yes |
+
+**The head is not representative of its own file.** 6 of 25 sampled large
+transcripts record `promptSource` file-wide but not within the first
+`titleScanBytes`. These are long sessions that outlived a Claude upgrade —
+old-schema head, new-schema tail. Any claim of the form "this transcript's schema
+is X", derived from the head, is false for roughly a quarter of long sessions.
+This kills the uniformity argument the first draft used to justify §3.
+
+**`ai-title` is not an old-schema marker, and is stable.** 21 of the 25 sampled
+large transcripts carry `ai-title` entries *alongside* `promptSource`. Each
+transcript carries exactly **one distinct `aiTitle` value**, repeated up to 3,116
+times. The entry shape is `{"type":"ai-title","aiTitle":…,"sessionId":…}`, which
+is what `readTitle`'s fallback 1 parses. #174's spec recorded this shape as
+*"transcribed from the fork's test fixtures, not from a transcript anyone here
+has inspected"* — that caveat is discharged, and the inference drawn from it was
+wrong.
+
+**What the §4 defect produces today.** For the four recording zero-typed
+transcripts, `readTitle` currently yields:
+
+```
+47acfe01  →  "a"
+b384c502  →  "main-agent"
+332fec5d  →  "E:/Projects/Stukans/monorepo/.claude/wor…"
+87eb2ea8  →  (nothing; falls through to the bare UUID)
+```
+
+and separately, on transcripts whose *head* is old-schema, it yields command
+machinery:
+
+```
+e57ea64e, 4b56614d, 8f8c8498  →  "<command-name>/goal</command-name> <command-message>goal…"
+9a540121                      →  "<local-command-caveat>Caveat: The messages below were generated…"
+```
+
+Two others (`fc8e3889`, `fd72815d`, both April-dated heads) yield **correct**
+titles from the same pass. Any fix must keep those.
+
+**Two structural markers separate machinery from prompts.** These were found
+after the first rewrite and they change §4's design; they are the reason it no
+longer needs a schema gate.
+
+| marker | on typed prompts | what it identifies |
+|---|---|---|
+| `toolUseResult` present | **0 / 2,698** | a tool RESULT whose content is a bare string |
+| `isMeta: true` | **0 / 2,698** | Claude-injected meta text in the user turn |
+
+`toolUseResult` is the one that matters most, because it falsifies the premise
+`contentIsString` encodes. Of user entries with **string** `message.content`,
+tool results are not the exception — every untagged non-prompt observed (`a`,
+`main-agent`, a directory path, `ls` and `git status` output) is a tool result
+carrying this field. The content *shape* was never the discriminant; the sibling
+field is.
+
+**The machinery tag census, anchored correctly.** An earlier count matched
+`"content":"<tag` anywhere on the line, which also matches the `content` key
+*nested inside* a `tool_result` block in an ARRAY-content entry —
+`contentIsString` (`:613`) rejects those before any denylist could see them.
+Anchoring on `"message":{"role":"user","content":"` gives the reachable set:
+
+| tag | entries | `isMeta` | `toolUseResult` |
+|---|---|---|---|
+| `task-notification` | 2541 | 0 | 0 |
+| `command-name` | 375 | 0 | 0 |
+| `local-command-stdout` | 360 | 0 | 0 |
+| `local-command-caveat` | 218 | **218** | 0 |
+| `system-reminder` | 39 | **39** | 0 |
+| `command-message` | 31 | 0 | 0 |
+| `bash-stdout` | 17 | 0 | 0 |
+| `bash-input` | 17 | 0 | 0 |
+
+Three tags from the earlier list — `tool_use_error` (391), `persisted-output`
+(71), `retrieval_status` (67) — occur **only** inside array content and are
+unreachable by the guarded pass. They are dropped. `system-reminder` was
+inflated 186 → 39 by the same error.
+
+**One untagged machinery form exists**, and only `isMeta` catches it: an injected
+`"A session-scoped Stop hook is now active…"` entry, which carries `isMeta:true`,
+no tag, and no `toolUseResult`. Without the `isMeta` test it becomes the title of
+three sessions.
+
+**Three of the four recording zero-typed transcripts carry
+`"promptSource":"sdk"`** — `47acfe01`, `b384c502`, `87eb2ea8` are the only three
+`sdk` entries in the whole population. They are SDK/agent-driven sessions, not
+human conversations, which is why `main-agent` is plumbing rather than a memory
+hook. The fourth, `332fec5d`, carries one `"promptSource":"queued"` entry — real
+typed text that no pass promotes, because fallback 2 considers only entries with
+no `promptSource` at all. See *Non-goals*.
+
+## Goals
+
+1. Remove the parallel join and restore the `…In` symmetry the package has (§1).
+2. Make the `ai-title` pass's comment true, and justify its lack of a guard on
+   grounds that survive §4 (§2).
+3. Skip `readDetail`'s second pass when the transcript's schema proves it cannot
+   contribute (§3).
+4. Stop both fallback paths promoting non-prompts to titles and prompt counts,
+   without costing the old-schema transcripts their correct titles (§4).
+
+## Non-goals
+
+- **No change to `readTitle`'s three-pass structure.** Extracting the passes into
+  named helpers was raised in review; it is a readability change with no defect
+  behind it and would obscure the corrections §2 and §4 make.
+- **No `syncPaneMeta`/`pluginCaps` work.** Separate concern, separate PR.
+- **No change to which `promptSource` values count as prompts.**
+  `suggestion_accepted` (429) and `queued` (47) are real user inputs that the
+  typed pass excludes from `UserPrompts`. Whether that exclusion was chosen or
+  inherited is a separate question, recorded here and deliberately not answered.
+
+  **Accepted fallout, stated because it is otherwise invisible:** `332fec5d`
+  holds exactly one real typed prompt, recorded as `"promptSource":"queued"`.
+  The typed pass skips it by this non-goal, and §4 removes the tool-result text
+  that currently stands in for a title, so that session goes from a wrong title
+  to no title. Titling it correctly requires widening the accepted value set —
+  which is this non-goal, and a separate change.
+
+- **No change to which files `ListIn` treats as sessions.** 5 of the 193 hold no
+  `"type":"user"` entry at all (`attachment`, `last-prompt`, `mode`,
+  `permission-mode`) and are listed as sessions regardless. Filtering them is a
+  distinct defect with a distinct fix; §4 merely stops them being titled from
+  machinery.
+
+---
+
+## §1 — `TranscriptPath` is dead production code
+
+### Problem
+
+`TranscriptPath` (`claudesessions.go:175`) is exported with **no production
+caller**. Verified independently twice: every other repo hit is
+`claudehook.SessionRecord.TranscriptPath` or `claudehook`'s local
+`refreshTranscriptPath` (`internal/claudehook/runhook.go:145`, `:493`) — a
+different type and a different function — or a test.
+
+It died in #174, when `ReadDetailIn` inlined the join it needed under an explicit
+config dir. `TestTranscriptPath_BuildsJSONLPath` now certifies a join nothing
+calls, while the join that *is* called has no direct test.
+
+### Design
+
+Add the `…In` variant the package already has elsewhere, and route both spellings
+through it:
+
+```go
+// TranscriptPathIn returns one session's transcript path under an explicit
+// config dir. Takes the directory for the same reason ProjectDirIn does: a
+// caller that already resolved one must not be at the mercy of a concurrent
+// Setenv, and tests need no environment at all.
+func TranscriptPathIn(configDir, cwd, sessionID string) string {
+	dir := ProjectDirIn(configDir, cwd)
+	if dir == "" || sessionID == "" {
+		return ""
+	}
+	return filepath.Join(dir, sessionID+".jsonl")
+}
+
+// TranscriptPath returns the absolute path of one session's transcript, or ""
+// when the config directory cannot be resolved or either argument is empty.
+func TranscriptPath(cwd, sessionID string) string {
+	return TranscriptPathIn(ConfigDir(), cwd, sessionID)
+}
+```
+
+`ReadDetailIn` calls `TranscriptPathIn` and checks the result for `""`, replacing
+both the inlined join and the separate `dir == ""` check. The existing error text
+(`"no transcript path for this session"`) is preserved — the TUI renders it.
+
+**Kept, not deleted.** It is the natural public spelling in a package documented
+as standalone and importable. What is fixed is that it is no longer a *parallel
+implementation*: it delegates, so the two cannot drift.
+
+### Success criteria
+
+- `grep -rn 'filepath.Join(dir, sessionID' internal/claudesessions/` returns
+  exactly one site, inside `TranscriptPathIn`.
+- A test asserts `ReadDetailIn` reads the path `TranscriptPathIn` produces.
+- `TranscriptPath` and `TranscriptPathIn` agree when the environment is unset.
+
+---
+
+## §2 — The `ai-title` pass keeps no schema guard; its comment is corrected
+
+### Problem
+
+`readTitle`'s fallback 1 (`claudesessions.go:550`) claims:
+
+> *"a `{"type":"ai-title"}` entry, emitted by builds that do not record
+> promptSource. […] an install whose transcripts carry both is unaffected."*
+
+Both sentences are false. Current builds emit `ai-title` **alongside**
+`promptSource` (21/25 sampled), and such an install **is** affected whenever a
+transcript has no typed prompt.
+
+A reviewer proposed adding the `promptSource`-absent guard fallback 2 carries, to
+restore #174's "strictly additive" claim. **That would make this pass dead code
+on every current transcript.**
+
+### Design
+
+Keep the pass ungated. Rewrite the comment to say what it does and why it needs
+no guard — **without contrasting it against fallback 2**, whose guard §4 is
+concurrently fixing. Justifying one pass by appeal to a sibling's safety would
+write a second false comment into the twenty lines this PR exists to de-falsify.
+
+```go
+	// Fallback 1 — a {"type":"ai-title"} entry. Reached only when the typed
+	// pass above found nothing.
+	//
+	// Deliberately NOT gated on the transcript's schema. Measured 2026-08-20:
+	// current Claude builds emit ai-title entries AND promptSource, so gating
+	// on the field's absence would make this pass dead code. It fires for any
+	// transcript with no typed prompt, whatever its schema.
+	//
+	// A guard would buy nothing anyway, because of what this pass reads.
+	// aiTitle is a dedicated title field: the only values it can yield are a
+	// title or nothing. Measured: one distinct value per transcript, however
+	// many times the entry repeats. Contrast the passes that promote message
+	// CONTENT, which must first establish that the content is a prompt at all.
+```
+
+### The accepted behaviour change
+
+A session with an `ai-title` and no typed prompt now shows that title where a
+bare UUID appeared before. This departs from #174's "strictly additive" promise,
+accepted deliberately: an AI-generated title beats a UUID, and the field cannot
+carry anything else. Observed once in 25 (`b61c1509`).
+
+### Why no input validation is needed
+
+Checked, so the next reader need not: `sanitizeTitle` (`:728`) maps `\n\r\t` to
+spaces, drops `unicode.IsControl` and `unicode.Cf` (which covers the bidi
+overrides `internal/tui/remotetext.go` exists to defend against), collapses
+whitespace, and truncates to `MaxTitleRunes`. The empty result is rejected by the
+`text != ""` check at the call site. Stale, hostile, over-long and control-bearing
+inputs are all already handled.
+
+### Success criteria
+
+- A test proves the pass fires on a transcript carrying **both** `ai-title` and
+  `promptSource` with no typed prompt — the exact case the proposed guard would
+  have killed. This is the regression test against someone re-adding it.
+- Existing sidechain and non-`ai-title`-entry tests pass unchanged.
+- `docs/superpowers/specs/2026-08-19-claude-session-seam-design.md` is amended:
+  its "not from a transcript anyone here has inspected" note is discharged, and
+  the inference drawn from it was wrong.
+
+---
+
+## §3 — Gate `readDetail`'s second pass on schema
+
+### Problem
+
+`readDetail`'s second pass (`:439`) is entered on `d.UserPrompts == 0` — "the
+typed pass found nothing", which is not "this transcript has no `promptSource`".
+A recording transcript with no typed prompt re-reads the entire file and
+unmarshals every `"type":"user"` line, discarding all of it.
+
+Incidence: **4 of 193** (17% of the 24 that reach the pass).
+
+### Design
+
+Before entering the pass, scan the first `titleScanBytes` for `"promptSource"`:
+
+```go
+	// Skipped when the transcript RECORDS promptSource. See recordsPromptSource
+	// for why that is a correctness improvement and not only a speed one.
+	if d.UserPrompts == 0 && !recordsPromptSource(f) {
+		…existing pass…
+	}
+```
+
+**Operand order is load-bearing.** `&&` short-circuits, so `recordsPromptSource`
+runs only on transcripts that already found no typed prompt — the rare path.
+Reversing it puts a seek and a 64 KiB read on *every* detail read.
+
+```go
+// recordsPromptSource reports whether the transcript's head mentions
+// promptSource, i.e. whether the build that wrote it records the field. Reads
+// the same titleScanBytes window readTitle uses, then seeks back so the pass's
+// own Seek(0) is unaffected. A seek or read error answers false, falling
+// through to the pass exactly as today.
+//
+// This is a CORRECTNESS gate that also saves work, not a pure optimisation.
+// On a transcript that records promptSource, an entry lacking the field is not
+// a typed prompt — whatever else it may be — so skipping the pass cannot lose
+// a prompt. It can only suppress entries the per-line filters would
+// misclassify, which is what §4 addresses at the other end.
+//
+// The two error directions are NOT symmetric. A false positive is near
+// impossible: the head is the OLDEST part of the file, and a build that records
+// the field at session start does not stop mid-session. A false negative — the
+// field appears only past the window, measured on 6 of 25 long transcripts that
+// outlived an upgrade — costs one re-read that happens today anyway. So the
+// head is a sample in one direction only, and the failure mode is current
+// behaviour.
+//
+// The substring test is sound because of JSON escaping: a mention of
+// promptSource inside message content is stored as \"promptSource\", which
+// cannot match the quoted needle. Content can never fake the field.
+func recordsPromptSource(f *os.File) bool
+```
+
+The first draft justified this with "schema is uniform within a transcript, so
+the head is representative." That is **false** and is not the argument. The
+argument is the failure mode: answering `false` runs the pass, which is today's
+behaviour.
+
+### Honest billing
+
+All four observed instances are ≤ 108 KB, so the saved re-read is ~100 KB —
+microseconds. The 88 MB transcript the surrounding comment cites has never been
+observed in this state. §3 is **correct-by-schema and cheap insurance**, not a
+measured performance win. It should be billed that way in review.
+
+### Success criteria
+
+- A recording transcript with no typed prompt is **not** rescanned — asserted on
+  the result (`UserPrompts == 0`), since the pass is unexported.
+  **The fixture must contain string-content user entries the rescan would
+  otherwise count**, and they must survive §4's filters (no `toolUseResult`, no
+  `isMeta`, untagged). Without that the assertion holds whether or not the gate
+  exists, and the mutation check below is vacuous.
+- A **false-negative** fixture: `promptSource` present only PAST the 64 KiB
+  window, zero typed prompts anywhere. The gate answers `false`, the rescan
+  runs, and the result must equal today's behaviour. This is the only fixture
+  that exercises `recordsPromptSource` returning `false` on a recording file —
+  the direction the honest-billing argument rests on.
+- A **mixed-schema** fixture — old-schema head, typed prompt only in the tail.
+  This pins `readTitle` running fallback 2 on the head while `readDetail`'s first
+  pass finds the tail prompt. Note what it does **not** do: with
+  `UserPrompts >= 1`, the `&&` short-circuits and `recordsPromptSource` is never
+  called, so this fixture says nothing about the gate. It is a behavioural pin
+  for the head/whole-file split, and is filed here only because that split is
+  what §3 reasons about.
+- An old-schema transcript still IS rescanned and still reports its
+  shape-detected prompts.
+- Mutation check: forcing `recordsPromptSource` to `true` fails the old-schema
+  test.
+- **Old-schema fixtures must drive the second pass directly.** With the gate on,
+  a §4 denylist gap is unreachable through current-schema fixtures — the gate
+  would otherwise mask §4's test surface.
+
+---
+
+## §4 — The `promptSource == ""` guard is per-line, documented as per-file
+
+### Problem
+
+Two sites carry the same defect, both introduced in #174:
+
+- `readTitle` fallback 2 — guard at `:594`, comment at `:575`
+- `readDetail` second pass — guard at `:455`, comment at `:428`
+
+The comments claim the check *"confines this to schemas that never record it"*
+and *"a current-schema transcript can never be reclassified here."* The check is
+`tl.PromptSource != ""` on a single line. A recording transcript is full of user
+entries that carry no `promptSource` — command machinery and assorted non-prompt
+input — and every one passes.
+
+This is exactly the failure the comment says it prevents. It ships in v1.62.5.
+
+### Design: reject what the entry IS, not what schema wrote it
+
+The first rewrite proposed a schema gate on `readTitle`'s fallback 2, mirroring
+§3. **That is dropped.** The measurements above supply two structural markers
+that identify machinery directly, so the pass no longer needs to guess from
+schema — and, unlike the gate, they never blank a transcript that does hold a
+real prompt.
+
+Three filters, applied at both sites, in this order:
+
+| # | filter | rejects | entries |
+|---|---|---|---|
+| 1 | `toolUseResult` present | tool results with bare-string content | `a`, `main-agent`, paths, `ls` / `git status` output |
+| 2 | `isMeta: true` | Claude-injected meta text | `<local-command-caveat>`, `<system-reminder>`, and the untagged Stop-hook notice |
+| 3 | leading tag in a 6-entry denylist | the remaining tagged machinery | `<task-notification>`, `<command-name>`, `<command-message>`, `<local-command-stdout>`, `<bash-stdout>`, `<bash-input>` |
+
+Filters 1 and 2 are maintenance-free and schema-independent: neither field ever
+appears on a typed prompt (0 / 2,698 each). Only filter 3 is a list, and it is
+now six tags rather than eleven, because filters 1–2 absorb two of the original
+rows and three more were unreachable (see *Evidence*).
+
+`transcriptLine` gains two fields:
+
+```go
+	IsMeta        bool            `json:"isMeta"`
+	ToolUseResult json.RawMessage `json:"toolUseResult"`
+```
+
+`ToolUseResult` is decoded as `json.RawMessage` and tested with `len(...) > 0` —
+a presence check, not a value check. Its shape varies by tool and none of it is
+needed. Both are top-level keys, siblings of `message`, not nested inside it.
+
+### The existing guards SURVIVE — the filters are additive
+
+**This is the single most important sentence in §4.** The three filters are added
+to the existing conditions; they replace nothing. Both guards keep every term
+they have today, `PromptSource == ""` included:
+
+```go
+	// readTitle fallback 2, after the change
+	if tl.Type != "user" || tl.IsSidechain || tl.PromptSource != "" ||
+		!contentIsString(tl.Message.Content) || isMachinery(tl) {
+		continue
+	}
+```
+
+Deleting `PromptSource != ""` while adding the filters produces a **different and
+wrong** feature. It is what excludes the `"sdk"` entries in `47acfe01`,
+`b384c502` and `87eb2ea8` and the `"queued"` entry in `332fec5d` — none of the
+three filters touches those, so the measured-effect table below only holds while
+that term stays.
+
+The filters therefore run **only on the fallback paths**, on entries that have
+already passed type, sidechain, `promptSource`-absence and `contentIsString`.
+They add nothing to the typed-prompt first pass, whose lines carry neither new
+field.
+
+### Matching rule
+
+Filters 1 and 2 are field reads on the already-unmarshalled struct. Filter 3 is a
+prefix test on the **decoded** content string — after `json.Unmarshal`, before
+`sanitizeTitle`:
+
+```go
+	strings.HasPrefix(content, "<"+tag+">") || strings.HasPrefix(content, "<"+tag+" ")
+```
+
+Both delimiters are required: `<command-name>` closes immediately, while
+`<task-notification …>` carries attributes. **No `TrimSpace`** — every observed
+machinery entry starts its tag at byte 0, and a whitespace-prefixed tag is
+therefore a miss, which yields today's behaviour. "Begins with", never
+"contains": a prompt that merely *mentions* `<command-name>` is prose.
+
+### Measured effect
+
+Every observed defect, before and after:
+
+| transcript | today | after |
+|---|---|---|
+| `fc8e3889` | *"I want you to buld a prototype…"* | **unchanged** |
+| `fd72815d` | *"Read docs/global-question-domain.md…"* | **unchanged** |
+| `47acfe01` | `a` | UUID |
+| `b384c502` | `main-agent` | UUID |
+| `332fec5d` | `E:/Projects/…/.claude/wor…` | UUID |
+| `9a540121`, `4afd60df` | `<local-command-caveat>…` | UUID |
+| `e57ea64e`, `4b56614d`, `8f8c8498` | `<command-name>/goal…` | UUID |
+| `9027ed39` | `<bash-input>git status</bash-input>` | UUID |
+| `87eb2ea8` | (none) | UUID |
+
+Both correct titles are preserved; all ten garbage titles are removed. Filters
+1–2 alone leave the `<command-name>` cases; filter 3 alone leaves `a` and
+`main-agent`; filter 2 alone catches the Stop-hook notice that neither of the
+others sees. All three are load-bearing.
+
+### Filter 3 — the denylist
+
+
+
+Six tags, derived from entries whose `message.content` is a string — the only
+ones the guarded pass can reach:
+
+| tag | entries | |
+|---|---|---|
+| `task-notification` | 2541 | |
+| `command-name` | 375 | |
+| `local-command-stdout` | 360 | |
+| `command-message` | 31 | |
+| `bash-stdout` | 17 | `!`-prefix shell-forward feature |
+| `bash-input` | 17 | same |
+
+`local-command-caveat` and `system-reminder` are **not** listed — filter 2
+(`isMeta`) covers both, on 218/218 and 39/39 entries respectively. Listing them
+as well would be dead weight that hides which mechanism is actually load-bearing.
+
+`tool_use_error`, `persisted-output` and `retrieval_status` appeared in the
+previous draft's table and are **removed**: they occur only inside array content,
+which `contentIsString` (`:613`) rejects before the denylist runs.
+`teammate-message` is plausible but did not occur; excluded to keep the list
+strictly data-derived.
+
+**Three boundary rules, each with a counterexample behind it:**
+
+1. **Never match on a bare leading `<`.** 80,630 string-content entries are
+   ordinary prose, and legitimate user-pasted markup occurs with leading tags
+   `html`, `svg`, `div`, `form`, `script`, `article`, `style`, `details`,
+   `section`, `input`, `title`, `li`, `a`, `tr`, `h…`, `testsuite`, `version`.
+   A "starts with `<`" rule eats real prompts.
+2. **Match the full tag with its closing delimiter** (`<command-name>` or
+   `<command-name `). Prefix matching makes `bash` swallow `bash-stdout`, and a
+   bare `h` collide with `html`.
+3. **`<` followed by a non-tag character is prose.** 184 entries begin `</`,
+   `<!`, or `<` plus a digit. Exact-tag matching handles these for free.
+
+The check applies at **both** sites — `readTitle` fallback 2 and `readDetail`'s
+second pass — because the same entries inflate `UserPrompts` and become
+`FirstPrompt`/`LastPrompt` in the detail panel, not only titles.
+
+Failure mode is benign and strictly better than today: an unrecognised machinery
+tag yields the bad title it already yields, and a user whose real prompt opens
+with a denylisted tag loses one candidate while the scan takes the next entry.
+
+### Success criteria
+
+- `fc8e3889` and `fd72815d`'s shape — an old-schema head whose first
+  string-content entry is ordinary prose — still yields its correct title. This
+  is the *preservation* test and it must exist before any filter lands.
+- One fixture per filter, each placing the rejected entry **before** a real
+  prompt and asserting the real prompt wins, at **both** call sites. Each
+  fixture must be reachable ONLY by the filter it targets, or its mutation check
+  is shadowed by a neighbour:
+  1. a string-content entry carrying `toolUseResult`, **untagged and not
+     `isMeta`** — otherwise deleting filter 1 still passes via 2 or 3,
+  2. an entry carrying `isMeta: true` and **no** tag (the Stop-hook shape) —
+     otherwise deleting filter 2 still passes via 3,
+  3. a `<command-name>`-led entry carrying neither new field.
+- At the `readDetail` site each fixture asserts **`UserPrompts == 1`** as well as
+  the text, not the text alone. The count is incremented unconditionally for a
+  rejected entry with empty text, so a text-only assertion can pass while the
+  count is wrong — which is the stronger failure this pass can produce.
+- Fixtures mirror real entry shape: `isMeta` and `toolUseResult` are top-level
+  siblings of `message`. A fixture written to match the struct rather than the
+  wire would pass even if the real placement differed.
+- A `<html>`-led entry IS taken as the title — the denylist must not eat
+  user-pasted markup.
+- Mutation checks, each paired with the fixture that makes it bite: deleting
+  filter 1 fails (1); deleting filter 2 fails (2); emptying the denylist fails
+  (3). The fixture notes above are what keep these from being vacuous.
+
+---
+
+## Rejected alternatives
+
+**Deleting `TranscriptPath` (§1).** The natural public spelling in a package
+documented as importable. Delegation removes the drift risk, which was the actual
+problem.
+
+**Adding the schema guard to fallback 1 (§2).** Makes the pass dead code on every
+current transcript to restore a claim in a merged PR description.
+
+**Justifying §2 by contrast with fallback 2 (§2).** The first draft's argument.
+Fallback 2's guard does not deliver the safety the contrast credits it with — §4
+is fixing it in the same PR.
+
+**"Schema is uniform within a transcript" (§3).** False: 6 of 25 sampled long
+transcripts have an old-schema head and a new-schema tail.
+
+**Tracking a `sawPromptSource` flag during `readDetail`'s first pass (§3).**
+Avoids the seek but adds a `bytes.Contains` to every line of the loop whose byte
+pre-filter is what keeps an 88 MB transcript affordable. Moves cost from the rare
+path to the hot one.
+
+**A schema gate on `readTitle`'s fallback 2 (§4).** The previous draft's design,
+mirroring §3. Dropped once `toolUseResult` and `isMeta` were measured. The reason
+is **not** that it would have blanked `fc8e3889` / `fd72815d` — measured, both
+have old-schema heads (`headHasPS=0`), so the gate answers `false` there and
+their titles survive it. The reason is that it rejects at the wrong granularity:
+it blanks a whole transcript's title on a schema signal, where the filters reject
+the individual entries that are not prompts. Entry-level rejection is strictly
+more precise, needs no schema inference, and reaches every case the gate reached.
+
+**A denylist alone (§4).** Leaves `a`, `main-agent` and a directory path as
+titles — none is tag-wrapped — and leaves the untagged Stop-hook notice.
+
+**`isMeta` alone (§4).** Covers `local-command-caveat`, `system-reminder` and the
+untagged notice, but is absent on `task-notification`, `command-name`,
+`command-message` and both `bash-*` forms — 3,341 entries.
+
+**Trusting `contentIsString` to mean "this is a prompt" (§4).** It is what the
+current code assumes. Measured false: of user entries with string
+`message.content`, tool results are the common case, not the exception. Shape
+was never the discriminant.
+
+**Treating any `<`-leading entry as machinery (filter 3).** Eats user-pasted HTML,
+which is a legitimate prompt.
+
+---
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| The denylist is incomplete | Failure mode is today's behaviour — an unrecognised tag yields the bad title it already yields. No regression, only unfixed cases. Two of the three filters need no list at all, so a new tag has to evade `toolUseResult` *and* `isMeta` before the list matters. |
+| A future machinery form evades all three filters | Bounded to today's behaviour. Note also that the vulnerable corpus is not growing: current builds emit `<command-name>` as `"type":"system","subtype":"local_command"` and most `task-notification` traffic as `"type":"queue-operation"` — neither shape is a `type:"user"` entry, so neither reaches the guarded passes. |
+| §4 suppresses a title a user wanted | The three affected `sdk` sessions are agent-driven, where `main-agent` describes plumbing rather than content; a stable-looking label that names nothing invites a misclick, where a UUID is honestly anonymous. The one real loss is `332fec5d`'s `queued` prompt — see *Non-goals*. |
+| §3's head sample misclassifies | Costs one re-read that happens today anyway; the per-line filters keep the answer correct either way. |
+| **§3 and §4 can disagree about the same entry** | Deliberate and eyes-open: §3 gates `readDetail`'s counts on schema, while `readTitle`'s fallback 2 stays ungated. Machinery that evades all three filters on a recording transcript can still become a *title* while the detail panel reports zero prompts. Bounded to today's behaviour. Do not "fix" the asymmetry by gating `readTitle` — that is the rejected alternative above, and the gate rejects at the wrong granularity. |
+| §1's delegation changes `TranscriptPath` when the env is unset | A test asserts the two spellings agree; both resolve through `ConfigDir()`. |
+| **All measurements are one machine, one user, 193 transcripts** | Every mechanism argument stands independently of frequency. Rates are cited as sample-local throughout and no design decision rests on a rate alone. |
+| A future reader re-adds the §2 guard by analogy with §4 | §2's comment states the asymmetry and a named test fails if the guard returns. |
+
+## Delivery
+
+One PR on `fix/claudesessions-fallback-gaps`, four commits — one per section, so
+any section can be dropped by dropping a commit **before merge**. The repo
+squash-merges, so this granularity does not survive onto master; it is a
+review-time affordance, not a revert-time one.
+
+**Commit order is §1, §2, §4, §3 — not section order.** §4 must land with or
+before §3: §3's gate masks §4's test surface on current-schema fixtures, and
+§3's safety argument assumes the filters already exist behind it. Numbering the
+sections by subject and committing them by dependency is deliberate.
+
+**§4 must land with or before §3.** §3's safety story assumes the denylist exists
+behind it, and §3's gate masks §4's test surface on current-schema fixtures (see
+§3's success criteria).
+
+**PR title:** `fix(claude): stop non-prompts becoming session titles`
+
+Release-critical — it is the squash subject the release pipeline classifies.
+`fix` is right: §4 repairs user-visible behaviour shipped in v1.62.5.
+
+**Changelog:** the PR touches `internal/`, so CI requires a fragment. §4 is the
+user-visible item. One `changelog.d/fixed-session-title-fallbacks.md` with the
+mandatory three-line `headline:` block (≤64 bytes, no `"` or `\`).
+
+## Verification
+
+- `./scripts/dev.sh test internal/claudesessions` for the inner loop.
+- `./scripts/dev.sh test` and `./scripts/dev.sh vet` before the PR.
+- `./scripts/dev.sh test-race` — this is the CI command; `dev.sh test` is not.
+- Every new guard mutation-checked: removing it must fail a named test.
+- No dev-mode runtime check needed — all four changes are in a pure, stdlib-only
+  package with no daemon or PTY involvement.
+- **Re-run the population sweep after implementing** and confirm all ten rows of
+  §4's measured-effect table: the four untagged cases (`47acfe01`, `b384c502`,
+  `332fec5d`, `87eb2ea8`) and the six tagged ones (`e57ea64e`, `4b56614d`,
+  `8f8c8498` — `command-name`; `9a540121`, `4afd60df` — `local-command-caveat`;
+  `9027ed39` — `bash-input`) no longer produce their recorded titles, and that
+  `fc8e3889` and `fd72815d` still produce theirs.

--- a/internal/claudesessions/claudesessions.go
+++ b/internal/claudesessions/claudesessions.go
@@ -560,9 +560,19 @@ func readTitle(path string) string {
 		}
 	}
 
-	// Fallback 1 — a {"type":"ai-title"} entry, emitted by builds that do not
-	// record promptSource. Reached only when the typed pass above found
-	// nothing, so an install whose transcripts carry both is unaffected.
+	// Fallback 1 — a {"type":"ai-title"} entry. Reached only when the typed
+	// pass above found nothing.
+	//
+	// Deliberately NOT gated on the transcript's schema. Measured 2026-08-20:
+	// current Claude builds emit ai-title entries AND promptSource, so gating
+	// this on the field's absence would make the pass dead code. It fires for
+	// any transcript with no typed prompt, whatever its schema.
+	//
+	// A guard would buy nothing anyway, because of what this pass reads.
+	// aiTitle is a dedicated title field: the only values it can yield are a
+	// title or nothing. Measured: one distinct value per transcript, however
+	// many times the entry repeats. Contrast the passes that promote message
+	// CONTENT, which must first establish that the content is a prompt at all.
 	for _, line := range lines {
 		if !bytes.Contains(line, []byte(`"type":"ai-title"`)) {
 			continue

--- a/internal/claudesessions/claudesessions.go
+++ b/internal/claudesessions/claudesessions.go
@@ -170,14 +170,27 @@ func ProjectDir(cwd string) string {
 	return ProjectDirIn(ConfigDir(), cwd)
 }
 
-// TranscriptPath returns the absolute path of one session's transcript, or ""
-// when the home directory is unavailable or either argument is empty.
-func TranscriptPath(cwd, sessionID string) string {
-	dir := ProjectDir(cwd)
+// TranscriptPathIn returns one session's transcript path under an explicit
+// config dir, or "" when the directory cannot be resolved or either remaining
+// argument is empty. It takes the directory for the same reason ProjectDirIn
+// does: a caller that already resolved one must not be at the mercy of a
+// concurrent Setenv, and tests need no environment at all.
+//
+// This is the ONLY place the session-id-to-filename join lives. ReadDetailIn
+// used to inline its own copy, which left the exported spelling below with no
+// production caller and its test certifying a join nothing ran.
+func TranscriptPathIn(configDir, cwd, sessionID string) string {
+	dir := ProjectDirIn(configDir, cwd)
 	if dir == "" || sessionID == "" {
 		return ""
 	}
 	return filepath.Join(dir, sessionID+".jsonl")
+}
+
+// TranscriptPath returns the absolute path of one session's transcript, or ""
+// when the home directory is unavailable or either argument is empty.
+func TranscriptPath(cwd, sessionID string) string {
+	return TranscriptPathIn(ConfigDir(), cwd, sessionID)
 }
 
 // List returns the sessions recorded for cwd, newest first, capped at
@@ -368,11 +381,11 @@ func ReadDetailIn(ctx context.Context, configDir, cwd, sessionID string) (Detail
 		sessionID == "." || sessionID == ".." || strings.ContainsRune(sessionID, filepath.Separator) {
 		return Detail{}, fmt.Errorf("invalid session id")
 	}
-	dir := ProjectDirIn(configDir, cwd)
-	if dir == "" {
+	path := TranscriptPathIn(configDir, cwd, sessionID)
+	if path == "" {
 		return Detail{}, fmt.Errorf("no transcript path for this session")
 	}
-	return readDetail(ctx, filepath.Join(dir, sessionID+".jsonl"), sessionID)
+	return readDetail(ctx, path, sessionID)
 }
 
 // readDetail is the filesystem half of ReadDetail, split out so tests can point

--- a/internal/claudesessions/claudesessions.go
+++ b/internal/claudesessions/claudesessions.go
@@ -179,6 +179,12 @@ func ProjectDir(cwd string) string {
 // This is the ONLY place the session-id-to-filename join lives. ReadDetailIn
 // used to inline its own copy, which left the exported spelling below with no
 // production caller and its test certifying a join nothing ran.
+//
+// It does NOT validate sessionID, and deliberately so — it is a path
+// constructor, not a gate. filepath.Join CLEANS a traversal rather than
+// refusing it, so a caller building a path from untrusted input must reject
+// separators and ".." itself first. ReadDetailIn does exactly that before it
+// calls here; any new caller owes the same check.
 func TranscriptPathIn(configDir, cwd, sessionID string) string {
 	dir := ProjectDirIn(configDir, cwd)
 	if dir == "" || sessionID == "" {
@@ -305,6 +311,24 @@ func listDir(ctx context.Context, dir string) (sessions []Session, truncated boo
 	return out, truncated, nil
 }
 
+// jsonPresent records only WHETHER a field appeared, never its value.
+//
+// json.RawMessage would answer the same question but keep a copy of the whole
+// blob: toolUseResult carries entire command outputs, and the rescan decodes
+// every tool-result line on a transcript that can reach tens of MB. Presence is
+// all isMachinery asks, so nothing is copied.
+//
+// An explicit null counts as ABSENT. encoding/json hands null to a custom
+// unmarshaler rather than skipping it, and this package has already been bitten
+// once by treating null as a value — see contentIsString.
+type jsonPresent bool
+
+func (p *jsonPresent) UnmarshalJSON(b []byte) error {
+	b = bytes.TrimSpace(b)
+	*p = jsonPresent(len(b) > 0 && !bytes.Equal(b, []byte("null")))
+	return nil
+}
+
 // transcriptLine mirrors the subset of a transcript entry needed to recognize
 // a typed human prompt and pull its text. Extra fields are ignored.
 type transcriptLine struct {
@@ -319,13 +343,12 @@ type transcriptLine struct {
 	// user wrote — hook notices, local-command caveats, system reminders.
 	IsMeta bool `json:"isMeta"`
 	// ToolUseResult is present, at top level, on every entry that is a tool
-	// RESULT. Decoded as RawMessage and tested only for presence: the shape
-	// varies per tool and none of it is needed. It is what separates a tool
-	// result from a prompt, because content SHAPE does not — a tool result's
-	// content is a bare string far more often than not.
-	ToolUseResult json.RawMessage `json:"toolUseResult"`
-	Timestamp     string          `json:"timestamp"`
-	Message   struct {
+	// RESULT. It is what separates a tool result from a prompt, because content
+	// SHAPE does not — a tool result's content is a bare string far more often
+	// than not.
+	ToolUseResult jsonPresent `json:"toolUseResult"`
+	Timestamp     string      `json:"timestamp"`
+	Message       struct {
 		// Content is a string for a plain prompt and an array of content
 		// blocks when the prompt carries attachments — both shapes occur in
 		// the wild, so it is decoded in a second pass.
@@ -657,14 +680,6 @@ func readTitle(path string) string {
 	return ""
 }
 
-// contentIsString reports whether a message content field decoded as a plain
-// JSON string. It is the schema-free way to tell a typed prompt from a tool
-// result: Claude records both as type "user", but a tool result always carries
-// an ARRAY of content blocks while a typed prompt carries a bare string.
-// Consulted only on transcripts that do not record promptSource at all.
-// Tests the raw token rather than round-tripping through json.Unmarshal, which
-// accepts JSON null into a string and reports success — so `"content": null`
-// counted as a prompt and inflated UserPrompts by one, with empty text.
 // recordsPromptSource reports whether the transcript's head mentions
 // promptSource, i.e. whether the build that wrote it records the field.
 //
@@ -681,9 +696,14 @@ func readTitle(path string) string {
 // appearing only past the window, which happens on transcripts that outlived a
 // claude upgrade — costs one re-read that happens today anyway.
 //
-// The substring test is sound because of JSON escaping: a mention of
-// promptSource inside message content is stored as \"promptSource\", which
-// cannot match the quoted needle. Content can never fake the field.
+// The needle includes the opening quote of the VALUE, and that is what bounds
+// the false-positive case. Message content cannot fake it at all — a mention of
+// promptSource inside a JSON string is stored escaped, as \"promptSource\". A
+// nested KEY is not escaped, so a tool result carrying its own promptSource
+// field could still match; requiring `:"` narrows that to a nested key whose
+// value is also a string. The residual cost is one blank detail panel on an
+// old-schema transcript that happens to contain such a key, which is why this
+// is a substring test and not a parse.
 func recordsPromptSource(f *os.File) bool {
 	if _, err := f.Seek(0, io.SeekStart); err != nil {
 		return false
@@ -692,7 +712,7 @@ func recordsPromptSource(f *os.File) bool {
 	if err != nil {
 		return false
 	}
-	found := bytes.Contains(head, []byte(`"promptSource"`))
+	found := bytes.Contains(head, []byte(`"promptSource":"`))
 	// Restore the offset for the caller. The pass seeks to 0 itself, so this is
 	// belt-and-braces; a failure here answers false and lets it run.
 	if _, err := f.Seek(0, io.SeekStart); err != nil {
@@ -732,7 +752,7 @@ var machineryTags = []string{
 // isMeta; a hook notice carries isMeta and no tag; command markup carries a tag
 // and neither field.
 func isMachinery(tl transcriptLine, content string) bool {
-	if len(tl.ToolUseResult) > 0 {
+	if bool(tl.ToolUseResult) {
 		return true
 	}
 	if tl.IsMeta {
@@ -751,6 +771,14 @@ func isMachinery(tl transcriptLine, content string) bool {
 	return false
 }
 
+// contentIsString reports whether a message content field decoded as a plain
+// JSON string. It tells a prompt from a tool result whose content is an ARRAY
+// of blocks — but NOT from one whose content is a bare string, which is the
+// common case; isMachinery's toolUseResult test is what covers those.
+// Consulted only on transcripts that do not record promptSource at all.
+// Tests the raw token rather than round-tripping through json.Unmarshal, which
+// accepts JSON null into a string and reports success — so `"content": null`
+// counted as a prompt and inflated UserPrompts by one, with empty text.
 func contentIsString(raw json.RawMessage) bool {
 	raw = bytes.TrimSpace(raw)
 	return len(raw) > 0 && raw[0] == '"'

--- a/internal/claudesessions/claudesessions.go
+++ b/internal/claudesessions/claudesessions.go
@@ -465,7 +465,10 @@ func readDetail(ctx context.Context, path, id string) (Detail, error) {
 	// any JSON parse, and parsing every "type":"user" line unconditionally
 	// would pay a full unmarshal per tool result on an 88 MB transcript for
 	// every existing user. This runs only when the fast path found nothing.
-	if d.UserPrompts == 0 {
+	// Operand order is load-bearing. && short-circuits, so recordsPromptSource
+	// runs only on transcripts that already found no typed prompt — the rare
+	// path. Reversing it puts a seek and a 64 KiB read on EVERY detail read.
+	if d.UserPrompts == 0 && !recordsPromptSource(f) {
 		if _, err := f.Seek(0, io.SeekStart); err != nil {
 			return d, nil // keep the timestamps the first pass gathered
 		}
@@ -662,6 +665,42 @@ func readTitle(path string) string {
 // Tests the raw token rather than round-tripping through json.Unmarshal, which
 // accepts JSON null into a string and reports success — so `"content": null`
 // counted as a prompt and inflated UserPrompts by one, with empty text.
+// recordsPromptSource reports whether the transcript's head mentions
+// promptSource, i.e. whether the build that wrote it records the field.
+//
+// This is a CORRECTNESS gate that also saves work, not a pure optimisation. On
+// a transcript that records the field, an entry LACKING it is not a typed
+// prompt — whatever else it may be — so skipping the shape-detecting pass
+// cannot lose a prompt. It can only suppress entries that pass would
+// misclassify.
+//
+// The two error directions are NOT symmetric, which is what makes a head sample
+// acceptable for a whole-file question. A false positive is near impossible:
+// the head is the OLDEST part of the file, and a build that records the field
+// at session start does not stop mid-session. A false negative — the field
+// appearing only past the window, which happens on transcripts that outlived a
+// claude upgrade — costs one re-read that happens today anyway.
+//
+// The substring test is sound because of JSON escaping: a mention of
+// promptSource inside message content is stored as \"promptSource\", which
+// cannot match the quoted needle. Content can never fake the field.
+func recordsPromptSource(f *os.File) bool {
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return false
+	}
+	head, err := io.ReadAll(io.LimitReader(f, titleScanBytes))
+	if err != nil {
+		return false
+	}
+	found := bytes.Contains(head, []byte(`"promptSource"`))
+	// Restore the offset for the caller. The pass seeks to 0 itself, so this is
+	// belt-and-braces; a failure here answers false and lets it run.
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return false
+	}
+	return found
+}
+
 // machineryTags are the wrappers claude puts around its own text in the user
 // turn. Derived from the transcripts on one developer's machine, counting only
 // entries whose message.content is a STRING — the only ones the shape-detecting

--- a/internal/claudesessions/claudesessions.go
+++ b/internal/claudesessions/claudesessions.go
@@ -318,14 +318,21 @@ func listDir(ctx context.Context, dir string) (sessions []Session, truncated boo
 // every tool-result line on a transcript that can reach tens of MB. Presence is
 // all isMachinery asks, so nothing is copied.
 //
-// An explicit null counts as ABSENT. encoding/json hands null to a custom
-// unmarshaler rather than skipping it, and this package has already been bitten
-// once by treating null as a value — see contentIsString.
+// The question is whether the KEY appeared, never what it held. encoding/json
+// calls this only for a key that is present, so any call means present —
+// including an explicit null, which says a tool returned nothing, not that this
+// entry is no longer a tool result.
+//
+// Measured: toolUseResult takes only object, string or array across 84,218
+// occurrences; null does not occur. So the strict reading costs nothing today
+// and stays conservative if it ever does — the permissive one would let tool
+// output reach the title passes with only isMeta and the tag denylist between
+// it and the screen, and untagged tool output is the case this whole change
+// exists to reject.
 type jsonPresent bool
 
-func (p *jsonPresent) UnmarshalJSON(b []byte) error {
-	b = bytes.TrimSpace(b)
-	*p = jsonPresent(len(b) > 0 && !bytes.Equal(b, []byte("null")))
+func (p *jsonPresent) UnmarshalJSON([]byte) error {
+	*p = true
 	return nil
 }
 

--- a/internal/claudesessions/claudesessions.go
+++ b/internal/claudesessions/claudesessions.go
@@ -314,8 +314,17 @@ type transcriptLine struct {
 	// AiTitle carries the session title on builds that emit a
 	// {"type":"ai-title"} entry. Absent on builds that do not; the title scan
 	// consults it only after the typed-prompt pass finds nothing.
-	AiTitle   string `json:"aiTitle"`
-	Timestamp string `json:"timestamp"`
+	AiTitle string `json:"aiTitle"`
+	// IsMeta marks text claude injected into the user turn rather than text the
+	// user wrote — hook notices, local-command caveats, system reminders.
+	IsMeta bool `json:"isMeta"`
+	// ToolUseResult is present, at top level, on every entry that is a tool
+	// RESULT. Decoded as RawMessage and tested only for presence: the shape
+	// varies per tool and none of it is needed. It is what separates a tool
+	// result from a prompt, because content SHAPE does not — a tool result's
+	// content is a bare string far more often than not.
+	ToolUseResult json.RawMessage `json:"toolUseResult"`
+	Timestamp     string          `json:"timestamp"`
 	Message   struct {
 		// Content is a string for a plain prompt and an array of content
 		// blocks when the prompt carries attachments — both shapes occur in
@@ -439,10 +448,17 @@ func readDetail(ctx context.Context, path, id string) (Detail, error) {
 	}
 
 	// Fallback: a transcript from a build that does not record promptSource
-	// yields zero prompts above. Re-scan classifying by CONTENT SHAPE instead —
-	// string content is a prompt, array content is a tool result — and only for
-	// entries carrying no promptSource, so a current-schema transcript can
-	// never be reclassified here (see readTitle's fallback 2).
+	// yields zero prompts above. Re-scan classifying by what each entry IS.
+	//
+	// This comment used to say the promptSource=="" test meant "a current-schema
+	// transcript can never be reclassified here". It does not — that is a
+	// per-entry test, and plenty of entries on a current-schema transcript carry
+	// no promptSource. Array content is rejected because a tool result whose
+	// content is a block list is not a prompt, but that check is not enough
+	// either: a tool result's content is a bare STRING more often than not.
+	// isMachinery is what carries the classification (see readTitle's
+	// fallback 2), and it must run BEFORE the count below — the increment and
+	// the text are set together, so one rejection point covers both.
 	//
 	// A SECOND pass rather than one combined pass, deliberately: the loop above
 	// owes its speed to rejecting non-typed lines with a byte compare before
@@ -467,12 +483,17 @@ func readDetail(ctx context.Context, path, id string) (Detail, error) {
 				if json.Unmarshal(bytes.TrimSpace(line), &tl) == nil &&
 					tl.Type == "user" && !tl.IsSidechain && tl.PromptSource == "" &&
 					contentIsString(tl.Message.Content) {
-					d.UserPrompts++
-					if text := sanitizePrompt(contentText(tl.Message.Content, MaxPromptRunes)); text != "" {
-						if d.FirstPrompt == "" {
-							d.FirstPrompt = text
+					// NOT `continue`: this sits inside the read loop, above the
+					// readErr check that ends it, so skipping the rest of the
+					// iteration would skip the break too.
+					if raw := contentText(tl.Message.Content, MaxPromptRunes); !isMachinery(tl, raw) {
+						d.UserPrompts++
+						if text := sanitizePrompt(raw); text != "" {
+							if d.FirstPrompt == "" {
+								d.FirstPrompt = text
+							}
+							d.LastPrompt = text
 						}
-						d.LastPrompt = text
 					}
 				}
 			}
@@ -595,17 +616,21 @@ func readTitle(path string) string {
 		}
 	}
 
-	// Fallback 2 — the first user entry whose content is a bare STRING, on a
-	// transcript that records no promptSource AT ALL.
+	// Fallback 2 — the first user entry whose content is a bare STRING and is
+	// not claude's own text.
 	//
-	// The PromptSource=="" condition is the correctness guard, not a nicety.
-	// Gating only on "the typed pass found nothing" would also fire for a
-	// CURRENT-schema transcript that happens to contain no typed prompt but
-	// does contain non-typed string-content user entries — slash-command
-	// expansions and compaction-continuation summaries, which are exactly what
-	// the promptSource=="typed" filter exists to exclude. Those would become
-	// titles, and a compaction summary makes a grotesque one. Keying on the
-	// field's ABSENCE confines this to schemas that never record it.
+	// PromptSource=="" is necessary but nowhere near sufficient, and this
+	// comment used to claim it "confines this to schemas that never record"
+	// the field. It cannot: it is a PER-ENTRY test and says nothing about the
+	// transcript. A current-schema file is full of user entries carrying no
+	// promptSource — tool results, slash-command expansions, hook notices —
+	// and every one of them passed. Sessions were titled "a", "main-agent" and
+	// a directory path because of it.
+	//
+	// isMachinery is what establishes the content is a prompt. The
+	// promptSource test STAYS: it is what excludes the non-typed SOURCES
+	// (sdk, queued, compact) — real input, but not typed input, and widening
+	// that set is a separate decision.
 	for _, line := range lines {
 		if !bytes.Contains(line, []byte(`"type":"user"`)) {
 			continue
@@ -618,8 +643,12 @@ func readTitle(path string) string {
 			!contentIsString(tl.Message.Content) {
 			continue
 		}
-		if text := sanitizeTitle(contentText(tl.Message.Content, MaxTitleRunes)); text != "" {
-			return text
+		text := contentText(tl.Message.Content, MaxTitleRunes)
+		if isMachinery(tl, text) {
+			continue
+		}
+		if title := sanitizeTitle(text); title != "" {
+			return title
 		}
 	}
 	return ""
@@ -633,6 +662,56 @@ func readTitle(path string) string {
 // Tests the raw token rather than round-tripping through json.Unmarshal, which
 // accepts JSON null into a string and reports success — so `"content": null`
 // counted as a prompt and inflated UserPrompts by one, with empty text.
+// machineryTags are the wrappers claude puts around its own text in the user
+// turn. Derived from the transcripts on one developer's machine, counting only
+// entries whose message.content is a STRING — the only ones the shape-detecting
+// passes can reach.
+//
+// Six, not more: local-command-caveat and system-reminder are covered by isMeta
+// on every observed entry, and listing them here as well would hide which
+// mechanism is load-bearing. tool_use_error, persisted-output and
+// retrieval_status occur only inside ARRAY content, which contentIsString
+// rejects before this runs.
+var machineryTags = []string{
+	"task-notification",
+	"command-name",
+	"command-message",
+	"local-command-stdout",
+	"bash-stdout",
+	"bash-input",
+}
+
+// isMachinery reports whether a user entry is claude's own text rather than the
+// user's, and so must not become a title or count as a prompt.
+//
+// Three tests, in cost order. The first two are field reads on the already
+// decoded entry; only the third touches the content. All three run solely on
+// the shape-detecting fallback paths — an entry reaches them only after failing
+// the promptSource=="typed" test, so the fast path pays nothing.
+//
+// Each is independently load-bearing: a tool result carries no tag and no
+// isMeta; a hook notice carries isMeta and no tag; command markup carries a tag
+// and neither field.
+func isMachinery(tl transcriptLine, content string) bool {
+	if len(tl.ToolUseResult) > 0 {
+		return true
+	}
+	if tl.IsMeta {
+		return true
+	}
+	// Prefix, never substring: a prompt that MENTIONS <command-name> is prose.
+	// Both delimiters, because <command-name> closes immediately while
+	// <task-notification …> carries attributes. No TrimSpace — every observed
+	// machinery entry opens its tag at byte 0, and a whitespace-prefixed tag is
+	// therefore a miss, which yields the behaviour we have today.
+	for _, tag := range machineryTags {
+		if strings.HasPrefix(content, "<"+tag+">") || strings.HasPrefix(content, "<"+tag+" ") {
+			return true
+		}
+	}
+	return false
+}
+
 func contentIsString(raw json.RawMessage) bool {
 	raw = bytes.TrimSpace(raw)
 	return len(raw) > 0 && raw[0] == '"'

--- a/internal/claudesessions/claudesessions.go
+++ b/internal/claudesessions/claudesessions.go
@@ -713,11 +713,11 @@ func recordsPromptSource(f *os.File) bool {
 		return false
 	}
 	found := bytes.Contains(head, []byte(`"promptSource":"`))
-	// Restore the offset for the caller. The pass seeks to 0 itself, so this is
-	// belt-and-braces; a failure here answers false and lets it run.
-	if _, err := f.Seek(0, io.SeekStart); err != nil {
-		return false
-	}
+	// Restore the offset for the caller. Deliberately NOT checked: the answer is
+	// already computed, and letting a failed restore turn a true into a false
+	// would send the caller into the very pass this gate exists to skip. The
+	// pass re-seeks and handles its own failure anyway.
+	_, _ = f.Seek(0, io.SeekStart)
 	return found
 }
 
@@ -744,9 +744,11 @@ var machineryTags = []string{
 // user's, and so must not become a title or count as a prompt.
 //
 // Three tests, in cost order. The first two are field reads on the already
-// decoded entry; only the third touches the content. All three run solely on
-// the shape-detecting fallback paths — an entry reaches them only after failing
-// the promptSource=="typed" test, so the fast path pays nothing.
+// decoded entry; only the third touches the content, which the caller passes in
+// because it already decoded it — that is the whole reason for the parameter,
+// not any difference between the two call sites' rune limits. All three run
+// solely on the shape-detecting fallback paths: an entry reaches them only
+// after failing the promptSource=="typed" test, so the fast path pays nothing.
 //
 // Each is independently load-bearing: a tool result carries no tag and no
 // isMeta; a hook notice carries isMeta and no tag; command markup carries a tag

--- a/internal/claudesessions/claudesessions.go
+++ b/internal/claudesessions/claudesessions.go
@@ -704,6 +704,15 @@ func readTitle(path string) string {
 // value is also a string. The residual cost is one blank detail panel on an
 // old-schema transcript that happens to contain such a key, which is why this
 // is a substring test and not a parse.
+//
+// That `:"` also makes the test sensitive to JSON spacing — a
+// `"promptSource": "typed"` with a space would miss it. That cannot cost a
+// prompt, and the reason is structural rather than a fact about Claude's
+// serializer: this needle is a strict prefix of typedMark, the mark the
+// whole-file pass above searches for. Any formatting that hides the field from
+// this gate hides it from that pass first, so the pass finds no typed prompt,
+// the gate answers false, and the rescan runs — which is the behaviour without
+// a gate at all. The gate can never be stricter than the path it guards.
 func recordsPromptSource(f *os.File) bool {
 	if _, err := f.Seek(0, io.SeekStart); err != nil {
 		return false

--- a/internal/claudesessions/claudesessions_test.go
+++ b/internal/claudesessions/claudesessions_test.go
@@ -851,16 +851,19 @@ func TestReadTitle_ToolResultIsNotATitle(t *testing.T) {
 	}
 }
 
-// An explicit null is ABSENT, not present. encoding/json hands null to a custom
-// unmarshaler rather than skipping it, so jsonPresent has to say so itself —
-// the same call contentIsString had to make for `"content": null`. Treating it
-// as present would discard a real prompt.
-func TestReadTitle_NullToolUseResultIsNotMachinery(t *testing.T) {
+// A null toolUseResult is still a tool result: the KEY is what marks the record,
+// and a tool that returned nothing has not stopped being a tool. encoding/json
+// routes null to a custom unmarshaler rather than skipping it, so this pins
+// which answer jsonPresent gives — the permissive reading would let tool output
+// through filter 1 with only isMeta and the tag denylist left, and untagged tool
+// output is exactly what those two do not catch.
+func TestReadTitle_NullToolUseResultIsStillAToolResult(t *testing.T) {
 	path := writeSchemaTranscript(t,
-		`{"type":"user","isSidechain":false,"toolUseResult":null,"message":{"role":"user","content":"a real prompt"}}`,
+		`{"type":"user","isSidechain":false,"toolUseResult":null,"message":{"role":"user","content":"tool output, not a prompt"}}`,
+		plainUserEntry("the real prompt"),
 	)
-	if got := readTitle(path); got != "a real prompt" {
-		t.Errorf("readTitle = %q, want the prompt — a null toolUseResult is absent, not present", got)
+	if got := readTitle(path); got != "the real prompt" {
+		t.Errorf("readTitle = %q, want the real prompt — the key marks a tool result whatever it holds", got)
 	}
 }
 

--- a/internal/claudesessions/claudesessions_test.go
+++ b/internal/claudesessions/claudesessions_test.go
@@ -884,6 +884,33 @@ func TestReadTitle_CommandMarkupIsNotATitle(t *testing.T) {
 	}
 }
 
+// The closing delimiter is what makes the denylist a TAG match rather than a
+// name-prefix match. Without it every tag also swallows every longer name that
+// starts with it — `bash` would eat `bash-input`, `command-name` would eat this.
+// Weakening the check to a bare HasPrefix passes every other test in this file.
+func TestReadTitle_TagPrefixWithoutDelimiterIsNotMachinery(t *testing.T) {
+	path := writeSchemaTranscript(t,
+		plainUserEntry("<command-nameless> is not one of claude's tags"),
+	)
+	if got := readTitle(path); got == "" {
+		t.Error("readTitle = empty, want the entry — only the exact tag plus a delimiter is machinery")
+	}
+}
+
+// isMachinery deliberately does NOT trim, and this pins that: every observed
+// machinery entry opens its tag at byte 0, so a leading space means the entry
+// is not the shape we are rejecting, and the result is what we do today.
+// Adding a TrimSpace passes every other test in this file, so without this the
+// documented behaviour is prose only.
+func TestReadTitle_WhitespacePrefixedTagIsNotMachinery(t *testing.T) {
+	path := writeSchemaTranscript(t,
+		plainUserEntry("   <command-name>/goal</command-name>"),
+	)
+	if got := readTitle(path); got == "" {
+		t.Error("readTitle = empty, want the entry — the tag test is not trimmed, by design")
+	}
+}
+
 // The denylist must reject CLAUDE's markup, not markup in general. A user who
 // pastes HTML has typed a prompt.
 func TestReadTitle_UserPastedMarkupIsATitle(t *testing.T) {

--- a/internal/claudesessions/claudesessions_test.go
+++ b/internal/claudesessions/claudesessions_test.go
@@ -939,3 +939,66 @@ func TestReadDetail_NullContentIsNotAPrompt(t *testing.T) {
 		t.Errorf("FirstPrompt = %q, want %q", d.FirstPrompt, "a real one")
 	}
 }
+
+func TestTranscriptPathIn_DoesNotConsultEnv(t *testing.T) {
+	t.Setenv(claudeConfigDirEnv, filepath.Join(t.TempDir(), "should-not-be-read"))
+	got := TranscriptPathIn("/explicit", "/work/repo", "abc-123")
+	want := filepath.Join("/explicit", "projects", EscapeCWD("/work/repo"), "abc-123.jsonl")
+	if got != want {
+		t.Errorf("TranscriptPathIn = %q, want %q", got, want)
+	}
+}
+
+func TestTranscriptPathIn_EmptyArgsReturnEmpty(t *testing.T) {
+	if got := TranscriptPathIn("/explicit", "/work/repo", ""); got != "" {
+		t.Errorf("empty session id = %q, want empty", got)
+	}
+	if got := TranscriptPathIn("/explicit", "", "abc-123"); got != "" {
+		t.Errorf("empty cwd = %q, want empty", got)
+	}
+}
+
+// TranscriptPath must DELEGATE rather than carry a second copy of the join —
+// two spellings of one path is how they drift.
+func TestTranscriptPath_AgreesWithTranscriptPathIn(t *testing.T) {
+	cfg := t.TempDir()
+	t.Setenv(claudeConfigDirEnv, cfg)
+	got := TranscriptPath("/work/repo", "abc-123")
+	want := TranscriptPathIn(cfg, "/work/repo", "abc-123")
+	if got == "" {
+		t.Fatal("TranscriptPath returned empty with the config dir set")
+	}
+	if got != want {
+		t.Errorf("TranscriptPath = %q, TranscriptPathIn = %q; the two must agree", got, want)
+	}
+}
+
+// The join ReadDetailIn uses must be the one under test, not a parallel copy:
+// point TranscriptPathIn at a real file and assert ReadDetailIn reads THAT one.
+// Before this, TestTranscriptPath_BuildsJSONLPath certified a join with no
+// production caller while the join actually used had no direct test.
+func TestReadDetailIn_ReadsPathFromTranscriptPathIn(t *testing.T) {
+	cfg := t.TempDir()
+	const cwd = "/work/repo"
+	const id = "11111111-2222-3333-4444-555555555555"
+
+	path := TranscriptPathIn(cfg, cwd, id)
+	if path == "" {
+		t.Fatal("TranscriptPathIn returned empty")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(typedPrompt("the only prompt")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	d, err := ReadDetailIn(context.Background(), cfg, cwd, id)
+	if err != nil {
+		t.Fatalf("ReadDetailIn: %v", err)
+	}
+	if d.FirstPrompt != "the only prompt" {
+		t.Errorf("FirstPrompt = %q, want %q — ReadDetailIn is not reading the path TranscriptPathIn builds",
+			d.FirstPrompt, "the only prompt")
+	}
+}

--- a/internal/claudesessions/claudesessions_test.go
+++ b/internal/claudesessions/claudesessions_test.go
@@ -900,6 +900,81 @@ func TestReadDetail_CommandMarkupIsNotAPrompt(t *testing.T) {
 // shape-detecting pass. The count is incremented separately from the text, so a
 // text-only assertion can pass while UserPrompts is wrong — which is the
 // stronger failure this pass can produce.
+// --- the schema gate on readDetail's second pass ----------------------------
+
+// A transcript that RECORDS promptSource but has no typed prompt must not be
+// rescanned: every entry the rescan could accept lacks the field, and on a
+// recording transcript that proves the entry is not a typed prompt.
+//
+// The two plain entries are load-bearing. They carry no toolUseResult, no
+// isMeta and no tag, so they survive every filter above — without them the
+// rescan would find nothing anyway and this would pass with the gate deleted.
+func TestReadDetail_RecordingTranscriptWithNoTypedPromptIsNotRescanned(t *testing.T) {
+	path := writeSchemaTranscript(t,
+		`{"type":"user","promptSource":"compact","message":{"content":"continued from a previous conversation"}}`,
+		plainUserEntry("something the rescan would otherwise count"),
+		plainUserEntry("and another"),
+	)
+	d, err := readDetail(context.Background(), path, "11111111-2222-3333-4444-555555555555")
+	if err != nil {
+		t.Fatalf("readDetail: %v", err)
+	}
+	if d.UserPrompts != 0 {
+		t.Errorf("UserPrompts = %d, want 0 — this transcript records promptSource, so an entry lacking it is not a typed prompt", d.UserPrompts)
+	}
+}
+
+// padTranscript returns filler lines totalling more than titleScanBytes, so a
+// caller can place an entry beyond the head window.
+func padTranscript() []string {
+	var out []string
+	for len(out)*96 < titleScanBytes+4096 {
+		out = append(out, assistantMsg("filler line to push the tail past the scan window"))
+	}
+	return out
+}
+
+// The gate's FALSE-NEGATIVE direction, and the only fixture that exercises it:
+// promptSource appears only past the 64 KiB head, so the gate answers false and
+// the rescan runs. The result must equal today's behaviour — that equivalence
+// is what makes a head sample an acceptable proxy for a whole-file question.
+func TestReadDetail_PromptSourceBeyondHeadStillRescans(t *testing.T) {
+	lines := append([]string{plainUserEntry("an old-schema prompt in the head")}, padTranscript()...)
+	lines = append(lines, `{"type":"user","promptSource":"compact","message":{"content":"a late current-schema entry"}}`)
+
+	path := writeSchemaTranscript(t, lines...)
+	d, err := readDetail(context.Background(), path, "11111111-2222-3333-4444-555555555555")
+	if err != nil {
+		t.Fatalf("readDetail: %v", err)
+	}
+	if d.UserPrompts != 1 || d.FirstPrompt != "an old-schema prompt in the head" {
+		t.Errorf("UserPrompts = %d, FirstPrompt = %q; want 1 and the head prompt — a field beyond the window must not gate the rescan off",
+			d.UserPrompts, d.FirstPrompt)
+	}
+}
+
+// A transcript that outlived a claude upgrade: old-schema head, typed prompt
+// only in the tail. This pins the head/whole-file split — readTitle sees only
+// the head and falls back, readDetail scans everything and finds the typed
+// prompt. It says NOTHING about the gate: with UserPrompts >= 1 the && ahead of
+// recordsPromptSource short-circuits and the gate is never consulted.
+func TestMixedSchemaTranscript_TitleFallsBackButDetailFindsTheTypedPrompt(t *testing.T) {
+	lines := append([]string{plainUserEntry("the old-schema head prompt")}, padTranscript()...)
+	lines = append(lines, typedPrompt("the typed prompt in the tail"))
+
+	path := writeSchemaTranscript(t, lines...)
+	if got := readTitle(path); got != "the old-schema head prompt" {
+		t.Errorf("readTitle = %q, want the head prompt — readTitle only ever reads the head", got)
+	}
+	d, err := readDetail(context.Background(), path, "11111111-2222-3333-4444-555555555555")
+	if err != nil {
+		t.Fatalf("readDetail: %v", err)
+	}
+	if d.UserPrompts != 1 || d.FirstPrompt != "the typed prompt in the tail" {
+		t.Errorf("UserPrompts = %d, FirstPrompt = %q; want 1 and the tail prompt", d.UserPrompts, d.FirstPrompt)
+	}
+}
+
 func assertDetailIgnoresMachinery(t *testing.T, machinery string) {
 	t.Helper()
 	path := writeSchemaTranscript(t, machinery, plainUserEntry("the real prompt"))

--- a/internal/claudesessions/claudesessions_test.go
+++ b/internal/claudesessions/claudesessions_test.go
@@ -998,12 +998,35 @@ func TestReadDetail_RecordingTranscriptWithNoTypedPromptIsNotRescanned(t *testin
 
 // padTranscript returns filler lines totalling more than titleScanBytes, so a
 // caller can place an entry beyond the head window.
+//
+// Counts the filler's ACTUAL bytes rather than estimating them. An estimate
+// gets the safety direction wrong in a way that fails silently: guess too high
+// and the loop stops early, the padding falls short of the window, and the
+// entry a caller meant to put BEYOND the head lands inside it — the test still
+// passes, having stopped testing what it claims. Measuring cannot drift when
+// the filler text is edited.
 func padTranscript() []string {
+	filler := assistantMsg("filler line to push the tail past the scan window")
 	var out []string
-	for len(out)*180 < titleScanBytes+4096 {
-		out = append(out, assistantMsg("filler line to push the tail past the scan window"))
+	for n := 0; n <= titleScanBytes; n += len(filler) + 1 { // +1 for the joining newline
+		out = append(out, filler)
 	}
 	return out
+}
+
+// The two tests that place an entry "beyond the head" are only meaningful if
+// the padding really does clear titleScanBytes. Nothing else would notice if it
+// stopped — both tests would keep passing against an entry that had quietly
+// moved inside the window.
+func TestPadTranscript_ClearsTheHeadWindow(t *testing.T) {
+	n := 0
+	for _, line := range padTranscript() {
+		n += len(line) + 1
+	}
+	if n <= titleScanBytes {
+		t.Fatalf("padding = %d bytes, want more than titleScanBytes (%d) — an entry placed after it would land INSIDE the head window",
+			n, titleScanBytes)
+	}
 }
 
 // The gate's FALSE-NEGATIVE direction, and the only fixture that exercises it:

--- a/internal/claudesessions/claudesessions_test.go
+++ b/internal/claudesessions/claudesessions_test.go
@@ -1005,10 +1005,17 @@ func TestReadDetail_RecordingTranscriptWithNoTypedPromptIsNotRescanned(t *testin
 // entry a caller meant to put BEYOND the head lands inside it — the test still
 // passes, having stopped testing what it claims. Measuring cannot drift when
 // the filler text is edited.
+// padSlack is margin over the window, not a fudge factor. Measuring the filler
+// exactly guarantees only that the total EXCEEDS titleScanBytes — by as little
+// as one byte, depending on where the last line falls. The callers append their
+// own entry after this padding and need it comfortably clear, so the slack is
+// kept deliberately rather than trimmed to the minimum that satisfies the loop.
+const padSlack = 4096
+
 func padTranscript() []string {
 	filler := assistantMsg("filler line to push the tail past the scan window")
 	var out []string
-	for n := 0; n <= titleScanBytes; n += len(filler) + 1 { // +1 for the joining newline
+	for n := 0; n <= titleScanBytes+padSlack; n += len(filler) + 1 { // +1 for the joining newline
 		out = append(out, filler)
 	}
 	return out
@@ -1023,9 +1030,9 @@ func TestPadTranscript_ClearsTheHeadWindow(t *testing.T) {
 	for _, line := range padTranscript() {
 		n += len(line) + 1
 	}
-	if n <= titleScanBytes {
-		t.Fatalf("padding = %d bytes, want more than titleScanBytes (%d) — an entry placed after it would land INSIDE the head window",
-			n, titleScanBytes)
+	if n <= titleScanBytes+padSlack {
+		t.Fatalf("padding = %d bytes, want more than titleScanBytes+padSlack (%d) — an entry placed after it would be too close to the head window",
+			n, titleScanBytes+padSlack)
 	}
 }
 

--- a/internal/claudesessions/claudesessions_test.go
+++ b/internal/claudesessions/claudesessions_test.go
@@ -892,8 +892,9 @@ func TestReadTitle_TagPrefixWithoutDelimiterIsNotMachinery(t *testing.T) {
 	path := writeSchemaTranscript(t,
 		plainUserEntry("<command-nameless> is not one of claude's tags"),
 	)
-	if got := readTitle(path); got == "" {
-		t.Error("readTitle = empty, want the entry — only the exact tag plus a delimiter is machinery")
+	const want = "<command-nameless> is not one of claude's tags"
+	if got := readTitle(path); got != want {
+		t.Errorf("readTitle = %q, want %q — only the exact tag plus a delimiter is machinery", got, want)
 	}
 }
 
@@ -906,8 +907,23 @@ func TestReadTitle_WhitespacePrefixedTagIsNotMachinery(t *testing.T) {
 	path := writeSchemaTranscript(t,
 		plainUserEntry("   <command-name>/goal</command-name>"),
 	)
-	if got := readTitle(path); got == "" {
-		t.Error("readTitle = empty, want the entry — the tag test is not trimmed, by design")
+	const want = "<command-name>/goal</command-name>"
+	if got := readTitle(path); got != want {
+		t.Errorf("readTitle = %q, want %q — the tag test is not trimmed, by design", got, want)
+	}
+}
+
+// The second delimiter, the one that admits attributes. task-notification is
+// the first tag in the denylist and the reason the branch exists — it is the
+// only observed form that carries them. Deleting that half of the check leaves
+// every other test green.
+func TestReadTitle_TagWithAttributesIsMachinery(t *testing.T) {
+	path := writeSchemaTranscript(t,
+		plainUserEntry(`<task-notification agent="impl-task7">done</task-notification>`),
+		plainUserEntry("the real prompt"),
+	)
+	if got := readTitle(path); got != "the real prompt" {
+		t.Errorf("readTitle = %q, want the real prompt — a tag with attributes is still machinery", got)
 	}
 }
 
@@ -917,8 +933,9 @@ func TestReadTitle_UserPastedMarkupIsATitle(t *testing.T) {
 	path := writeSchemaTranscript(t,
 		plainUserEntry("<html><body>why does this render wrong?</body></html>"),
 	)
-	if got := readTitle(path); got == "" {
-		t.Error("readTitle = empty, want the pasted markup — only claude's own tags are machinery")
+	const want = "<html><body>why does this render wrong?</body></html>"
+	if got := readTitle(path); got != want {
+		t.Errorf("readTitle = %q, want %q — only claude's own tags are machinery", got, want)
 	}
 }
 
@@ -934,11 +951,28 @@ func TestReadDetail_CommandMarkupIsNotAPrompt(t *testing.T) {
 	assertDetailIgnoresMachinery(t, plainUserEntry("<local-command-stdout>ok</local-command-stdout>"))
 }
 
-// assertDetailIgnoresMachinery pins BOTH halves of a rejection in readDetail's
-// shape-detecting pass. The count is incremented separately from the text, so a
-// text-only assertion can pass while UserPrompts is wrong — which is the
-// stronger failure this pass can produce.
 // --- the schema gate on readDetail's second pass ----------------------------
+
+// The needle is `"promptSource":"`, including the value's opening quote, and
+// this is what pins the narrowing. A nested KEY inside a tool result is not
+// JSON-escaped, so the wider `"promptSource"` needle matched it and gated the
+// rescan off on a transcript that records nothing of the sort — costing the
+// real prompt below. Reverting that one character sequence leaves every other
+// test in this package green.
+func TestReadDetail_NestedPromptSourceKeyDoesNotGateTheRescan(t *testing.T) {
+	path := writeSchemaTranscript(t,
+		`{"type":"user","isSidechain":false,"toolUseResult":{"promptSource":null},"message":{"role":"user","content":"tool output"}}`,
+		plainUserEntry("a real old-schema prompt"),
+	)
+	d, err := readDetail(context.Background(), path, "11111111-2222-3333-4444-555555555555")
+	if err != nil {
+		t.Fatalf("readDetail: %v", err)
+	}
+	if d.UserPrompts != 1 || d.FirstPrompt != "a real old-schema prompt" {
+		t.Errorf("UserPrompts = %d, FirstPrompt = %q; want 1 and the real prompt — a nested promptSource KEY is not a schema marker",
+			d.UserPrompts, d.FirstPrompt)
+	}
+}
 
 // A transcript that RECORDS promptSource but has no typed prompt must not be
 // rescanned: every entry the rescan could accept lacks the field, and on a
@@ -966,7 +1000,7 @@ func TestReadDetail_RecordingTranscriptWithNoTypedPromptIsNotRescanned(t *testin
 // caller can place an entry beyond the head window.
 func padTranscript() []string {
 	var out []string
-	for len(out)*96 < titleScanBytes+4096 {
+	for len(out)*180 < titleScanBytes+4096 {
 		out = append(out, assistantMsg("filler line to push the tail past the scan window"))
 	}
 	return out
@@ -1013,6 +1047,10 @@ func TestMixedSchemaTranscript_TitleFallsBackButDetailFindsTheTypedPrompt(t *tes
 	}
 }
 
+// assertDetailIgnoresMachinery pins BOTH halves of a rejection in readDetail's
+// shape-detecting pass. The count is incremented separately from the text, so a
+// text-only assertion can pass while UserPrompts is wrong — which is the
+// stronger failure this pass can produce.
 func assertDetailIgnoresMachinery(t *testing.T, machinery string) {
 	t.Helper()
 	path := writeSchemaTranscript(t, machinery, plainUserEntry("the real prompt"))

--- a/internal/claudesessions/claudesessions_test.go
+++ b/internal/claudesessions/claudesessions_test.go
@@ -401,9 +401,31 @@ func TestReadTitle_PromptBeyondScanWindow_ReturnsEmpty(t *testing.T) {
 
 // toolResult builds the shape claude records for a tool result: type "user",
 // but with no promptSource, because the user did not type it.
+// toolResult builds the entry claude writes for a tool RESULT: type "user",
+// but carrying a top-level toolUseResult. The content is a bare STRING, which
+// is the common case and the reason content shape cannot classify these — the
+// sibling field is what identifies them.
 func toolResult(text string) string {
 	return fmt.Sprintf(
-		`{"type":"user","isSidechain":false,"message":{"role":"user","content":%q},"timestamp":"2026-07-01T10:05:00.000Z"}`,
+		`{"type":"user","isSidechain":false,"toolUseResult":{"stdout":"…"},"message":{"role":"user","content":%q},"timestamp":"2026-07-01T10:05:00.000Z"}`,
+		text)
+}
+
+// metaEntry builds a claude-injected meta entry: no tag, no toolUseResult, only
+// isMeta. Hook notices take this shape, so isMeta is the only marker that
+// identifies them.
+func metaEntry(text string) string {
+	return fmt.Sprintf(
+		`{"type":"user","isSidechain":false,"isMeta":true,"message":{"role":"user","content":%q},"timestamp":"2026-07-01T10:06:00.000Z"}`,
+		text)
+}
+
+// plainUserEntry is an old-schema user entry carrying no marker at all — no
+// promptSource, no isMeta, no toolUseResult. This is what a real prompt looks
+// like on a build that predates promptSource.
+func plainUserEntry(text string) string {
+	return fmt.Sprintf(
+		`{"type":"user","isSidechain":false,"message":{"role":"user","content":%q},"timestamp":"2026-07-01T10:07:00.000Z"}`,
 		text)
 }
 
@@ -797,6 +819,99 @@ func TestReadTitle_AiTitleFiresOnCurrentSchemaWithNoTypedPrompt(t *testing.T) {
 	)
 	if got := readTitle(path); got != "Refactor the parser" {
 		t.Errorf("readTitle = %q, want the ai-title — the pass must not be gated on promptSource being absent", got)
+	}
+}
+
+// --- machinery rejection ----------------------------------------------------
+//
+// The shape-detecting passes promote message CONTENT, so they must first
+// establish the content is a prompt. promptSource-absence cannot do that: it is
+// a per-entry test, and entries that are not prompts routinely carry no
+// promptSource. Three markers separate them, and each fixture below is
+// reachable only by the one it targets — a fixture carrying two markers would
+// stay green with either filter deleted.
+
+// The PRESERVATION test. It must keep passing through every filter added: an
+// old-schema transcript whose first string-content entry is ordinary prose is
+// the case the fallback exists to serve.
+func TestReadTitle_OldSchemaProsePromptIsPreserved(t *testing.T) {
+	path := writeSchemaTranscript(t,
+		plainUserEntry("Read docs/global-question-domain.md and summarise it"),
+	)
+	if got := readTitle(path); got != "Read docs/global-question-domain.md and summarise it" {
+		t.Errorf("readTitle = %q, want the real prompt", got)
+	}
+}
+
+func TestReadTitle_ToolResultIsNotATitle(t *testing.T) {
+	path := writeSchemaTranscript(t,
+		toolResult("total 9224 -rw-r--r-- 1 artjo"),
+		plainUserEntry("the real prompt"),
+	)
+	if got := readTitle(path); got != "the real prompt" {
+		t.Errorf("readTitle = %q, want the real prompt — a tool result is not a prompt", got)
+	}
+}
+
+func TestReadTitle_MetaEntryIsNotATitle(t *testing.T) {
+	path := writeSchemaTranscript(t,
+		metaEntry("A session-scoped Stop hook is now active"),
+		plainUserEntry("the real prompt"),
+	)
+	if got := readTitle(path); got != "the real prompt" {
+		t.Errorf("readTitle = %q, want the real prompt — isMeta marks claude's own text", got)
+	}
+}
+
+func TestReadTitle_CommandMarkupIsNotATitle(t *testing.T) {
+	path := writeSchemaTranscript(t,
+		plainUserEntry("<command-name>/goal</command-name> <command-message>goal</command-message>"),
+		plainUserEntry("the real prompt"),
+	)
+	if got := readTitle(path); got != "the real prompt" {
+		t.Errorf("readTitle = %q, want the real prompt — command markup is not a prompt", got)
+	}
+}
+
+// The denylist must reject CLAUDE's markup, not markup in general. A user who
+// pastes HTML has typed a prompt.
+func TestReadTitle_UserPastedMarkupIsATitle(t *testing.T) {
+	path := writeSchemaTranscript(t,
+		plainUserEntry("<html><body>why does this render wrong?</body></html>"),
+	)
+	if got := readTitle(path); got == "" {
+		t.Error("readTitle = empty, want the pasted markup — only claude's own tags are machinery")
+	}
+}
+
+func TestReadDetail_ToolResultIsNotAPrompt(t *testing.T) {
+	assertDetailIgnoresMachinery(t, toolResult("main-agent"))
+}
+
+func TestReadDetail_MetaEntryIsNotAPrompt(t *testing.T) {
+	assertDetailIgnoresMachinery(t, metaEntry("A session-scoped Stop hook is now active"))
+}
+
+func TestReadDetail_CommandMarkupIsNotAPrompt(t *testing.T) {
+	assertDetailIgnoresMachinery(t, plainUserEntry("<local-command-stdout>ok</local-command-stdout>"))
+}
+
+// assertDetailIgnoresMachinery pins BOTH halves of a rejection in readDetail's
+// shape-detecting pass. The count is incremented separately from the text, so a
+// text-only assertion can pass while UserPrompts is wrong — which is the
+// stronger failure this pass can produce.
+func assertDetailIgnoresMachinery(t *testing.T, machinery string) {
+	t.Helper()
+	path := writeSchemaTranscript(t, machinery, plainUserEntry("the real prompt"))
+	d, err := readDetail(context.Background(), path, "11111111-2222-3333-4444-555555555555")
+	if err != nil {
+		t.Fatalf("readDetail: %v", err)
+	}
+	if d.UserPrompts != 1 {
+		t.Errorf("UserPrompts = %d, want 1 — the machinery entry was counted", d.UserPrompts)
+	}
+	if d.FirstPrompt != "the real prompt" {
+		t.Errorf("FirstPrompt = %q, want %q", d.FirstPrompt, "the real prompt")
 	}
 }
 

--- a/internal/claudesessions/claudesessions_test.go
+++ b/internal/claudesessions/claudesessions_test.go
@@ -399,8 +399,6 @@ func TestReadTitle_PromptBeyondScanWindow_ReturnsEmpty(t *testing.T) {
 
 // --- ReadDetail ------------------------------------------------------------
 
-// toolResult builds the shape claude records for a tool result: type "user",
-// but with no promptSource, because the user did not type it.
 // toolResult builds the entry claude writes for a tool RESULT: type "user",
 // but carrying a top-level toolUseResult. The content is a bare STRING, which
 // is the common case and the reason content shape cannot classify these — the
@@ -850,6 +848,19 @@ func TestReadTitle_ToolResultIsNotATitle(t *testing.T) {
 	)
 	if got := readTitle(path); got != "the real prompt" {
 		t.Errorf("readTitle = %q, want the real prompt — a tool result is not a prompt", got)
+	}
+}
+
+// An explicit null is ABSENT, not present. encoding/json hands null to a custom
+// unmarshaler rather than skipping it, so jsonPresent has to say so itself —
+// the same call contentIsString had to make for `"content": null`. Treating it
+// as present would discard a real prompt.
+func TestReadTitle_NullToolUseResultIsNotMachinery(t *testing.T) {
+	path := writeSchemaTranscript(t,
+		`{"type":"user","isSidechain":false,"toolUseResult":null,"message":{"role":"user","content":"a real prompt"}}`,
+	)
+	if got := readTitle(path); got != "a real prompt" {
+		t.Errorf("readTitle = %q, want the prompt — a null toolUseResult is absent, not present", got)
 	}
 }
 

--- a/internal/claudesessions/claudesessions_test.go
+++ b/internal/claudesessions/claudesessions_test.go
@@ -780,6 +780,26 @@ func TestReadTitle_FallsBackToAiTitle(t *testing.T) {
 	}
 }
 
+// The guard that must NOT be added. Reading the pass below this one, it is
+// natural to conclude the ai-title pass is missing a matching
+// promptSource-absent condition. It is not: measured 2026-08-20, current Claude
+// builds emit ai-title entries AND promptSource, so that guard would make the
+// pass dead code on every current transcript.
+//
+// This transcript is the case it would kill — records promptSource, carries an
+// ai-title, has no typed prompt. TestReadTitle_FallsBackToAiTitle above does
+// not cover it: that fixture has no promptSource at all, so the guard would
+// leave it green while breaking this.
+func TestReadTitle_AiTitleFiresOnCurrentSchemaWithNoTypedPrompt(t *testing.T) {
+	path := writeSchemaTranscript(t,
+		`{"type":"ai-title","aiTitle":"Refactor the parser","leafUuid":"u1"}`,
+		`{"type":"user","promptSource":"compact","message":{"content":"This session is being continued from a previous conversation..."}}`,
+	)
+	if got := readTitle(path); got != "Refactor the parser" {
+		t.Errorf("readTitle = %q, want the ai-title — the pass must not be gated on promptSource being absent", got)
+	}
+}
+
 func TestReadTitle_FallsBackToStringContentUserEntry(t *testing.T) {
 	path := writeSchemaTranscript(t,
 		`{"type":"user","message":{"content":"no promptSource here"}}`,


### PR DESCRIPTION
Four changes in `internal/claudesessions`, all fallout from the transcript fallbacks added in #174. Design: `docs/superpowers/specs/2026-08-20-claudesessions-fallback-gaps-design.md`.

## The defect

`readTitle`'s shape-detecting fallback and `readDetail`'s second pass both gate on `tl.PromptSource == ""`, and both comments described that as a property of the *transcript*: *"a current-schema transcript can never be reclassified here."* It is a **per-entry** test. Transcripts that record `promptSource` are full of user entries that carry no `promptSource` — tool results, slash-command expansions, injected hook notices — and every one of them passed the guard.

Measured over the 193 transcripts `ListIn` can reach, ten sessions were titled from entries nobody typed:

| titled as | cause |
|---|---|
| `a`, `main-agent`, `E:/Projects/…/.claude/wor…` | tool results whose content is a bare string |
| `<command-name>/goal</command-name> …` ×3 | slash-command expansion |
| `<local-command-caveat>Caveat: …` ×2 | injected caveat |
| `<bash-input>git status</bash-input>` | `!`-prefix shell forward |

The same entries were counted as prompts in the detail panel, so its prompt count and first/last prompt were wrong in the same sessions.

## The fix

Classify by what the entry **is**, with three independent tests:

1. **`toolUseResult` present** marks a tool result. This is the one that matters most — `contentIsString` assumes string content means prompt and array content means tool result, but a tool result's content is a bare string far more often than not. Shape was never the discriminant; the sibling field is.
2. **`isMeta`** marks text Claude injected into the user turn, including hook notices that carry no wrapper tag at all.
3. **Six wrapper tags** cover the remaining machinery, matched as a prefix with a closing delimiter so a prompt that merely *mentions* one stays a prompt, and user-pasted `<html>` is untouched.

Neither field appears on a typed prompt anywhere in the sample (0 / 2,698 each).

The `promptSource` test **stays**. It is what excludes the non-typed sources (`sdk`, `queued`, `compact`) that are real input but not typed input; widening that set is a separate decision, recorded as a non-goal.

## Also in this PR

- **`TranscriptPath` no longer duplicates a join.** `ReadDetailIn` inlined its own copy when it gained an explicit config dir, leaving the exported spelling with no production caller and its test certifying a join nothing runs. Added `TranscriptPathIn` and routed both through it.
- **The `ai-title` fallback comment was false.** It claimed the pass serves builds that do not record `promptSource`. Current builds emit both, so the pass fires on current transcripts. The pass stays ungated — adding the guard its sibling carries would make it dead code — and is now justified on what it reads rather than by comparison with a sibling whose guard this PR is repairing.
- **`readDetail`'s rescan is skipped when the schema rules it out.** On a transcript that records `promptSource`, an entry lacking it is not a typed prompt, so the pass can only re-read the file to find nothing. 4 of 193 transcripts reach that state.

## Verification

```
./scripts/dev.sh vet         → exit 0
./scripts/dev.sh test        → all packages ok
./scripts/dev.sh test-race   → exit 0
```

Every new guard is mutation-checked and each fails only its own fixture at both call sites — no filter is shadowed by another:

| mutation | fails |
|---|---|
| filter 1 disabled | `TestReadTitle_ToolResultIsNotATitle`, `TestReadDetail_ToolResultIsNotAPrompt` |
| filter 2 disabled | `TestReadTitle_MetaEntryIsNotATitle`, `TestReadDetail_MetaEntryIsNotAPrompt` |
| filter 3 emptied | `TestReadTitle_CommandMarkupIsNotATitle`, `TestReadDetail_CommandMarkupIsNotAPrompt` |
| `recordsPromptSource` forced true | `TestReadDetail_FallsBackToShapeWhenNoPromptSource` + 5 more |
| `ai-title` pass gated on schema | `TestReadTitle_AiTitleFiresOnCurrentSchemaWithNoTypedPrompt` |

Beyond the unit tests, a throwaway in-package harness ran `readTitle` and `readDetail` against the real transcripts: all ten defect cases now yield no title, and the two transcripts that were correctly titled keep theirs. The harness was removed rather than committed — it reads a specific machine's data.

## Deliberately out of scope

- **Which `promptSource` values count as prompts.** `suggestion_accepted` (429 entries) and `queued` (47) are real user input the typed pass excludes. One consequence is recorded in the spec: `332fec5d`'s only real prompt is `queued`, so it goes from a wrong title to no title.
- **Which files `ListIn` treats as sessions.** 5 of the 193 hold no user entry at all (`attachment`, `last-prompt`, `mode`, `permission-mode`) and are listed as sessions regardless.
- **Widening `readTitle`'s scan window.** Four sessions whose real prompts sit past the 64 KiB head now show a session id where they previously showed machinery. Both are poor; the id is at least honest. Reading further costs a larger read across every listed session.

## Post-review changes

- **`recordsPromptSource`'s needle now includes the value's opening quote.** The old comment claimed content could never fake the field, which holds only for string *values* — a nested `promptSource` **key** inside a `toolUseResult` blob is unescaped and matched, gating the rescan off on a transcript that records no such thing. Narrowed to `"promptSource":"`, with a test.
- **`toolUseResult` decodes into a presence flag, not `json.RawMessage`.** Only presence was ever read, but `RawMessage` retained the whole blob — a copy of every command output on the rescan path. The new type also treats an explicit `null` as absent, closing a latent bug where a null field would have discarded a real prompt.
- **Two mutation-green branches now have tests**: the attribute form of the tag match (`<tag `, which exists for `task-notification`), and the needle narrowing above. Deleting either previously left the whole package passing.
- **Two documented behaviours now have tests**: the closing delimiter that makes the denylist a tag match rather than a name-prefix match, and the deliberate absence of a `TrimSpace`.
- Three assertions that checked only for non-empty now assert the expected title. `recordsPromptSource` no longer inverts a computed `true` when its courtesy seek fails. Struct alignment, a stranded doc comment, and a duplicated test comment fixed.
- **Changelog wording corrected.** It said the detail panel and the title "now agree". They do on every transcript observed, but nothing guarantees it — the title path is deliberately ungated where the detail path is gated on schema, which the design records as an accepted asymmetry. The entry now claims only what the change does.

Verification re-run after these: `vet` exit 0, all packages ok, `test-race` exit 0, gofmt clean, and every guard re-mutation-checked.

## Further changes

- **A null `toolUseResult` now counts as a tool result.** The presence type special-cased `null` as *absent*, which let such an entry past the tool-result filter with only `isMeta` and the tag denylist behind it — and untagged tool output is exactly what those two don't catch, so the permissive reading reopened the case this PR closes. It also contradicted the design doc, and its comment cited `contentIsString` as precedent when that rejects `null` and argues the opposite way. Measured before changing it: `toolUseResult` takes only object, string or array across 84,218 occurrences; `null` does not occur, so the branch was dead as well as wrong. The key marks the record, not its value — a tool that returned nothing has not stopped being a tool.
- **The scan-window padding is measured, not estimated, and keeps a named margin.** The helper's line-size constant was raised to match the real line length, which inverted its safety direction: the loop bound is `lines × estimate`, so guessing high stops early and under-pads. It now counts the filler's actual bytes and keeps the original `+4096` as a named `padSlack`, with a test that fails if either property is lost.
- **`recordsPromptSource` documents why it cannot be stricter than the pass it guards.** The `:"` needle is sensitive to JSON spacing, but it is a strict prefix of the mark the whole-file pass already searches for, so any formatting that hides the field here hides it there first — the gate then degrades to no gate. That is structural, where the previous note relied on a fact about Claude's serializer.
- Spec realigned with the shipped code.

Round 3 review: `security`, `rules` and `qa` returned no findings; `quality` returned the null-semantics divergence above. Verification re-run after: `vet` exit 0, all packages ok, `test-race` exit 0, gofmt clean, changelog valid, and every filter re-mutation-checked.
