### PR TITLE
fix(remote): offer the upgrade a version-drifted host needs

### DIFF
--- a/.claude/reviews/tui/remote-connection.md
+++ b/.claude/reviews/tui/remote-connection.md
@@ -1,0 +1,32 @@
+# Code Review State: tui / remote-connection
+
+Last reviewed: 2026-08-23
+Rounds completed: 1
+
+## Resolved (fixed in code; do not re-raise)
+- [security/HIGH-1] private IP + ssh username in a tracked fixture — `sidebar_offline_test.go` now uses the `artyom@gpu01` placeholder, and the commit was amended so the blob never carried it — round 1
+- [security/MEDIUM-2] project name rendered uncapped; `lipgloss.Place` pads but never clips — every line of the empty-tab area is capped, offline and live branches alike, with a frame-width regression test carrying a non-vacuity guard — round 1
+- [security/MEDIUM-3] daemon-reported version unbounded (10 MB IPC frame the only ceiling; `version.Parsed` truncates at the first `-`) and re-measured every frame — clamped at the handshake door via `clampVersionString`, 64 bytes, cut on a rune boundary — round 1
+- [security/LOW-5] six-line block overflows a short frame because `PlaceVertical` also no-ops on overflow — detail dropped when `h < len(lines)+2` — round 1
+- [security/LOW-6] multi-line ssh stderr fused into one word (`sanitizeRemoteText` drops `\n` with no separator) — `firstErrLine` applied first, reusing reconnect.go's idiom — round 1
+- [rules/MEDIUM] no techdebt entry for the self-identified limitation in the PR body — `techdebt/3-3-remote-host-cannot-apply-its-own-staged-update.md` — round 1
+- [qa/coverage] `promptNextUpgrade`'s moved guard was only covered by a test that passes for either reading — `TestUpgradePrompt_NoProvisionerHoldsTheAskRatherThanDroppingIt` pins "held, not dropped" and fails on master — round 1
+
+## Deferred to techdebt (recorded, deliberately not fixed here)
+- [security/LOW-4] `truncateToWidth` sums independently-measured runes and can return ~2x its budget — helper-wide (~10 call sites); `techdebt/3-3-truncatetowidth-sums-runes-not-graphemes.md`
+- [ci] `TestHandleMessage_KillProcessIsWiredUpAndSingleFlighted` races the worker it observes — failed 2 of 4 CI runs on this branch, passes in isolation under `-race`, package byte-identical to master; `techdebt/3-2-flaky-kill-process-single-flight-test.md`. Not fixed here: a deterministic fix needs an `ipc.Conn` seam that does not exist yet, and building one to repair a test belongs in its own change.
+
+## Resolved — second pass, from the code-quality and QA reports
+- [code-quality/CRITICAL] the drain point did not cover the launch it targets: `promptNextUpgrade`'s "every dialog dismissal calls this again" was true of ONE dismissal (the upgrade confirm's own Esc), so a client auto-update — which opens what's-new AND drifts every host at once — filled the queue and never opened it. Drain moved to a `handleDialogKey` funnel on any return to `dialogNone`; pinned by `TestUpgradePrompt_SurvivesTheWhatsNewDialogAtLaunch` over both what's-new and the disclaimer — round 1
+- [code-quality/HIGH] a host that came back ONLINE was still offered a daemon-restarting upgrade (`Offline` cleared on reconnect, `installedDests` untouched, project still non-nil) — `promptNextUpgrade` now also requires `p.Offline != nil` — round 1
+- [code-quality/HIGH] `offlineRetrying` rendered "Reconnecting…" for a PARKED link with no ladder running, while `renderReconnectBanner` returns "" for an inactive link — so the only thing on screen was a false claim that contradicted `bannerCandidates`' own wording. Now an explicit `case offlineRetrying:` reading link health — round 1
+- [code-quality/MEDIUM] `offlineNeedsInstall` reached a confirm written for an upgrade, warning a host with no daemon that its panes would be killed. `upgradePrompt` now carries the kind and the confirm branches on it — round 1
+- [code-quality/MEDIUM] verbatim duplication: the needs-install pane printed `ErrRemoteQuilMissing`'s sentence twice, once capitalised and once behind a `dial <host>:` prefix — the detail is suppressed when it repeats the sentinel — round 1
+
+## Dismissed (acknowledged, will not fix; agents may escalate with explicit justification)
+- (none)
+
+## Notes
+- Three occurrences of the same private IP remain in `.claude/reviews/quil/issue-169.md`, `issue-172.md` and `tui/keybinding-registry.md`. Pre-existing on master, untouched by this branch, and left alone rather than bundled into a fix PR.
+- All four agents reported. `cq-186` and `qa-186` needed three prompts each and delivered late — after the first fixes had already been pushed — so their findings landed against a moved tree and both re-verified before reporting. Every dimension is covered for round 1.
+- The critical finding came from the dimension that reported LAST. Worth remembering before treating an early-returning review as complete.

--- a/changelog.d/fixed-remote-connection.md
+++ b/changelog.d/fixed-remote-connection.md
@@ -1,0 +1,28 @@
+---
+headline: A version-drifted remote host is offered the upgrade again
+---
+- **A remote host left behind by a client update is offered the upgrade again.** When
+  this client is newer than the daemon on a configured host, Quil refuses to attach —
+  by design — and offers to upgrade that host from inside the tool. The offer was
+  raised at launch and immediately discarded, because the launch path records the
+  offline host before it wires the provisioner that would perform the install. The
+  result was a project row wearing a ⚡ and nothing else: the host stayed unusable for
+  the whole session, and every later client update widened the gap.
+
+- **The offer survives the dialogs a fresh launch puts in front of it.** It is raised
+  before the screen is free, and only the offer's own dismissal used to collect it
+  again — so on the one launch where it matters most, right after a client update, the
+  what's-new dialog swallowed it. Every dialog now hands it back on the way out. A host
+  that reconnects before you answer is no longer offered an upgrade it does not need,
+  which matters because accepting one restarts that daemon and takes its panes with it.
+
+- **A host that has never run Quil is asked the right question.** The same prompt served
+  both cases and was worded for an upgrade, so a first install warned about killing
+  panes on a machine that had none.
+
+- **A project whose host is offline says so, instead of claiming it has no tabs.** The
+  pane area rendered the same "No tabs in … — Ctrl+T opens one" it shows for an empty
+  live project, which reads as the tabs having been deleted. The remote daemon still
+  holds every one of them; this client simply did not attach. It now names the host,
+  says whether the problem is a version drift, a missing install, or a link still
+  reconnecting, and carries the command that fixes it.

--- a/cmd/quil/handshake.go
+++ b/cmd/quil/handshake.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/artyomsv/quil/internal/ipc"
 	versionpkg "github.com/artyomsv/quil/internal/version"
@@ -15,6 +17,30 @@ import (
 // Daemons from before the version-negotiation protocol silently ignore
 // the request; the timeout is the only way to notice.
 const handshakeTimeout = 2 * time.Second
+
+// maxVersionStringLen bounds a version string reported by a daemon this client
+// did not start. Generous next to any real one ("1.63.2", or "1.63.2-rc1" at
+// its longest) and small enough that carrying it costs nothing — the point is
+// only that SOME ceiling exists below the 10 MB IPC frame limit.
+const maxVersionStringLen = 64
+
+// clampVersionString truncates on a RUNE boundary, so a clamped value stays
+// valid UTF-8 and sanitizeRemoteText's precondition still holds downstream.
+// No ellipsis: the result is compared and interpolated as a version, not shown
+// as prose, and a "…" would only make a garbage value look deliberate.
+func clampVersionString(s string) string {
+	if len(s) <= maxVersionStringLen {
+		return s
+	}
+	var b strings.Builder
+	for _, r := range s {
+		if b.Len()+utf8.RuneLen(r) > maxVersionStringLen {
+			break
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
 
 // handshakeResult bundles the outcome of asking the daemon its version.
 type handshakeResult struct {
@@ -119,6 +145,15 @@ func versionHandshakeWithin(client *ipc.Client, timeout time.Duration) handshake
 			log.Printf("handshake: decode payload: %v", err)
 			return handshakeResult{DaemonUnknown: true}
 		}
+		// Clamped at the door, before anything reads it — the log line below
+		// included. Nothing else bounds this string: the daemon may be remote
+		// and the only ceiling on the wire is ipc.maxFrameSize (10 MB), while
+		// versionpkg.Parsed truncates at the first "-" or "+", so
+		// "1.0.0-"+<megabytes> compares as a perfectly ordinary 1.0.0 and the
+		// whole payload flows on into gateExtraVersion's error text, from there
+		// into OfflineState.Detail, and gets re-measured on every frame the
+		// offline pane area draws.
+		payload.Version = clampVersionString(payload.Version)
 
 		cmp, err := versionpkg.Compare(tuiVer, payload.Version)
 		if err != nil {

--- a/cmd/quil/remote_gate_test.go
+++ b/cmd/quil/remote_gate_test.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"net"
+	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/artyomsv/quil/internal/ipc"
 	"github.com/artyomsv/quil/internal/tui"
@@ -93,5 +95,50 @@ func TestVerifyRemoteLinkGated_MatchingVersionPassesEitherWay(t *testing.T) {
 		if err := verifyRemoteLinkGated(client, time.Second, gate); err != nil {
 			t.Errorf("gate=%v: %v, want nil", gate, err)
 		}
+	}
+}
+
+// A daemon this client did not start controls the version string, and nothing
+// on the wire bounds it below ipc.maxFrameSize (10 MB). versionpkg.Parsed
+// truncates at the first "-", so "1.0.0-"+<megabytes> compares as an ordinary
+// 1.0.0 and the whole payload would flow into gateExtraVersion's error text,
+// then into OfflineState.Detail, and be re-measured on every rendered frame.
+func TestClampVersionString(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"a real version is untouched", "1.63.2", "1.63.2"},
+		{"a pre-release version is untouched", "1.63.2-rc1+build.7", "1.63.2-rc1+build.7"},
+		{"empty stays empty", "", ""},
+		{"exactly at the limit is untouched", strings.Repeat("a", maxVersionStringLen), strings.Repeat("a", maxVersionStringLen)},
+		{"one over is cut", strings.Repeat("a", maxVersionStringLen+1), strings.Repeat("a", maxVersionStringLen)},
+		{"a hostile payload is cut", "1.0.0-" + strings.Repeat("A", 9_000_000), "1.0.0-" + strings.Repeat("A", maxVersionStringLen-6)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := clampVersionString(tc.in); got != tc.want {
+				t.Errorf("clampVersionString(%d bytes) = %d bytes, want %d",
+					len(tc.in), len(got), len(tc.want))
+			}
+		})
+	}
+}
+
+// The cut must land on a rune boundary: sanitizeRemoteText downstream documents
+// valid UTF-8 as a PRECONDITION, and a severed multi-byte sequence decodes to
+// U+FFFD — a rune outside every range it strips, so it would pass through.
+func TestClampVersionString_CutsOnARuneBoundary(t *testing.T) {
+	// Multi-byte runes chosen so the byte limit falls mid-sequence.
+	got := clampVersionString(strings.Repeat("日", 40)) // 3 bytes each = 120
+	if !utf8.ValidString(got) {
+		t.Fatalf("clamped value is not valid UTF-8: %q", got)
+	}
+	if len(got) > maxVersionStringLen {
+		t.Errorf("clamped to %d bytes, over the %d-byte limit", len(got), maxVersionStringLen)
+	}
+	if len(got) < maxVersionStringLen-3 {
+		t.Errorf("clamped to %d bytes, wasting more than one rune of the %d-byte budget",
+			len(got), maxVersionStringLen)
 	}
 }

--- a/internal/tui/dialog.go
+++ b/internal/tui/dialog.go
@@ -578,7 +578,45 @@ func shortcutsList(m *Model) []shortcutRow {
 
 // --- Input handling ---
 
+// handleDialogKey routes a key to the open dialog's handler, then drains any
+// deferred upgrade offer once the screen comes free.
+//
+// The drain is HERE rather than in each handler because promptNextUpgrade's own
+// contract — "every dialog dismissal calls this again, so a deferred prompt
+// arrives as soon as the screen is free" — was true of exactly one dismissal:
+// the upgrade confirm's own Esc. handleDisclaimerKey, handleWhatsNewKey and the
+// migration handler all return to dialogNone and drained nothing.
+//
+// That gap swallowed the flagship case rather than an edge. A client
+// auto-update is precisely when gateExtraVersion refuses every configured host
+// (cmd/quil/main.go:589 says so in as many words) AND when ResolveWhatsNew
+// opens a dialog at startup — so the queue filled, the first WindowSizeMsg
+// no-oped on `dialog != dialogNone`, dismissing what's-new drained nothing, and
+// the 1 s size poll is echo-guarded so no later resize arrived on its own. The
+// user was left with the ⚡ and no offer: the exact symptom the offer exists to
+// remove.
+//
+// Gated on a dialog having been OPEN, so an ordinary keystroke with no dialog
+// on screen cannot raise one. A dismissal that opens another dialog (the
+// confirm's own Esc chaining to the next queued host) leaves dialog non-none
+// and is skipped here, so the offer is never raised twice for one key.
 func (m Model) handleDialogKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	wasOpen := m.dialog != dialogNone
+	updated, cmd := m.dispatchDialogKey(msg)
+	if !wasOpen {
+		return updated, cmd
+	}
+	next, ok := updated.(Model)
+	if !ok || next.dialog != dialogNone {
+		return updated, cmd
+	}
+	next.promptNextUpgrade()
+	return next, cmd
+}
+
+// dispatchDialogKey is handleDialogKey's switch, split out so the drain above
+// wraps every arm without being repeated in any of them.
+func (m Model) dispatchDialogKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	switch m.dialog {
 	case dialogAbout:
 		return m.handleAboutKey(msg)
@@ -1695,7 +1733,19 @@ func (m Model) renderConfirmDialog() string {
 		b.WriteString("\n\n")
 		b.WriteString("  " + dialogSubtle.Render("Every tab and pane in this project is destroyed too."))
 	case confirmKindUpgradeDest:
-		b.WriteString("  " + dialogNormal.Render(fmt.Sprintf("Upgrade quil on %s?", sanitizeRemoteText(m.confirmName))))
+		// Two states queue this confirm and they do not cost the same thing.
+		// SeedOfflineDest enqueues for needsInstall as well as needsUpgrade, and
+		// once the launch-path ask actually fired, a host that has never run
+		// quil started being told its panes would be killed — there are none,
+		// and no daemon to restart. That is a reason to decline something that
+		// was free. installOffer already splits these two sentences; this is the
+		// same split at the place the user is asked.
+		firstInstall := m.confirmOfflineKind == offlineNeedsInstall
+		title := "Upgrade quil on %s?"
+		if firstInstall {
+			title = "Install quil on %s?"
+		}
+		b.WriteString("  " + dialogNormal.Render(fmt.Sprintf(title, sanitizeRemoteText(m.confirmName))))
 		b.WriteString("\n\n")
 		// The version pair comes from the daemon's own handshake and is the
 		// answer to "why can I not reach it" — the reason the row parked. It is
@@ -1707,15 +1757,22 @@ func (m Model) renderConfirmDialog() string {
 		}
 		b.WriteString("  " + dialogSubtle.Render("Quil pushes this build over ssh."))
 		b.WriteString("\n")
-		// Named explicitly because an upgrade is not free the way a first
-		// install is: the push stops the remote daemon, so panes over there
-		// respawn and whatever was running in their shells is killed. The CLI
-		// says the same before asking; this is the same warning in the place
-		// the user is actually being asked.
-		b.WriteString("  " + dialogSubtle.Render("Its daemon RESTARTS: panes there respawn and"))
-		b.WriteString("\n")
-		b.WriteString("  " + dialogSubtle.Render("anything running in their shells is killed."))
-		footer = "y upgrade    Esc not now"
+		if firstInstall {
+			// Nothing is running over there yet, so there is nothing to warn
+			// about — saying otherwise invents a cost and buys a decline.
+			b.WriteString("  " + dialogSubtle.Render("Nothing is running there yet, so nothing is lost."))
+			footer = "y install    Esc not now"
+		} else {
+			// Named explicitly because an upgrade is not free the way a first
+			// install is: the push stops the remote daemon, so panes over there
+			// respawn and whatever was running in their shells is killed. The CLI
+			// says the same before asking; this is the same warning in the place
+			// the user is actually being asked.
+			b.WriteString("  " + dialogSubtle.Render("Its daemon RESTARTS: panes there respawn and"))
+			b.WriteString("\n")
+			b.WriteString("  " + dialogSubtle.Render("anything running in their shells is killed."))
+			footer = "y upgrade    Esc not now"
+		}
 	case confirmKindDisconnectHost:
 		b.WriteString("  " + dialogNormal.Render(fmt.Sprintf("Disconnect %q?", sanitizeRemoteText(m.confirmName))))
 		b.WriteString("\n\n")

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -443,6 +443,7 @@ type Model struct {
 	confirmID          string                 // ID of pane/tab to delete
 	confirmName        string                 // display name for confirmation
 	confirmDetail      string                 // extra remote-sourced line (upgrade/apply-update confirm); sanitized+bounded at render
+	confirmOfflineKind OfflineKind            // which provisioning ask this is (upgrade vs first install); decides the confirm's body
 	pendingApplyVer    string                 // version to apply when the in-flight MsgStageUpdateReq answers; set only by a press meaning APPLY (see applyStageUpdateResp)
 	updateReqInFlight  bool                   // a MsgStageUpdateReq is unanswered; a second press must not queue a second one (see sendStageUpdateReq)
 	applyConfirmReturn dialogScreen           // where Esc on the apply confirm goes: About when the press came from there, else back to the panes
@@ -1405,7 +1406,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// sidebar offer the upgrade instead" described nothing: the sidebar
 			// had no such affordance, so a link that drifted out of version
 			// mid-session went quiet with no way to act on it in the tool.
-			m.enqueueUpgradePrompt(msg.dest, msg.err.Error())
+			m.enqueueUpgradePrompt(msg.dest, msg.err.Error(), offlineNeedsUpgrade)
 			m.promptNextUpgrade()
 			return m, nil
 		}

--- a/internal/tui/offline.go
+++ b/internal/tui/offline.go
@@ -70,8 +70,16 @@ const confirmDetailCap = 60
 // already provisioned this session that STILL reports a mismatch did not
 // restart its daemon, and pushing the same archive again cannot change that —
 // the loop that guard exists to break is install, retry, same error, install.
-func (m *Model) enqueueUpgradePrompt(dest, detail string) {
-	if dest == "" || m.installDestFn == nil || m.installedDests[dest] {
+//
+// Whether a provisioner EXISTS is deliberately not asked here, and that is the
+// whole reason the launch path offered nothing for a year: cmd/quil/main.go
+// seeds the offline rows at :597 and wires installDestFn at :765, so every
+// launch-time ask was rejected before it was queued and the drain point found
+// an empty queue. Queueing is a record of what is wrong with a host — it does
+// not depend on what this Model can do about it yet. promptNextUpgrade asks
+// that question instead, by which time the wiring has run.
+func (m *Model) enqueueUpgradePrompt(dest, detail string, kind OfflineKind) {
+	if dest == "" || m.installedDests[dest] {
 		return
 	}
 	for _, q := range m.upgradeQueue {
@@ -79,29 +87,57 @@ func (m *Model) enqueueUpgradePrompt(dest, detail string) {
 			return
 		}
 	}
-	m.upgradeQueue = append(m.upgradeQueue, upgradePrompt{dest: dest, detail: detail})
+	m.upgradeQueue = append(m.upgradeQueue, upgradePrompt{dest: dest, detail: detail, kind: kind})
 }
 
-// upgradePrompt is one queued ask: which host, and the version pair to show.
-type upgradePrompt struct{ dest, detail string }
+// upgradePrompt is one queued ask: which host, why, and the version pair to show.
+//
+// kind rides along because the confirm's BODY is not the same sentence for both
+// of the two states that queue one. An upgrade stops a running daemon and takes
+// its panes with it; a first install has no daemon and no panes to lose, and
+// telling a user their panes will be killed on a host that has never run quil
+// is a reason to decline something that was free. installOffer already draws
+// that line for its own two messages.
+type upgradePrompt struct {
+	dest, detail string
+	kind         OfflineKind
+}
 
 // promptNextUpgrade opens the confirm for the next queued host, if the screen
 // is free to show it.
 //
-// Gated on dialogNone so it cannot displace the disclaimer or the plugin
-// migration at startup — both of which the user is already answering, and the
-// migration deliberately blocks until resolved. Every dialog dismissal calls
-// this again, so a deferred prompt arrives as soon as the screen is free
-// rather than being dropped.
+// Gated on dialogNone so it cannot displace the disclaimer, the what's-new
+// dialog or the plugin migration at startup — all of which the user is already
+// answering, and the migration deliberately blocks until resolved.
+// handleDialogKey calls this on every dialog's return to dialogNone, so a
+// deferred prompt arrives as soon as the screen is free rather than being
+// dropped. That sentence used to appear here while only ONE dismissal honoured
+// it; see the comment on handleDialogKey for what that cost.
+//
+// The no-provisioner check lives HERE rather than at enqueue time because this
+// is the moment the answer is final: a dialog whose only action cannot run is
+// worse than the parked row, but a Model that has not been wired YET is the
+// ordinary launch state, not a Model that never will be.
 func (m *Model) promptNextUpgrade() {
-	if m.dialog != dialogNone || len(m.upgradeQueue) == 0 {
+	if m.installDestFn == nil || m.dialog != dialogNone || len(m.upgradeQueue) == 0 {
 		return
 	}
 	next := m.upgradeQueue[0]
 	m.upgradeQueue = m.upgradeQueue[1:]
-	// The destination may have been disconnected, or provisioned through the
-	// New Project dialog, between queueing and now.
-	if m.installedDests[next.dest] || m.projectForDest(next.dest) == nil {
+	// The destination may have been disconnected, provisioned through the New
+	// Project dialog, or COME BACK, between queueing and now.
+	//
+	// That third one is not cosmetic. A host that reconnected has its
+	// Offline cleared by applyWorkspaceState while adoptDest never touches
+	// installedDests, so it still resolves to a live project and would be
+	// offered an upgrade it no longer needs — and accepting runs the same
+	// runRemoteSetup as the CLI, which STOPS that daemon and takes its panes
+	// down with it. The confirm's own body warns about exactly that cost; it
+	// must not be charged against a host that is working. The window was one
+	// WindowSizeMsg wide before the drain moved to every dialog dismissal,
+	// which is what made it worth closing rather than noting.
+	p := m.projectForDest(next.dest)
+	if m.installedDests[next.dest] || p == nil || p.Offline == nil {
 		m.promptNextUpgrade()
 		return
 	}
@@ -111,6 +147,7 @@ func (m *Model) promptNextUpgrade() {
 	m.confirmID = next.dest
 	m.confirmName = next.dest
 	m.confirmDetail = next.detail
+	m.confirmOfflineKind = next.kind
 }
 
 // SeedOfflineDest installs (or replaces) the stand-in rows for one destination.
@@ -142,7 +179,7 @@ func (m *Model) SeedOfflineDest(dest, label string, kind OfflineKind, detail str
 	// and because the disclaimer or the plugin migration may own the screen at
 	// that point. promptNextUpgrade drains it once the screen is free.
 	if kind == offlineNeedsInstall || kind == offlineNeedsUpgrade {
-		m.enqueueUpgradePrompt(dest, detail)
+		m.enqueueUpgradePrompt(dest, detail, kind)
 	}
 
 	rows := make([]*ProjectModel, 0, len(cached))

--- a/internal/tui/project.go
+++ b/internal/tui/project.go
@@ -201,9 +201,108 @@ func (m Model) renderEmptyTabArea(w, h int) string {
 	}
 	msg := "Connecting to quild…"
 	if p := m.cur(); p != nil {
-		msg = "No tabs in " + sanitizeRemoteText(p.displayName()) + "\n\nCtrl+T opens one"
+		// Capped, not merely sanitized. lipgloss.Place does not CLIP: both
+		// PlaceHorizontal and PlaceVertical compute `gap := width - contentWidth`
+		// and `return str` unchanged when it is non-positive, so an over-wide
+		// line leaves this function whole and the sidebar's JoinHorizontal then
+		// emits rows wider than the terminal. A project NAME is not local text
+		// on this path — an offline row is seeded from the on-disk cache of what
+		// a remote daemon reported, which LoadRemoteProjects bounds to 4096
+		// BYTES and never to display CELLS.
+		msg = truncateToWidth("No tabs in "+sanitizeRemoteText(p.displayName()), offlineTextCap(w)) +
+			"\n\nCtrl+T opens one"
+		if p.Offline != nil {
+			msg = m.offlineTabAreaMsg(p, w, h)
+		}
 	}
 	return lipgloss.Place(w, h, lipgloss.Center, lipgloss.Center, dialogSubtle.Render(msg))
+}
+
+// offlineTabAreaMsg is what an OFFLINE project's pane area says instead.
+//
+// A third reason renderEmptyTabArea's own doc comment did not account for: the
+// project has no tabs HERE, but that is a statement about this client, not
+// about the host — a remote daemon refused over a version mismatch keeps every
+// tab it had. Rendering the live-project text there told a user their two tabs
+// were gone and invited a Ctrl+T that could not reach the daemon which would
+// have to mint the tab. The row's ⚡ was the only thing saying otherwise, and a
+// glyph is not an explanation.
+//
+// Detail is remote-influenced (ssh's stderr, or a version pair the far side
+// reported), so it is sanitized and capped here — the render, per the same rule
+// every other remote string in this package follows. firstErrLine runs BEFORE
+// the sanitize, reusing reconnect.go's idiom for the same class of text: ssh
+// writes multi-line stderr, and sanitizeRemoteText DROPS \n as a C0 control
+// with no separator, so the alternative is two sentences fused into one word.
+//
+// EVERY line is capped, this package's own prose included. lipgloss.Place pads
+// but never clips, so one over-wide line escapes the w×h box and shifts the
+// whole frame — and the fixed strings below are wider than the pane area of a
+// narrow terminal on their own, quite apart from anything a remote sent.
+//
+// h is taken because the block is 4 lines without a detail and 6 with one:
+// PlaceVertical has the same no-clip escape hatch as its horizontal sibling, so
+// on a short frame the detail is what gets dropped, not the status bar.
+// A METHOD, because the retrying arm cannot answer from the project alone: an
+// offline destination with no dialer is PARKED and no ladder is running, while
+// its Kind stays offlineRetrying. Saying "Reconnecting…" there is the same
+// confidently-wrong answer this function exists to remove — and it is the only
+// thing on screen, since renderReconnectBanner returns "" for a link that is
+// not active.
+func (m Model) offlineTabAreaMsg(p *ProjectModel, w, h int) string {
+	lines := []string{sanitizeRemoteText(p.displayName()), ""}
+	switch p.Offline.Kind {
+	case offlineNeedsUpgrade:
+		lines = append(lines, "That host runs a different version of Quil,", "so this client will not attach to it.")
+	case offlineNeedsInstall:
+		lines = append(lines, "Quil is not installed on that host.")
+	case offlineRetrying:
+		// Named explicitly rather than left to a default: laddered() one file
+		// over is safe as a default because it is a POSITIVE test, so a new
+		// kind falls out as "not laddered". This switch defaults to a CLAIM,
+		// which a kind nobody has written yet would inherit silently.
+		if m.linkOf(p.Dest).parked {
+			lines = append(lines, "Reconnecting stopped.", "Press "+reconnectResumeKey+" to try again.")
+		} else {
+			lines = append(lines, "Reconnecting…")
+		}
+	}
+	// The detail is dropped when the fixed line above already says it. The
+	// needs-install sentinel is literally "quil is not installed on that host",
+	// and cmd/quil seeds Detail from the dial error's own text, so rendering
+	// both prints one sentence twice — once capitalised, once behind a "dial
+	// <host>:" prefix. The sentinel is the single source; this is the seam that
+	// keeps the two from drifting apart.
+	detail := sanitizeRemoteText(firstErrLine(p.Offline.Detail))
+	if p.Offline.Kind == offlineNeedsInstall &&
+		strings.Contains(strings.ToLower(detail), strings.ToLower(ErrRemoteQuilMissing.Error())) {
+		detail = ""
+	}
+	if detail != "" && h >= len(lines)+2 {
+		lines = append(lines, "", detail)
+	}
+	for i, line := range lines {
+		lines[i] = truncateToWidth(line, offlineTextCap(w))
+	}
+	return strings.Join(lines, "\n")
+}
+
+// offlineTextCap is the cell budget one line of the empty-tab area may occupy.
+//
+// The margin keeps the block off the frame edge. It is given up rather than
+// returning zero on a narrow frame: truncateToWidth answers "" for a
+// non-positive budget, so a blank pane area — saying nothing at all about a
+// host that cannot be reached — is what a hard margin would produce on the
+// terminal least able to spare the space.
+func offlineTextCap(w int) int {
+	const margin = 8
+	if c := w - margin; c > 0 {
+		return c
+	}
+	if w > 0 {
+		return w
+	}
+	return 0
 }
 
 // cur returns the active project, or nil when the Model has no projects yet.

--- a/internal/tui/sidebar_offline_test.go
+++ b/internal/tui/sidebar_offline_test.go
@@ -3,6 +3,8 @@ package tui
 import (
 	"strings"
 	"testing"
+
+	"charm.land/lipgloss/v2"
 )
 
 // 208 is the repo's orange (styles.go:62). 214 is deliberately NOT reused: it is
@@ -31,5 +33,274 @@ func TestLinkGlyph_ReadsOfflineKindWhenTheLadderIsNotRunning(t *testing.T) {
 	}
 	if got := m.linkGlyph("gpu01", nil); got != "" {
 		t.Errorf("a live destination with no ladder rendered %q, want empty", got)
+	}
+}
+
+// The pane area for an OFFLINE project used to render the same "No tabs in X —
+// Ctrl+T opens one" as an empty live one. That is the confidently-wrong answer:
+// the host is up, its tabs exist, this client just refused to attach — and the
+// Ctrl+T it invites cannot reach the daemon that would have to mint the tab.
+func TestEmptyTabArea_OfflineProjectSaysWhyInsteadOfOfferingCtrlT(t *testing.T) {
+	m := Model{
+		width: 120, height: 30,
+		sidebarOpen:  true,
+		sidebarWidth: 22,
+		projects: []*ProjectModel{{
+			ID:   "proj-cluster",
+			Name: "cluster-management",
+			Dest: "artyom@gpu01",
+			Offline: &OfflineState{
+				Kind:   offlineNeedsUpgrade,
+				Detail: "artyom@gpu01 runs 1.55.0, this client runs 1.63.2; run `quil remote setup artyom@gpu01`",
+			},
+		}},
+		notifications: NewNotificationCenter(30, 50),
+	}
+
+	out := stripANSI(m.View().Content)
+	if strings.Contains(out, "Ctrl+T opens one") {
+		t.Errorf("an offline project still invites Ctrl+T, which cannot reach the host:\n%s", out)
+	}
+	if !strings.Contains(out, "1.55.0") {
+		t.Errorf("the pane area does not report the version drift that blocked the attach:\n%s", out)
+	}
+	if !strings.Contains(out, "quil remote setup") {
+		t.Errorf("the pane area names no way out:\n%s", out)
+	}
+	// The sidebar reserves layout width; an unwrapped message overflows the frame.
+	for i, line := range strings.Split(out, "\n") {
+		if got := lipgloss.Width(line); got > m.width {
+			t.Errorf("line %d measured %d cells, wider than the %d-cell frame", i, got, m.width)
+		}
+	}
+}
+
+// A host merely unreachable is a different sentence: nothing to run, the ladder
+// is already working on it.
+func TestEmptyTabArea_RetryingProjectSaysReconnecting(t *testing.T) {
+	m := Model{
+		width: 120, height: 30,
+		projects: []*ProjectModel{{
+			ID: "proj-1", Name: "api", Dest: "gpu01",
+			Offline: &OfflineState{Kind: offlineRetrying, Detail: "ssh: connect: no route to host"},
+		}},
+		notifications: NewNotificationCenter(30, 50),
+	}
+	out := stripANSI(m.View().Content)
+	if strings.Contains(out, "Ctrl+T opens one") {
+		t.Errorf("an unreachable project still invites Ctrl+T:\n%s", out)
+	}
+	if !strings.Contains(out, "gpu01") {
+		t.Errorf("the pane area does not name the host it is waiting on:\n%s", out)
+	}
+}
+
+// MEDIUM-2 from the review of PR #186. An offline row's NAME is not local text:
+// it is seeded from the on-disk cache of what a remote daemon reported, bounded
+// by LoadRemoteProjects at 4096 BYTES and never at display CELLS. lipgloss.Place
+// does not clip — PlaceHorizontal computes `gap := width - contentWidth` and
+// returns str unchanged when gap <= 0 — so an over-wide line leaves the pane
+// area whole and the sidebar join then emits rows wider than the terminal.
+//
+// Asserted for BOTH branches: the live-project text has the identical shape and
+// had the same gap before this test existed, so covering only the offline one
+// would leave the sibling free to regress.
+func TestEmptyTabArea_LongRemoteNameStaysInsideTheFrame(t *testing.T) {
+	huge := strings.Repeat("wide-remote-project-name-", 160) // ~4000 cells
+	for _, tc := range []struct {
+		name    string
+		offline *OfflineState
+	}{
+		{"offline row", &OfflineState{Kind: offlineNeedsUpgrade, Detail: "gpu01 runs 1.0.0, this client runs 2.0.0"}},
+		{"live row with no tabs", nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := Model{
+				width: 100, height: 30,
+				projects: []*ProjectModel{{
+					ID: "proj-1", Name: huge, Dest: "gpu01", Offline: tc.offline,
+				}},
+				notifications: NewNotificationCenter(30, 50),
+			}
+			out := stripANSI(m.View().Content)
+			// Non-vacuity: without this, a frame that never rendered the
+			// message at all would satisfy every width assertion below.
+			if !strings.Contains(out, "wide-remote-project-name") {
+				t.Fatalf("the pane area never rendered the project name, so the "+
+					"width assertions below prove nothing:\n%s", out)
+			}
+			for i, line := range strings.Split(out, "\n") {
+				if got := lipgloss.Width(line); got > m.width {
+					t.Fatalf("line %d measured %d cells against a %d-cell frame — "+
+						"lipgloss.Place pads but never clips", i, got, m.width)
+				}
+			}
+		})
+	}
+}
+
+// A remote-supplied detail is capped too, and on the same budget.
+func TestEmptyTabArea_LongRemoteDetailStaysInsideTheFrame(t *testing.T) {
+	m := Model{
+		width: 100, height: 30,
+		projects: []*ProjectModel{{
+			ID: "proj-1", Name: "api", Dest: "gpu01",
+			Offline: &OfflineState{Kind: offlineNeedsUpgrade, Detail: strings.Repeat("A", 9000)},
+		}},
+		notifications: NewNotificationCenter(30, 50),
+	}
+	for i, line := range strings.Split(stripANSI(m.View().Content), "\n") {
+		if got := lipgloss.Width(line); got > m.width {
+			t.Fatalf("line %d measured %d cells against a %d-cell frame", i, got, m.width)
+		}
+	}
+}
+
+// ssh writes multi-line stderr, and sanitizeRemoteText drops \n as a C0 control
+// with NO separator — so without firstErrLine the two sentences fuse into one
+// word. reconnect.go already made this call for the same class of text.
+func TestEmptyTabArea_MultiLineStderrKeepsOnlyTheFirstLine(t *testing.T) {
+	m := Model{
+		width: 100, height: 30,
+		projects: []*ProjectModel{{
+			ID: "proj-1", Name: "api", Dest: "gpu01",
+			Offline: &OfflineState{
+				Kind:   offlineRetrying,
+				Detail: "ssh: connect to host gpu01 port 22: Connection refused\nHost key verification failed.",
+			},
+		}},
+		notifications: NewNotificationCenter(30, 50),
+	}
+	out := stripANSI(m.View().Content)
+	if strings.Contains(out, "refusedHost") {
+		t.Errorf("two stderr lines fused into one word:\n%s", out)
+	}
+	if !strings.Contains(out, "Connection refused") {
+		t.Errorf("the first stderr line is missing:\n%s", out)
+	}
+	if strings.Contains(out, "Host key verification") {
+		t.Errorf("the second stderr line survived; only the first belongs on one row:\n%s", out)
+	}
+}
+
+// The needsInstall arm had no coverage: a host that never had quil at all reads
+// differently from one whose daemon is merely the wrong version.
+func TestEmptyTabArea_NeedsInstallSaysNotInstalled(t *testing.T) {
+	m := Model{
+		width: 100, height: 30,
+		projects: []*ProjectModel{{
+			ID: "proj-1", Name: "api", Dest: "gpu01",
+			Offline: &OfflineState{Kind: offlineNeedsInstall, Detail: "quil: command not found"},
+		}},
+		notifications: NewNotificationCenter(30, 50),
+	}
+	out := stripANSI(m.View().Content)
+	if !strings.Contains(out, "not installed") {
+		t.Errorf("a host with no quil is not told apart from a version drift:\n%s", out)
+	}
+	if strings.Contains(out, "different version") {
+		t.Errorf("needsInstall borrowed the version-drift wording:\n%s", out)
+	}
+}
+
+// An empty Detail must not leave a dangling blank line where the reason should be.
+func TestEmptyTabArea_EmptyDetailAppendsNothing(t *testing.T) {
+	withDetail := Model{}.offlineTabAreaMsg(&ProjectModel{
+		Name: "api", Dest: "gpu01",
+		Offline: &OfflineState{Kind: offlineNeedsUpgrade, Detail: "gpu01 runs 1.0.0"},
+	}, 100, 30)
+	without := Model{}.offlineTabAreaMsg(&ProjectModel{
+		Name: "api", Dest: "gpu01",
+		Offline: &OfflineState{Kind: offlineNeedsUpgrade},
+	}, 100, 30)
+
+	if got := strings.Count(without, "\n"); got != 3 {
+		t.Errorf("an empty detail produced %d newlines, want 3 (a 4-line block):\n%q", got, without)
+	}
+	if strings.HasSuffix(without, "\n") {
+		t.Errorf("an empty detail left a trailing blank line: %q", without)
+	}
+	if strings.Count(withDetail, "\n") != 5 {
+		t.Errorf("a detail should add exactly two lines: %q", withDetail)
+	}
+}
+
+// PlaceVertical has the same no-clip escape hatch as PlaceHorizontal, so on a
+// frame too short for six lines the DETAIL is what gets dropped — not the
+// status bar the overflow would otherwise push off screen.
+func TestEmptyTabArea_ShortFrameDropsTheDetail(t *testing.T) {
+	p := &ProjectModel{
+		Name: "api", Dest: "gpu01",
+		Offline: &OfflineState{Kind: offlineNeedsUpgrade, Detail: "gpu01 runs 1.0.0, this client runs 2.0.0"},
+	}
+	if got := strings.Count(Model{}.offlineTabAreaMsg(p, 100, 5), "\n"); got != 3 {
+		t.Errorf("a 5-row frame got %d newlines, want 3 — the detail must be dropped", got)
+	}
+	if got := strings.Count(Model{}.offlineTabAreaMsg(p, 100, 6), "\n"); got != 5 {
+		t.Errorf("a 6-row frame got %d newlines, want 5 — the detail fits", got)
+	}
+}
+
+// offlineRetrying does NOT imply reconnecting. model.go:1305 parks a dest with
+// no dialer and starts no ladder, while Kind stays offlineRetrying — and
+// renderReconnectBanner returns "" for a link that is not active, so the pane
+// area is the ONLY thing on screen. "Reconnecting…" there is the same
+// confidently-wrong answer the function exists to remove, and it contradicts
+// bannerCandidates' own "unreachable — stopped, r retries" for the same state.
+func TestEmptyTabArea_ParkedLinkDoesNotClaimToBeReconnecting(t *testing.T) {
+	newModel := func() Model {
+		return Model{
+			width: 100, height: 30,
+			projects: []*ProjectModel{{
+				ID: "proj-1", Name: "api", Dest: "gpu01",
+				Offline: &OfflineState{Kind: offlineRetrying, Detail: "ssh: connect: no route to host"},
+			}},
+			notifications: NewNotificationCenter(30, 50),
+		}
+	}
+
+	parked := newModel()
+	parked.linkFor("gpu01").parked = true
+	out := stripANSI(parked.View().Content)
+	if strings.Contains(out, "Reconnecting…") {
+		t.Errorf("a parked link claims to be reconnecting; nothing is, and nothing will be:\n%s", out)
+	}
+	if !strings.Contains(out, reconnectResumeKey) || !strings.Contains(out, "stopped") {
+		t.Errorf("a parked link does not say it stopped or how to resume:\n%s", out)
+	}
+
+	// A link genuinely mid-ladder keeps the original wording.
+	active := newModel()
+	active.linkFor("gpu01").active = true
+	if out := stripANSI(active.View().Content); !strings.Contains(out, "Reconnecting…") {
+		t.Errorf("an active ladder no longer says it is reconnecting:\n%s", out)
+	}
+}
+
+// ErrRemoteQuilMissing is literally "quil is not installed on that host", and
+// cmd/quil seeds Detail from the dial error's own text — so rendering the fixed
+// line AND the detail printed one sentence twice, once capitalised and once
+// behind a "dial <host>:" prefix. The sentinel is the single source.
+func TestEmptyTabArea_NeedsInstallDoesNotSayItTwice(t *testing.T) {
+	m := Model{
+		width: 100, height: 30,
+		projects: []*ProjectModel{{
+			ID: "proj-1", Name: "api", Dest: "gpu01",
+			Offline: &OfflineState{
+				Kind:   offlineNeedsInstall,
+				Detail: "dial gpu01: " + ErrRemoteQuilMissing.Error(),
+			},
+		}},
+		notifications: NewNotificationCenter(30, 50),
+	}
+	out := stripANSI(m.View().Content)
+	if n := strings.Count(strings.ToLower(out), "not installed on that host"); n != 1 {
+		t.Errorf("the same sentence renders %d times, want 1:\n%s", n, out)
+	}
+
+	// A detail that says something ELSE is still worth showing.
+	m.projects[0].Offline.Detail = "ssh: permission denied (publickey)"
+	if out := stripANSI(m.View().Content); !strings.Contains(out, "permission denied") {
+		t.Errorf("a detail that adds information was suppressed:\n%s", out)
 	}
 }

--- a/internal/tui/upgrade_prompt_test.go
+++ b/internal/tui/upgrade_prompt_test.go
@@ -233,3 +233,186 @@ func TestUpgradePrompt_AlreadyInstalledHostIsNotOfferedAgain(t *testing.T) {
 		t.Error("a host provisioned this session was offered again — install, retry, same error, install")
 	}
 }
+
+// THE ORDER THAT SHIPS. cmd/quil/main.go seeds the offline rows (:597) and
+// wires the provisioner (:765) — 168 lines apart, seeding first — so at seed
+// time installDestFn is still nil. upgradeModel wires it FIRST, which is the
+// reverse, and that inversion is why every test above passed while the launch
+// path offered nothing: enqueueUpgradePrompt's nil-provisioner guard rejected
+// the ask before it was ever queued, and the drain point found an empty queue.
+//
+// The symptom reached a user as a sidebar row with a ⚡ and a pane area reading
+// "No tabs in cluster-management@… — Ctrl+T opens one", against a remote daemon
+// that was up the whole time with two tabs in it.
+func TestUpgradePrompt_SeedBeforeInstallFuncStillOffers(t *testing.T) {
+	m := *newSplitDragTestModel(t)
+	m.width, m.height = 120, 44
+	m.SeedOfflineDest("artyom@host", "artyom@host", OfflineNeedsUpgrade, mismatchDetail, nil)
+
+	var installed []string
+	m.SetInstallFunc(func(dest string) error {
+		installed = append(installed, dest)
+		return nil
+	})
+
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 44})
+	got := updated.(Model)
+	if got.dialog != dialogConfirm || got.confirmKind != confirmKindUpgradeDest {
+		t.Fatalf("a host seeded before the provisioner was wired raised no offer: "+
+			"dialog=%v kind=%q queue=%+v", got.dialog, got.confirmKind, got.upgradeQueue)
+	}
+	if got.confirmID != "artyom@host" {
+		t.Errorf("confirmID = %q, want the destination", got.confirmID)
+	}
+}
+
+// The guard that MOVED, pinned on the side the existing test cannot see.
+//
+// TestUpgradePrompt_NoInstallFuncRaisesNothing asserts only that no dialog
+// opens, which was true BEFORE this change for the opposite reason — the ask
+// was refused at the door and the queue was empty. Both readings satisfy it, so
+// on its own it cannot tell "held until a provisioner arrives" from "dropped".
+// That distinction is the entire fix: cmd/quil/main.go wires the provisioner
+// 168 lines after it seeds these rows.
+func TestUpgradePrompt_NoProvisionerHoldsTheAskRatherThanDroppingIt(t *testing.T) {
+	m := *newSplitDragTestModel(t)
+	m.width, m.height = 120, 44
+	m.SeedOfflineDest("artyom@host", "artyom@host", OfflineNeedsUpgrade, mismatchDetail, nil)
+
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 44})
+	got := updated.(Model)
+
+	if got.dialog == dialogConfirm {
+		t.Fatal("an upgrade was offered with no provisioner wired")
+	}
+	if len(got.upgradeQueue) != 1 {
+		t.Fatalf("the ask was dropped instead of held: %+v — a provisioner wired "+
+			"later would then have nothing to surface", got.upgradeQueue)
+	}
+
+	// And wiring one later surfaces it, without a second seed.
+	//
+	// The second size must DIFFER: an unchanged one is swallowed by the
+	// poll-echo guard well above the drain point, so re-sending 120x44 here
+	// asserts nothing about the queue and fails for a reason that has nothing
+	// to do with provisioners. Production never depends on this arm — main.go
+	// wires the provisioner before tea.NewProgram, so the first WindowSizeMsg
+	// already has one — but "held" is only meaningful if something can still
+	// collect it.
+	got.SetInstallFunc(func(string) error { return nil })
+	updated, _ = got.Update(tea.WindowSizeMsg{Width: 121, Height: 45})
+	if final := updated.(Model); final.dialog != dialogConfirm || final.confirmID != "artyom@host" {
+		t.Errorf("a held ask did not surface once a provisioner was wired: dialog=%v id=%q",
+			final.dialog, final.confirmID)
+	}
+}
+
+// THE FLAGSHIP PATH, and the one the first version of this fix still lost.
+//
+// promptNextUpgrade's doc promised "every dialog dismissal calls this again",
+// but only the upgrade confirm's own Esc did. handleWhatsNewKey and
+// handleDisclaimerKey return to dialogNone and drained nothing — so on the ONE
+// launch that matters, the queue filled and was never opened: a client
+// auto-update is exactly when gateExtraVersion refuses every configured host
+// AND when ResolveWhatsNew puts a dialog on screen. The first WindowSizeMsg
+// no-ops on `dialog != dialogNone`, the 1 s size poll is echo-guarded so no
+// second one arrives by itself, and dismissing what's-new dropped the ask on
+// the floor. Symptom: the ⚡ and no offer — what the PR exists to remove.
+func TestUpgradePrompt_SurvivesTheWhatsNewDialogAtLaunch(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		dialog  dialogScreen
+		dismiss tea.KeyPressMsg
+	}{
+		{"what's new", dialogWhatsNew, tea.KeyPressMsg{Code: tea.KeyEscape, Text: "esc"}},
+		{"disclaimer", dialogDisclaimer, tea.KeyPressMsg{Code: tea.KeyEnter, Text: "enter"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m, _ := upgradeModel(t)
+			m.dialog = tc.dialog
+			m.SeedOfflineDest("artyom@host", "artyom@host", OfflineNeedsUpgrade, mismatchDetail, nil)
+
+			updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 44})
+			held := updated.(Model)
+			if held.dialog != tc.dialog {
+				t.Fatalf("the offer displaced the startup dialog: %v", held.dialog)
+			}
+			if len(held.upgradeQueue) != 1 {
+				t.Fatalf("the ask was dropped before the dialog was even answered: %+v", held.upgradeQueue)
+			}
+
+			// Dismissing the startup dialog must surface it — with no resize,
+			// because none arrives on its own.
+			updated, _ = held.Update(tc.dismiss)
+			got := updated.(Model)
+			if got.dialog != dialogConfirm || got.confirmKind != confirmKindUpgradeDest {
+				t.Fatalf("dismissing %v dropped the queued offer: dialog=%v kind=%q queue=%+v",
+					tc.dialog, got.dialog, got.confirmKind, got.upgradeQueue)
+			}
+			if got.confirmID != "artyom@host" {
+				t.Errorf("confirmID = %q, want the destination", got.confirmID)
+			}
+		})
+	}
+}
+
+// A host that came BACK must not be offered an upgrade it no longer needs.
+//
+// applyWorkspaceState clears Offline on reconnect and adoptDest never touches
+// installedDests, so the queued ask still resolved to a live project. Accepting
+// it runs the same runRemoteSetup the CLI does, which STOPS that daemon — the
+// cost the confirm's own body warns about, charged against a host that works.
+func TestUpgradePrompt_HostThatCameBackIsNotOffered(t *testing.T) {
+	m, _ := upgradeModel(t)
+	m.SeedOfflineDest("artyom@host", "artyom@host", OfflineNeedsUpgrade, mismatchDetail, nil)
+	if len(m.upgradeQueue) != 1 {
+		t.Fatalf("fixture did not queue the ask: %+v", m.upgradeQueue)
+	}
+
+	// The host reconnects before the queue is drained.
+	for _, p := range m.projects {
+		if p.Dest == "artyom@host" {
+			p.Offline = nil
+		}
+	}
+
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 44})
+	if got := updated.(Model); got.dialog == dialogConfirm {
+		t.Errorf("a reconnected host was offered a daemon-restarting upgrade: %q", got.confirmID)
+	}
+}
+
+// needsInstall queues the same confirm as needsUpgrade, and the body was written
+// for the upgrade alone. A host that has never run quil has no daemon to restart
+// and no panes to lose; telling the user otherwise invents a cost and buys a
+// decline for something that was free.
+func TestUpgradePrompt_FirstInstallDoesNotThreatenPanes(t *testing.T) {
+	m, _ := upgradeModel(t)
+	m.SeedOfflineDest("artyom@fresh", "artyom@fresh", OfflineNeedsInstall, "quil: command not found", nil)
+
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 44})
+	got := updated.(Model)
+	if got.dialog != dialogConfirm {
+		t.Fatalf("a host with no quil raised no offer: %v", got.dialog)
+	}
+	out := got.renderConfirmDialog()
+
+	if !strings.Contains(out, "Install quil on") {
+		t.Errorf("a first install is titled as an upgrade:\n%s", out)
+	}
+	if strings.Contains(out, "RESTARTS") || strings.Contains(out, "is killed") {
+		t.Errorf("a host with no daemon was warned its panes would be killed:\n%s", out)
+	}
+	if !strings.Contains(out, "y install") {
+		t.Errorf("the footer still offers an upgrade:\n%s", out)
+	}
+
+	// The upgrade wording must survive for the kind it was written for.
+	m2, _ := upgradeModel(t)
+	m2.SeedOfflineDest("artyom@old", "artyom@old", OfflineNeedsUpgrade, mismatchDetail, nil)
+	updated2, _ := m2.Update(tea.WindowSizeMsg{Width: 120, Height: 44})
+	up := updated2.(Model).renderConfirmDialog()
+	if !strings.Contains(up, "Upgrade quil on") || !strings.Contains(up, "RESTARTS") {
+		t.Errorf("the upgrade confirm lost its own warning:\n%s", up)
+	}
+}

--- a/techdebt/3-2-flaky-kill-process-single-flight-test.md
+++ b/techdebt/3-2-flaky-kill-process-single-flight-test.md
@@ -1,0 +1,91 @@
+# TestHandleMessage_KillProcessIsWiredUpAndSingleFlighted races the worker it observes
+
+| Field | Value |
+|-------|-------|
+| Criticality | Medium |
+| Complexity | Small |
+| Location | `internal/daemon/procreport_dispatch_test.go:183` |
+| Found during | Code review of PR #186 (remote upgrade offer) — CI failed on a branch that touches no daemon file |
+| Date | 2026-08-23 |
+
+## Issue
+
+The second half of the test asserts a POSITIVE by polling for a flag that the
+code under test sets and then clears on its own:
+
+```go
+d.killRunning.Store(false)
+d.handleMessage(nil, msg)
+
+deadline := time.Now().Add(5 * time.Second)
+claimed := false
+for time.Now().Before(deadline) {
+    if d.killRunning.Load() {
+        claimed = true
+        break
+    }
+    time.Sleep(time.Millisecond)
+}
+if !claimed {
+    t.Fatal("the kill request never claimed the single-flight — ...")
+}
+```
+
+`handleMessage` claims the flight and hands the work to a goroutine, which
+releases it when it finishes. The request names `PaneID: "no-such-pane"` and
+`PID: 999999`, so that work is a lookup miss — it can complete before the
+polling loop's first `Load()`. Nothing distinguishes "never claimed" from
+"claimed and released before I looked", and the failure message asserts the
+first with confidence.
+
+The first half of the test does not have this problem: it pre-claims the flight
+so the handler takes its synchronous busy path, and the test's own comment says
+why ("there is no goroutine to race"). The property is only unobservable on the
+half that lets the goroutine run.
+
+## Evidence
+
+CI run 32640108969 on commit 6d74cf4:
+
+```
+--- FAIL: TestHandleMessage_KillProcessIsWiredUpAndSingleFlighted (5.00s)
+    procreport_dispatch_test.go:193: the kill request never claimed the
+    single-flight — the dispatch arm for MsgKillProcessReq is not reaching
+    handleKillProcessReq
+FAIL	github.com/artyomsv/quil/internal/daemon	21.276s
+```
+
+Re-run of the same job on the same commit, no code change: pass in 3m10s. The
+branch it failed on modifies only `cmd/quil` and `internal/tui`.
+
+The 5.00s duration is the whole polling budget being spent, which is the
+signature: a genuinely disconnected dispatch arm and a flag released too early
+both burn the full deadline and print the same line.
+
+## Risks
+
+- A red CI on a PR that changed nothing in `internal/daemon` sends the author
+  looking for a fault in their own diff. That cost real time here.
+- Repeated unexplained reds train the reflex of re-running until green, which is
+  how a genuine regression in the dispatch arm gets waved through — this test
+  exists precisely to catch that arm being disconnected.
+- Same family as `3-2-flaky-router-removed-pump-test.md` and
+  `3-2-flaky-flush-on-closed-conn-test.md`: an assertion about a concurrent
+  transition observed by polling from outside.
+
+## Suggested Solutions
+
+1. Observe the completion instead of the claim. Have the worker signal a channel
+   the test waits on, then assert the flight was released — the release is the
+   stable end state, and reaching it proves the arm ran. Preferred: it tests the
+   same property without a window.
+2. Make the work slow enough to observe by pointing the request at a pane that
+   exists with a process that lingers. Rejected — it swaps a timing race for a
+   timing assumption and makes the test depend on process spawning.
+3. Count invocations. Give the handler a test-visible counter incremented on
+   entry, and assert it moved. Simple and race-free, but adds a field that exists
+   only for the test.
+
+Whichever is chosen, the `t.Fatal` message must stop asserting a cause it cannot
+distinguish — "never claimed" and "released before observed" need different text
+or the failure keeps misdirecting whoever reads it.

--- a/techdebt/3-3-remote-host-cannot-apply-its-own-staged-update.md
+++ b/techdebt/3-3-remote-host-cannot-apply-its-own-staged-update.md
@@ -1,0 +1,68 @@
+# A remote host stages updates it can never apply
+
+| Field | Value |
+|-------|-------|
+| Criticality | Medium |
+| Complexity | Medium |
+| Location | `cmd/quil/main.go` — `launchTUI()` (`maybeApplyStagedUpdate`), against the `case "--stdio": runStdio()` arm of the subcommand switch; `internal/update/` staging; `internal/daemon/update.go` |
+| Found during | Root-cause investigation behind PR #186 (version-drifted remote offered no upgrade) |
+| Date | 2026-08-23 |
+
+## Issue
+
+The daemon checks for releases and STAGES them into `$QUIL_HOME/update/staged/<ver>/`.
+Applying a staged release happens in exactly one place: `maybeApplyStagedUpdate(false)`,
+called from `launchTUI()`. Nothing ever launches a TUI on a remote host — the client
+reaches it as `ssh -T <dest> "quil --stdio"`, and `--stdio` returns from the subcommand
+switch well before that call, deliberately.
+
+So a host used only over `--remote` / a `[[destinations]]` entry stages every release
+and applies none. Its daemon keeps running whatever version it was last started with,
+while the client that talks to it auto-updates on its own schedule. `gateExtraVersion`
+refuses any version difference, so the gap closes the destination.
+
+Measured on a real host, 2026-08-23: daemon running 1.55.0 since Aug 14, 1.63.1 staged
+since Aug 21, client on 1.63.1. Nine days of `client connected → version_req → client
+disconnected` in the remote daemon log with no `attach` between them, while the daemon
+itself was healthy and snapshotting `2 tabs, 3 panes` every 30 s.
+
+`quil --version` on such a host is also unusable: it is not a recognised subcommand, so
+it falls through to `launchTUI()`, hits the apply prompt, and dies with
+`bubbletea: could not open TTY` under a non-interactive ssh session.
+
+## Risks
+
+- Every client auto-update silently widens the gap. The drift is not a one-off state to
+  recover from; it re-arms on a timer.
+- The only repair is initiated from the CLIENT (`quil remote setup <dest>`, or the
+  in-tool offer PR #186 restored). A user who dismisses the offer has no in-tool path
+  back until the next launch.
+- Staged archives accumulate on the remote — disk spent on binaries that will never run.
+- The failure is invisible from the client: `gateExtraVersion` deliberately makes a
+  refused destination indistinguishable from an absent one.
+
+## Not addressed by PR #186
+
+That PR fixes the OFFER — the launch-path ask was queued behind a nil provisioner and
+dropped, so the drift was silent as well as unrepaired. It does not give the remote any
+ability to update itself; it makes the client reliably ask the user to push one.
+
+## Suggested Solutions
+
+1. Let the DAEMON apply its own staged update on a controlled restart, and have the
+   client's version gate ask it to. The daemon already owns the stage step and the
+   rename-aside swap + rollback (`internal/update/`); what it lacks is a trigger that
+   is not a TUI launch. Needs care against `restartDaemonForUpgrade`'s documented
+   hazard — a stop that cannot be confirmed must never be followed by a spawn, or the
+   host ends up with two daemons owning one workspace.
+2. Have `quil --stdio` apply a staged update before connecting, with the prompt
+   suppressed (there is no TTY) and consent taken once at `quil remote setup` time.
+   Cheaper, but it moves an install into the hot path of every attach, and a failed
+   swap would surface as a dial failure rather than an update error.
+3. Leave applying to the client and make the DRIFT loud instead: have the daemon stop
+   staging on a host that cannot apply, and report `staged but unappliable` in the
+   version handshake so the client can say so precisely. Smallest change; does not fix
+   the underlying gap.
+4. Make `--version` (and `--help`) real subcommands so an operator can read a remote
+   host's version over plain ssh without tripping the apply prompt. Independent of the
+   above and worth doing regardless.

--- a/techdebt/3-3-truncatetowidth-sums-runes-not-graphemes.md
+++ b/techdebt/3-3-truncatetowidth-sums-runes-not-graphemes.md
@@ -1,0 +1,64 @@
+# truncateToWidth sums independently-measured runes, so it can return a string wider than its budget
+
+| Field | Value |
+|-------|-------|
+| Criticality | Medium |
+| Complexity | Medium |
+| Location | `internal/tui/palette.go` — `truncateToWidth`; ~10 call sites, several on remote-influenced text |
+| Found during | Security review of PR #186 (offline pane area renders a remote-supplied detail) |
+| Date | 2026-08-23 |
+
+## Issue
+
+`truncateToWidth` walks `for _, r := range s` and accumulates
+`lipgloss.Width(string(r))` per rune, stopping when the sum would exceed the
+budget. Its own doc comment claims "Cell-aware, NOT rune-count".
+
+A rune measured ALONE does not always contribute that many cells in context. A
+variation selector (U+FE0F) measures 0 on its own while promoting the character
+before it from 1 cell to 2; a ZWJ sequence measures as its parts rather than the
+single glyph the terminal draws. Summing independent measurements therefore
+UNDER-counts, and the returned string can render up to roughly twice its budget.
+
+`lastCellsToWidth` sits immediately below it in the same file, documents this
+exact hazard verbatim — "a variation selector measures 0 alone while making the
+pair before it 2, so summing independently-measured runes returns a suffix WIDER
+than w" — and solves it with `uniseg` grapheme segmentation. `truncateToWidth`
+was left on the per-rune path.
+
+## Risks
+
+- Every consumer treats the return value as bounded. `internal/tui/project.go`'s
+  `offlineTabAreaMsg` is one of them, and its input is a string a remote daemon
+  supplied — so the overflow is reachable by the far host, not only by a user
+  with an emoji in a directory name.
+- `lipgloss.Place` pads but never CLIPS (`PlaceHorizontal`: `gap := width -
+  contentWidth`, `if gap <= 0 { return str }`), so an over-budget line escapes
+  its box and the sidebar's `JoinHorizontal` emits rows wider than the terminal
+  — the row-drift family this codebase has shipped before.
+- The 8-cell margin `offlineTextCap` reserves is not enough to absorb a 2x
+  overshoot on a long string.
+
+## Not a PR #186 regression
+
+The helper predates that PR, which only adds another caller. Flagged there
+because the new caller renders remote-controlled text, which moves the reachable
+input from "a name the user typed" to "a string the other machine chose".
+
+## Suggested Solutions
+
+1. Rewrite `truncateToWidth` on `uniseg.NewGraphemes`, mirroring
+   `lastCellsToWidth` exactly — measure each grapheme CLUSTER with
+   `lipgloss.Width` and accumulate that. The idiom already exists one function
+   away, and `rivo/uniseg` is already a direct dependency for this reason.
+   Preferred.
+2. Keep the loop and re-measure the accumulated prefix with `lipgloss.Width`
+   after each append, backing off when it exceeds the budget. Correct without a
+   new dependency on the segmenter, but O(n²) on the prefix — acceptable only
+   because these strings are bounded by a cell budget in the first place.
+3. Do nothing in the helper and clamp at each call site instead. Rejected: ten
+   call sites, and the next caller inherits the same wrong assumption from the
+   doc comment.
+
+Whichever is chosen, the doc comment's "Cell-aware, NOT rune-count" claim must
+become true or be corrected — it is what invites callers to trust the bound.


### PR DESCRIPTION
## Summary

- **The in-tool upgrade offer never fired on the launch path.** `cmd/quil/main.go` seeds offline rows at `:597` and wires the provisioner at `:765`; `enqueueUpgradePrompt` rejected any ask made while `installDestFn` was nil, so the queue was empty by construction and the drain point on the first `WindowSizeMsg` found nothing. A host left behind by a client update stayed unusable for the whole session, showing a `⚡` and no explanation. The guard now sits at the point of action (`promptNextUpgrade`), which makes the fix immune to call order rather than pinning `main.go`'s.
- **And the drain had to move to where the screen actually comes free.** `promptNextUpgrade`'s doc promised "every dialog dismissal calls this again" while exactly one dismissal did — the upgrade confirm's own `Esc`. That swallowed the flagship case rather than an edge: a client auto-update is *precisely* when `gateExtraVersion` refuses every configured host **and** when `ResolveWhatsNew` opens a dialog at startup. The queue filled, the first `WindowSizeMsg` no-oped on `dialog != dialogNone`, the 1 s size poll is echo-guarded so no later resize arrived on its own, and dismissing what's-new dropped the ask. `handleDialogKey` now drains on any return to `dialogNone`.
- **An offline project's pane area no longer claims its tabs are gone.** It rendered the empty-live-project text — "No tabs in X — Ctrl+T opens one" — when the remote daemon still held every tab and that `Ctrl+T` could not reach the daemon that would have to mint one. It now names the host, separates a version drift from a missing install from a link still reconnecting, and carries the command that fixes it.
- Every existing test in `upgrade_prompt_test.go` wired the provisioner *before* seeding — the reverse of the shipping order — so the suite certified a path production never runs.

## Observed failure

A remote daemon up for 9 days, with `2 tabs, 3 panes` in its snapshot, unreachable from the client. Its log holds nothing but version probes since the client outgrew it:

```
ipc: client connected (total=1)
ipc recv: version_req
ipc: client disconnected (remaining=0)
```

Client 1.63.1, daemon 1.55.0. The refusal is correct; the silence after it was not.

## Correctness found in review

- **A host that came BACK is no longer offered.** Reconnecting clears its `Offline` while `installedDests` goes untouched, so a queued ask still resolved to a live project — and accepting runs the same `runRemoteSetup` the CLI does, **stopping that daemon and taking its panes with it**. The confirm's own body warns about that cost; it must not be charged against a host that works.
- **`offlineRetrying` is answered from link health rather than assumed.** A destination with no dialer is *parked* with no ladder running while its kind stays `offlineRetrying`, and `renderReconnectBanner` draws nothing for an inactive link — so "Reconnecting…" was both false and the only thing on screen, contradicting two of the four `bannerCandidates` rungs that describe the same state. `laddered()` is safe as a *positive* test; a switch that defaults to a *claim* is not.
- **The provisioning confirm asks the right question for each of the two states that queue it.** `needsInstall` reached a body written for an upgrade, warning that panes would be killed on a host with no daemon and no panes — a reason to decline something that was free.
- **The needs-install pane no longer prints one sentence twice.** `ErrRemoteQuilMissing` is literally "quil is not installed on that host" and `cmd/quil` seeds `Detail` from the dial error's own text, so the fixed line and the detail said the same thing, once capitalised and once behind a `dial <host>:` prefix.

## Hardening found in review

The render site this PR introduces made two pre-existing gaps reachable from a host the user may not control, so both are closed here rather than left for the caller that trips them:

- **Every line of the pane area is capped, this package's own prose included.** `lipgloss.Place` pads but never clips — `PlaceHorizontal`/`PlaceVertical` both compute `gap := width - contentWidth` and `return str` once it is non-positive — so one over-wide line escapes the `w×h` box and the sidebar's `JoinHorizontal` emits rows wider than the terminal. A project *name* is not local text on this path: an offline row is seeded from the on-disk cache of what a remote daemon reported, which `LoadRemoteProjects` bounds to 4096 **bytes** and never to display **cells**. Measured pre-fix: a 43-cell literal corrupted the whole frame to 43 columns on a 40-column terminal, reachable either by a narrow terminal or by dragging the sidebar wide (`paneAreaWidth` floors at exactly `minTermWidth`). The live-project branch had the identical gap and is capped too.
- **A daemon's reported version is clamped where it enters** (`clampVersionString`, 64 bytes, cut on a rune boundary). Nothing else bounded it: the only ceiling on the wire is `ipc.maxFrameSize` (10 MB), and `version.Parsed` truncates at the first `-`, so `"1.0.0-"` followed by megabytes compares as an ordinary `1.0.0` and the whole payload flowed into `gateExtraVersion`'s error text, into `OfflineState.Detail`, and was re-measured by `lipgloss.Width` on every frame — with a guaranteed repaint every second from the size poll, and a state that never clears because `offlineNeedsUpgrade` is deliberately not laddered.
- Smaller: the detail is dropped rather than the frame overflowed when the height cannot hold six lines, and `firstErrLine` keeps only the first line of ssh's multi-line stderr (`sanitizeRemoteText` drops `\n` as a C0 control **with no separator**, so two sentences would otherwise fuse into one word).

Verified in dependency source rather than assumed: `PlaceHorizontal`'s `if gap <= 0 { return str }` and `Parsed`'s truncation at the first `-`/`+`.

## Test plan

Run per package — `dev.sh test` takes one package argument and silently drops the rest.

- `./scripts/dev.sh test internal/tui`, `./scripts/dev.sh test cmd/quil`, full `./scripts/dev.sh test`, `./scripts/dev.sh vet`, `promote-changelog.sh --validate` — all green.
- The offer, end to end: `TestUpgradePrompt_SeedBeforeInstallFuncStillOffers` (production ordering), `..._NoProvisionerHoldsTheAskRatherThanDroppingIt` (held, not dropped — the second resize must differ in size or the poll-echo guard swallows it before the drain), `..._SurvivesTheWhatsNewDialogAtLaunch` (both what's-new and the disclaimer, dismissed with no resize), `..._HostThatCameBackIsNotOffered`, `..._FirstInstallDoesNotThreatenPanes`.
- The pane area: `TestEmptyTabArea_LongRemoteNameStaysInsideTheFrame` (offline *and* live branches, ~4000 cells, with a non-vacuity guard so a frame that never rendered the message cannot pass), `..._LongRemoteDetailStaysInsideTheFrame`, `..._MultiLineStderrKeepsOnlyTheFirstLine`, `..._NeedsInstallSaysNotInstalled`, `..._NeedsInstallDoesNotSayItTwice`, `..._ParkedLinkDoesNotClaimToBeReconnecting`, `..._EmptyDetailAppendsNothing`, `..._ShortFrameDropsTheDetail`.
- The clamp: `TestClampVersionString` (real / pre-release / empty / exact-boundary / 9 MB hostile) and `..._CutsOnARuneBoundary`.
- `TestUpgradePrompt_NoInstallFuncRaisesNothing` still passes — a Model that will never have a provisioner still opens no dialog.

Not covered: a live TUI driven against a genuinely version-drifted host. The tests exercise `Update`/`View` with production ordering, which is where the decisions are made.

## Recorded, not fixed here

Three limits found while investigating, each with an entry under `techdebt/`:

- **A remote host stages updates it can never apply.** Staging happens on the daemon; applying happens on a *TUI launch*, and nothing launches a TUI on a remote box — `quil --stdio` returns before that call. The host observed here has 1.63.1 staged since Aug 21 and still runs 1.55.0 from Aug 14, while the client auto-updates weekly. The in-tool offer this PR repairs is the only path back, which is why it failing silently mattered as much as it did.
- **`truncateToWidth` sums independently-measured runes**, so it can return a string up to ~2x its budget — `lastCellsToWidth`, immediately below it in the same file, documents that exact hazard and solves it with grapheme segmentation. Helper-wide (~10 call sites); one of them now renders remote-controlled text, and the 8-cell margin is what absorbs it today.
- **`TestHandleMessage_KillProcessIsWiredUpAndSingleFlighted` observes a single-flight by polling an atomic its own worker can cycle before the first read.** Failed 2 of 4 CI runs on this branch, passes in isolation under `-race`, and `internal/daemon` is byte-identical to master. Not a memory race — a test-design TOCTOU, which is why `-race` has nothing to flag. A deterministic fix needs an `ipc.Conn` test seam that does not exist yet.
