### PR TITLE
fix(license): keep LICENSE detectable, move the caveat to NOTICE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,10 +174,16 @@ jobs:
           # changelog.d/ is denied for the same reason as docs/: a typo fix in
           # a pending fragment would otherwise read as payload and cut a
           # release whose five platform binaries are identical to the last tag.
+          #
+          # NOTICE and MIT-LICENSE.txt are listed here rather than caught by the
+          # `^[^/]+\.md$` filter above, which only covers root-level markdown —
+          # one has no extension and the other is .txt. TRADEMARK.md is NOT
+          # listed, because that filter already has it. All three ship in the
+          # release archives and none of them changes a binary.
           CODE=$(echo "$CHANGED" \
             | grep -vE '^(site|docs|tools|techdebt|marketing|\.github|\.claude|changelog\.d)/' \
             | grep -vE '^[^/]+\.md$' \
-            | grep -vE '^(VERSION|LICENSE|Makefile|package-lock\.json|\.gitignore|\.gitattributes|\.editorconfig|\.dockerignore)$' \
+            | grep -vE '^(VERSION|LICENSE|MIT-LICENSE\.txt|NOTICE|Makefile|package-lock\.json|\.gitignore|\.gitattributes|\.editorconfig|\.dockerignore)$' \
             | grep -v '_test\.go$' || true)
           if [ -z "$CODE" ]; then
             echo "::notice::No changes reach the binary — changelog fragment not required"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,7 +200,7 @@ jobs:
             PAYLOAD=$(git diff --name-only "${LAST_TAG}..HEAD" \
               | grep -vE '^(site|docs|tools|techdebt|marketing|\.github|\.claude|changelog\.d)/' \
               | grep -vE '^[^/]+\.md$' \
-              | grep -vE '^(VERSION|LICENSE|Makefile|package-lock\.json|\.gitignore|\.gitattributes|\.editorconfig|\.dockerignore)$' \
+              | grep -vE '^(VERSION|LICENSE|MIT-LICENSE\.txt|NOTICE|Makefile|package-lock\.json|\.gitignore|\.gitattributes|\.editorconfig|\.dockerignore)$' \
               | grep -v '_test\.go$' || true)
             if [ -z "$PAYLOAD" ]; then
               echo "::notice::No changes reach the binary since ${LAST_TAG} (docs/site/workflow only) — skipping release"

--- a/LICENSE
+++ b/LICENSE
@@ -1,20 +1,3 @@
-Quil is transitioning from the MIT License to the Apache License, Version 2.0
-("Apache-2.0"). All new contributions are licensed under Apache-2.0.
-
-Contributions for which relicensing consent has been obtained are licensed
-under Apache-2.0. Contributions made by authors who originally licensed their
-work under the MIT License and who have not granted explicit permission to
-relicense remain licensed under the MIT License, the text of which is
-reproduced in MIT-LICENSE.txt.
-
-No rights beyond those granted by the applicable original license are conveyed
-for such contributions.
-
-Releases published before this change remain under the MIT License they
-shipped with.
-
----
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/NOTICE
+++ b/NOTICE
@@ -4,12 +4,39 @@ Copyright 2026 Artjoms Stukans
 This product includes software developed at
 https://github.com/artyomsv/quil
 
-Licensed under the Apache License, Version 2.0. Some contributions remain under
-the MIT License pending relicensing consent from their authors; see LICENSE and
-MIT-LICENSE.txt.
+Licensed under the Apache License, Version 2.0 (the "License"). You may obtain
+a copy in the LICENSE file, or at http://www.apache.org/licenses/LICENSE-2.0
+
+--- Licensing transition -------------------------------------------------------
+
+Quil is transitioning from the MIT License to the Apache License, Version 2.0.
+All new contributions are licensed under Apache-2.0.
+
+Contributions for which relicensing consent has been obtained are licensed
+under Apache-2.0. Contributions made by authors who originally licensed their
+work under the MIT License and who have not granted explicit permission to
+relicense remain licensed under the MIT License, the text of which is
+reproduced in MIT-LICENSE.txt.
+
+No rights beyond those granted by the applicable original license are conveyed
+for such contributions.
+
+Releases published before August 2026 remain under the MIT License they
+shipped with.
+
+This statement lives here rather than in LICENSE deliberately. LICENSE is kept
+byte-identical to the canonical Apache-2.0 text, because GitHub's licence
+detector matches the whole file and any preamble drops it below the confidence
+threshold, reporting the project as "Other". NOTICE is also the file Apache-2.0
+section 4(d) requires derivatives to carry, so the caveat travels further here
+than it would there.
+
+--- Third-party ----------------------------------------------------------------
 
 Third-party components redistributed with this software, and their licenses,
 are listed in THIRD_PARTY_LICENSES.md.
+
+--- Trademarks -----------------------------------------------------------------
 
 "Quil" and the Quil mark are trademarks of Artjoms Stukans. The Apache License
 grants no rights to them; see TRADEMARK.md.

--- a/site/src/pages/legal.astro
+++ b/site/src/pages/legal.astro
@@ -57,7 +57,7 @@ const schemas = [
           Releases published before August 2026 were licensed under the MIT
           License and remain so. Some contributions are still licensed under MIT
           pending relicensing consent from their authors; the
-          <a href={SITE.github + "/blob/master/LICENSE"} rel="noopener external">LICENSE</a>
+          <a href={SITE.github + "/blob/master/NOTICE"} rel="noopener external">NOTICE</a>
           file says which.
         </p>
 


### PR DESCRIPTION
#183 prepended the licensing-transition statement to `LICENSE`. That broke GitHub's licence detection, and it is live on `master` now.

## Measured

| repo | `LICENSE` | GitHub `spdx_id` |
|---|---|---|
| `alacritty/alacritty` | plain Apache-2.0 | `Apache-2.0` |
| `modelcontextprotocol/go-sdk` | preamble + Apache | `NOASSERTION` ("Other") |
| **`artyomsv/quil`** | preamble + Apache | **`NOASSERTION` ("Other")** |

GitHub's detector matches the whole file against known texts at a confidence threshold. A ~700-byte preamble on an 11 KB licence drops it below the cut.

## Why it matters beyond the sidebar

Anything that reads the repository's SPDX id now gets "Other" — licence-based search and filtering, dependency and SBOM tooling, and `org.opencontainers.image.licenses` on projects that publish container images, since `docker/metadata-action` derives that label from exactly this field. quil does not publish images, but `artyomsv/marauder` does, and the same fix is going in there before its relicense merges.

## The fix

`LICENSE` is restored to byte-identical canonical Apache-2.0 — verified with `diff` against GitHub's own licence API.

The transition statement moves to `NOTICE`, which is the better home regardless: **§4(d) requires derivatives to carry `NOTICE`**, so the caveat now travels with the software, where a `LICENSE` preamble obliges nobody to reproduce it.

The legal page's "the LICENSE file says which" link is repointed to `NOTICE` to match.

Nothing about the licensing position changes — the same contributions remain under MIT for the same reason, stated in a file that propagates further.

## Verification

- `diff LICENSE <canonical Apache-2.0>` → identical.
- `npx astro check` → 0 errors, 0 warnings across 34 files.