### PR TITLE
chore(license): relicense from MIT to Apache-2.0

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -95,6 +95,29 @@ archives:
     # offering v1.55.2.
     allow_different_binary_count: true
     name_template: "quil_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    # Explicit, because the defaults are wrong in both directions. The default
+    # globs are LICENSE*, README* and CHANGELOG*, which MISS `NOTICE` and
+    # `MIT-LICENSE.txt` — and Apache-2.0 makes both an obligation rather than a
+    # courtesy: §4(a) says recipients get the licence, §4(d) says they get the
+    # NOTICE, and LICENSE itself points at MIT-LICENSE.txt, so shipping one
+    # without the other puts a dangling reference in a legal document.
+    #
+    # THIRD_PARTY_LICENSES.md carries Microsoft's MIT notice for the OpenConsole
+    # binaries that internal/pty/winconpty embeds into the Windows build. MIT
+    # requires that notice to travel with copies of the software, and the
+    # binary in this archive is one.
+    #
+    # The globs also sweep IN `changelog.d/README.md` — the contributor guide to
+    # writing fragments, which reached every user download of v1.63.0 and
+    # earlier. Listing files explicitly drops it.
+    files:
+      - LICENSE
+      - MIT-LICENSE.txt
+      - NOTICE
+      - TRADEMARK.md
+      - THIRD_PARTY_LICENSES.md
+      - README.md
+      - CHANGELOG.md
     formats:
       - tar.gz
     format_overrides:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,27 @@ PRs get squash-merged to `master` for a clean history. GitHub uses the **PR titl
 >
 > One file per PR is what keeps parallel PRs from conflicting: entries used to go under a shared `## [Unreleased]` heading in `CHANGELOG.md`, so two open PRs edited the same anchor line and the second to merge always conflicted. **Do not edit `CHANGELOG.md` directly** — the release workflow owns it.
 
+## Licensing of contributions
+
+Quil is licensed under the [Apache License 2.0](LICENSE). By opening a pull
+request you agree that your contribution is licensed under the same terms —
+this is Apache-2.0 section 5, which applies by default to anything you
+deliberately submit for inclusion, unless you state otherwise in the PR.
+
+There is no CLA and no copyright assignment. You keep your copyright.
+
+Two consequences worth knowing, because they are easy to get wrong:
+
+- **Only contribute code you have the right to contribute.** Your own work, or
+  work under a licence compatible with Apache-2.0 — and if it is the latter,
+  say where it came from in the PR description so the attribution can be
+  carried into [`NOTICE`](NOTICE) and
+  [`THIRD_PARTY_LICENSES.md`](THIRD_PARTY_LICENSES.md).
+- **The name is not covered by the licence.** Apache-2.0 grants rights over the
+  code and explicitly not over trade names or marks. If you are distributing a
+  modified build rather than contributing one, read [TRADEMARK.md](TRADEMARK.md)
+  — the short version is that forks are welcome and should carry their own name.
+
 ## Documentation maintenance
 
 When your change adds a new feature, configuration knob, or significant architectural decision:

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,202 @@
-MIT License
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2026 Artjoms Stukans
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,20 @@
+Quil is transitioning from the MIT License to the Apache License, Version 2.0
+("Apache-2.0"). All new contributions are licensed under Apache-2.0.
+
+Contributions for which relicensing consent has been obtained are licensed
+under Apache-2.0. Contributions made by authors who originally licensed their
+work under the MIT License and who have not granted explicit permission to
+relicense remain licensed under the MIT License, the text of which is
+reproduced in MIT-LICENSE.txt.
+
+No rights beyond those granted by the applicable original license are conveyed
+for such contributions.
+
+Releases published before this change remain under the MIT License they
+shipped with.
+
+---
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/MIT-LICENSE.txt
+++ b/MIT-LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Artjoms Stukans
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,11 @@
+Quil
+Copyright 2026 Artjoms Stukans
+
+This product includes software developed at
+https://github.com/artyomsv/quil
+
+Third-party components redistributed with this software, and their licenses,
+are listed in THIRD_PARTY_LICENSES.md.
+
+"Quil" and the Quil mark are trademarks of Artjoms Stukans. The Apache License
+grants no rights to them; see TRADEMARK.md.

--- a/NOTICE
+++ b/NOTICE
@@ -4,6 +4,10 @@ Copyright 2026 Artjoms Stukans
 This product includes software developed at
 https://github.com/artyomsv/quil
 
+Licensed under the Apache License, Version 2.0. Some contributions remain under
+the MIT License pending relicensing consent from their authors; see LICENSE and
+MIT-LICENSE.txt.
+
 Third-party components redistributed with this software, and their licenses,
 are listed in THIRD_PARTY_LICENSES.md.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **The persistent workflow orchestrator for AI-native development.**
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Go](https://img.shields.io/badge/Go-1.25-00ADD8.svg)](https://go.dev)
 [![Platform](https://img.shields.io/badge/Platform-Linux%20%7C%20macOS%20%7C%20Windows-lightgrey.svg)](#install)
 [![MCP](https://img.shields.io/badge/MCP-18%20tools-orange.svg)](docs/mcp.md)
@@ -239,6 +239,10 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for branch / commit conventions and the d
 
 ## License
 
-[MIT](LICENSE) — Copyright (c) 2026 Artjoms Stukans
+[Apache License 2.0](LICENSE) — Copyright 2026 Artjoms Stukans
+
+"Quil" and the Quil mark are trademarks of Artjoms Stukans. The licence covers the
+code, not the name — see [TRADEMARK.md](TRADEMARK.md) if you are distributing a
+modified build.
 
 The Windows build bundles Microsoft's MIT-licensed [OpenConsole](https://github.com/microsoft/terminal) (`OpenConsole.exe` + `conpty.dll`) to host terminal panes correctly on Windows 10. See [THIRD_PARTY_LICENSES.md](THIRD_PARTY_LICENSES.md) for full third-party attribution.

--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -1,0 +1,71 @@
+# Quil Trademark Policy
+
+"Quil", the Quil name, and the Quil brand mark are trademarks of Artjoms Stukans.
+
+This policy is separate from the software licence, and deliberately so. Quil's
+code is licensed under [Apache License 2.0](LICENSE), which grants broad rights
+to use, modify and redistribute it. **A software licence governs copying; it
+does not govern names.** Apache-2.0 says so explicitly in section 6: it grants
+no permission to use the licensor's trade names or product names. This file
+sets out what that means in practice, so nobody has to guess.
+
+The goal is narrow: a person who downloads something called Quil should be able
+to tell whose Quil it is. Nothing here is intended to discourage forks.
+
+## What you may do without asking
+
+- **Say what your software is built from.** "Based on Quil", "a fork of Quil",
+  "compatible with Quil", "works with Quil" — accurate, descriptive statements
+  are fine and always will be. This is nominative use and no licence is needed
+  for it.
+- **Keep the name while you contribute.** Branches, pull requests, forks kept
+  for the purpose of sending changes back upstream — use the name freely.
+- **Write about Quil.** Articles, talks, reviews, tutorials, comparisons,
+  criticism. Use the name and the mark as needed to refer to the project.
+- **Distribute unmodified builds** of an official release under the name Quil.
+- **Package it.** Distribution maintainers may ship Quil under its own name,
+  including with the patches packaging normally requires.
+
+## What needs a different name
+
+If you distribute a **modified** version to anyone else, give it your own name.
+
+Concretely, without written permission, please do not:
+
+- Name a modified distribution "Quil", or a name likely to be confused with it.
+- Use the Quil brand mark or logo as the icon or brand of your distribution.
+- Use the name in a way that suggests the project endorses, maintains, or is
+  responsible for your version.
+- Register "Quil", a confusingly similar name, or a domain built around one.
+
+Renaming is the expected outcome of a fork that diverges, not a penalty. It is
+also the thing that protects *you*: users of your build should be reporting its
+bugs to you, not to this repository.
+
+## Attribution, which is a separate ask
+
+Renaming does not remove the Apache-2.0 obligations in section 4. If you
+distribute a derivative work, you must retain the copyright, patent, trademark
+and attribution notices from the source, and carry the contents of
+[`NOTICE`](NOTICE) into your distribution.
+
+Beyond the licence, a request rather than a requirement: if your build shows an
+About screen, a version banner, or a credits view, please keep a line saying it
+derives from Quil, with a link to this repository. It costs one line and it is
+how the people using your build find out where the work came from.
+
+## Questions, and permission
+
+Uses this policy does not cover are not automatically forbidden — they are just
+not pre-approved. If you want to do something the list above does not allow,
+ask: open an issue, or contact the maintainer through the address in the repo
+metadata. Permission is often given.
+
+If you believe your use is nominative or otherwise permitted by law regardless
+of this policy, that argument is not waived by anything written here.
+
+## Scope
+
+This policy covers the trademarks only. It does not modify, restrict or add
+conditions to the Apache License 2.0, and nothing in it should be read as
+limiting the rights that licence grants over the code.

--- a/changelog.d/changed-apache-2-license.md
+++ b/changelog.d/changed-apache-2-license.md
@@ -1,0 +1,16 @@
+---
+headline: Quil is now licensed under Apache 2.0
+---
+- **Quil is now licensed under the Apache License 2.0**, replacing the MIT
+  licence. Quil stays open source and free to use, fork, modify and
+  redistribute — Apache-2.0 is an OSI-approved permissive licence, and nothing
+  about how you may use Quil changes.
+
+  What it adds over MIT is a patent grant from contributors, a requirement that
+  modified distributions mark which files they changed, and an explicit
+  statement that the licence covers the code and not the project's name. That
+  last point is spelled out in a new `TRADEMARK.md`: forks are welcome and
+  should carry their own name, and describing your software as "based on Quil"
+  needs no permission.
+
+  Releases before this change remain under the MIT licence they shipped with.

--- a/docs/competitive-analysis.md
+++ b/docs/competitive-analysis.md
@@ -36,7 +36,7 @@ architectural bet.
 | Git worktree-per-session | ❌ | ✅ | ✅ (+ multi-repo) |
 | AI agents supported | **2** deep + tools | **~18** detected, 14 integrations | **~13** terminal, 7 ACP |
 | Scale | ~30–40k Go | ~170k Rust | ~292k Rust + large web app |
-| License / backing | MIT, product | Apache-2.0 (was AGPL-3.0 + commercial until 2026-07-22), solo + sponsors | MIT, Mozilla.ai community |
+| License / backing | Apache-2.0, product | Apache-2.0 (was AGPL-3.0 + commercial until 2026-07-22), solo + sponsors | MIT, Mozilla.ai community |
 
 **On herdr's licensing, because the reversal is the interesting part:** it
 shipped in March 2026 dual-licensed AGPL-3.0-or-later plus a commercial licence

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -74,7 +74,7 @@ const year = new Date().getFullYear();
         <p>
           The workflow orchestrator that survives reboots. Typed panes,
           AI session resume, an MCP server, TOML plugins. Open source
-          under MIT.
+          under Apache 2.0.
         </p>
         <p style="margin-top:10px;">
           <span class="pill flame"><span class="dot"></span>v{SITE.software.version}</span>
@@ -105,7 +105,7 @@ const year = new Date().getFullYear();
     <div class="footer-bottom">
       <span>
         © {year} {SITE.name} ·
-        <a href={SITE.github + "/blob/master/LICENSE"} rel="noopener external">MIT Licensed</a>
+        <a href={SITE.github + "/blob/master/LICENSE"} rel="noopener external">Apache 2.0 Licensed</a>
       </span>
       <span class="mono">└── made by @artyomsv · hosted on GitHub Pages</span>
     </div>

--- a/site/src/content/blog/resume-claude-code-session-after-reboot.md
+++ b/site/src/content/blog/resume-claude-code-session-after-reboot.md
@@ -119,4 +119,4 @@ Install Quil (Linux/macOS):
 curl -sSfL https://raw.githubusercontent.com/artyomsv/quil/master/scripts/install.sh | sh
 ```
 
-*Quil is free and open source (MIT). [quil.cc](/) · [GitHub](https://github.com/artyomsv/quil)*
+*Quil is free and open source (Apache 2.0). [quil.cc](/) · [GitHub](https://github.com/artyomsv/quil)*

--- a/site/src/data/faq.ts
+++ b/site/src/data/faq.ts
@@ -70,7 +70,7 @@ export const homeFaq: FaqItem[] = [
   {
     question: "Is Quil free?",
     answer:
-      "Yes. Quil is open source under the MIT License. There's no hosted version, no paid tier, no telemetry. You self-host it on your own machine and it stores all state locally under ~/.quil/.",
+      "Yes. Quil is open source under the Apache License 2.0. There's no hosted version, no paid tier, no telemetry. You self-host it on your own machine and it stores all state locally under ~/.quil/.",
   },
   {
     question: "How do I install it?",

--- a/site/src/data/schemas.ts
+++ b/site/src/data/schemas.ts
@@ -93,7 +93,7 @@ export function softwareApplicationSchema(): Record<string, unknown> {
     softwareRequirements: "Linux kernel 4.x+, macOS 11+, or Windows 10+",
     memoryRequirements: "150 MB RSS typical",
     fileSize: "~40 MB",
-    license: "https://opensource.org/licenses/MIT",
+    license: "https://www.apache.org/licenses/LICENSE-2.0",
     releaseNotes: SITE.github + "/blob/master/CHANGELOG.md",
     downloadUrl: SITE.github + "/releases/latest",
     installUrl: SITE.url + "/install",

--- a/site/src/data/seo.ts
+++ b/site/src/data/seo.ts
@@ -45,7 +45,7 @@ export const SITE = {
    *  (the next release will overwrite both via sed). */
   software: {
     version: "1.63.0",
-    license: "MIT",
+    license: "Apache-2.0",
     operatingSystem: "Linux, macOS, Windows",
     applicationCategory: "DeveloperApplication",
     runtime: "Cross-platform binary",

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -434,7 +434,7 @@ const revTimestamp = new Date().toISOString().slice(0, 10).replace(/-/g, "");
 
         <p>
           One binary. ~40 MB. No database. No cloud account. No
-          telemetry. No runtime dependencies. Open source under MIT.
+          telemetry. No runtime dependencies. Open source under Apache 2.0.
           Tested on Linux, macOS, and native Windows.
         </p>
 

--- a/site/src/pages/legal.astro
+++ b/site/src/pages/legal.astro
@@ -12,7 +12,7 @@ import { breadcrumbSchema } from "@/data/schemas";
 const seo = {
   title: "Legal notice",
   description:
-    "Quil is open-source software under the MIT License. No telemetry, no cookies, no tracking. What you run inside Quil is your responsibility and subject to the laws of your jurisdiction.",
+    "Quil is open-source software under the Apache License 2.0. No telemetry, no cookies, no tracking. What you run inside Quil is your responsibility and subject to the laws of your jurisdiction.",
   path: "/legal",
   ogImage: "/og/legal.png",
 };
@@ -29,7 +29,7 @@ const schemas = [
     <div class="container-ember stack">
       <div class="hero-ruler">
         <span>§ LEGAL</span>
-        <span style="margin-left:auto;">MIT Licensed · No telemetry · No cookies</span>
+        <span style="margin-left:auto;">Apache 2.0 · No telemetry · No cookies</span>
       </div>
       <span class="eyebrow">LEGAL NOTICE</span>
       <h1>Legal notice.</h1>
@@ -46,9 +46,19 @@ const schemas = [
         <h2>License</h2>
         <p>
           Quil is released under the
-          <a href={SITE.github + "/blob/master/LICENSE"} rel="noopener external">MIT License</a>.
+          <a href={SITE.github + "/blob/master/LICENSE"} rel="noopener external">Apache License 2.0</a>.
           You are free to use, modify, and redistribute the software for any purpose,
-          including commercial use, provided the copyright notice is preserved.
+          including commercial use, provided you retain the copyright, patent,
+          trademark and attribution notices, carry the
+          <a href={SITE.github + "/blob/master/NOTICE"} rel="noopener external">NOTICE</a>
+          file, and state which files you changed.
+        </p>
+        <p>
+          Releases published before August 2026 were licensed under the MIT
+          License and remain so. Some contributions are still licensed under MIT
+          pending relicensing consent from their authors; the
+          <a href={SITE.github + "/blob/master/LICENSE"} rel="noopener external">LICENSE</a>
+          file says which.
         </p>
 
         <h2>No warranty</h2>
@@ -89,6 +99,15 @@ const schemas = [
         </p>
 
         <h2>Trademarks</h2>
+        <p>
+          "Quil" and the Quil mark are trademarks of Artjoms Stukans. The
+          Apache License covers the code and not the name — section 6 says so
+          explicitly. Forks are welcome and should carry their own name;
+          describing your software as "based on Quil" or "compatible with Quil"
+          needs no permission at all. The full policy, including what is
+          pre-approved, is in
+          <a href={SITE.github + "/blob/master/TRADEMARK.md"} rel="noopener external">TRADEMARK.md</a>.
+        </p>
         <p>
           Claude Code is a trademark of Anthropic PBC. tmux, Zellij, WezTerm,
           GNU Screen, and other project names mentioned on this site are


### PR DESCRIPTION
Moves quil from MIT to the **Apache License 2.0**.

## Why

Three things MIT is silent on, all of which a project taking outside contributions wants:

- **A patent grant** from contributors, with termination for anyone who sues over one.
- **Change marking** — modified distributions must state which files they altered.
- **An explicit statement** that the licence covers the code and not the project's name.

It is also where this category has settled: aider, goose, cline, continue and Roo Code are Apache-2.0, and `modelcontextprotocol/go-sdk` — which quil depends on — is itself mid-transition to it from MIT. The closest direct competitor, herdr, moved to Apache-2.0 in July after four months on AGPL-3.0 plus a commercial licence.

Nothing about quil's openness changes. Apache-2.0 is OSI-approved and permissive; use, forking, modification and redistribution are unaffected.

## What's in it

| File | |
|---|---|
| `LICENSE` | Apache-2.0, prefaced by the transition statement below |
| `MIT-LICENSE.txt` | new — the MIT text, for the contributions still under it |
| `NOTICE` | new — what Apache §4(d) requires derivatives to carry |
| `TRADEMARK.md` | new — what the licence deliberately does not cover |
| `CONTRIBUTING.md` | new "Licensing of contributions" section: §5 inbound = outbound, no CLA, no assignment |
| `README.md`, `site/src/data/*` | licence references |

## On the contributions this does not yet cover

Two outside contributors hold copyright in the tree and have been asked for consent in #180 and #181. Neither has replied yet, and neither is required to.

Rather than block, `LICENSE` opens with a preamble stating that contributions whose authors have not granted permission **remain under MIT**, with the text reproduced in `MIT-LICENSE.txt`. This is the shape `modelcontextprotocol/go-sdk` uses for exactly this situation.

Merging now is deliberate: `CONTRIBUTING.md` binds new pull requests to Apache-2.0 from the moment it lands, so every day spent on MIT is another day contributions arrive under the licence being left behind. Nothing here asserts consent nobody gave. When #180 and #181 are answered, the preamble comes out and `LICENSE` becomes plain Apache-2.0.

Releases already published stay under the MIT licence they shipped with, which no relicensing can alter.

## Verification

- `LICENSE` is the canonical Apache-2.0 text fetched from GitHub's licence API — 9 sections, patent grant and trademark clauses present.
- `sh scripts/promote-changelog.sh --validate` → valid.
- `npx astro check` → 0 errors, 0 warnings across 34 files.
- `./scripts/dev.sh test internal/tui` → ok.