### PR TITLE
fix(remote): reconnect the host after an accepted upgrade, and let any offline host be retried

### DIFF
--- a/changelog.d/fixed-remote-upgrade-completion.md
+++ b/changelog.d/fixed-remote-upgrade-completion.md
@@ -1,0 +1,15 @@
+---
+headline: Accepting a remote upgrade now reconnects the host
+---
+- **Accepting the remote-upgrade offer no longer leaves the host with no daemon.** The
+  push does its job — new binaries, and the remote daemon stopped so it can restart on
+  the new ones — but the message saying it had finished was filtered against a field only
+  the New Project dialog ever sets, so the offer's own completion matched nothing and was
+  discarded. Since the only thing that starts a remote daemon is a dial, and nothing
+  dialled, the host was left updated, daemonless, with its panes stopped and the project
+  still reading "upgrading…". It now hands the host back to the reconnect ladder, which
+  dials it, starts the daemon, and restores the panes from the snapshot the old daemon
+  wrote on its way out.
+
+- **A push that fails says so.** It reported nothing at all before, for the same reason;
+  the project now names the command that finishes the job by hand.

--- a/changelog.d/fixed-remote-upgrade-completion.md
+++ b/changelog.d/fixed-remote-upgrade-completion.md
@@ -13,3 +13,10 @@ headline: Accepting a remote upgrade now reconnects the host
 
 - **A push that fails says so.** It reported nothing at all before, for the same reason;
   the project now names the command that finishes the job by hand.
+
+- **Any offline host can be retried from inside the client — press `r`.** A host waiting
+  on an install or an upgrade never enters the reconnect ladder, deliberately: retrying a
+  missing binary or a version mismatch just re-fails until the far side changes. But
+  nothing noticed when the far side *did* change, so the only cure was relaunching. The
+  pane area now offers the key, and pressing it dials the host, starts its daemon, and
+  brings the panes back.

--- a/internal/tui/dialog.go
+++ b/internal/tui/dialog.go
@@ -1064,6 +1064,14 @@ func (m Model) handleConfirmKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 				m.installedDests = map[string]bool{}
 			}
 			m.installedDests[id] = true
+			// Claim the completion BEFORE starting the install, or
+			// destInstalledMsg arrives matching nothing and is dropped — which
+			// leaves the host with its daemon stopped by the push and no dial
+			// to start a new one. See Model.upgradingDests.
+			if m.upgradingDests == nil {
+				m.upgradingDests = map[string]bool{}
+			}
+			m.upgradingDests[id] = true
 			if p := m.projectForDest(id); p != nil && p.Offline != nil {
 				p.Offline.Detail = "upgrading — the daemon on that host restarts…"
 			}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -613,6 +613,19 @@ type Model struct {
 	// projectFormInstalling holds the host a remote install is running for,
 	// so its result is matched the same way a dial's is.
 	projectFormInstalling string
+	// upgradingDests records hosts an in-tool upgrade is provisioning RIGHT NOW,
+	// so destInstalledMsg can be routed to the offer's completion path.
+	//
+	// Not projectFormInstalling: that field belongs to the New Project dialog
+	// and is the filter destInstalledMsg was written around. The upgrade confirm
+	// never set it, so its completion message matched nothing and was dropped —
+	// which meant a successful push STOPPED the remote daemon (runRemoteSetup
+	// does) and then nothing ever dialled the host again, so nothing ran the
+	// `quil --stdio` that would have started a new one. Observed on a real host:
+	// binaries updated, daemon shut down, panes gone, and the project stuck on
+	// "upgrading…" for an hour and a half.
+	upgradingDests map[string]bool
+
 	// installedDests records hosts this session has already provisioned, so a
 	// dial that still reports the binary missing afterwards reports instead of
 	// installing again.
@@ -2152,6 +2165,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tea.Batch(attach, browse)
 
 	case destInstalledMsg:
+		// The in-tool upgrade offer's own completion, checked FIRST because it
+		// has nothing to do with the New Project dialog whose field the filter
+		// below reads. Without this arm the message matched nothing and was
+		// discarded, and since runRemoteSetup stops the remote daemon as part
+		// of the push, "discarded" meant the host was left with no daemon and
+		// no dial to start one.
+		if m.upgradingDests[msg.dest] {
+			delete(m.upgradingDests, msg.dest)
+			return m.finishDestUpgrade(msg)
+		}
 		if msg.dest != m.projectFormInstalling {
 			return m, nil // the user moved on, same as a stale dial
 		}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1168,6 +1168,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.resumeReconnect()
 		}
 	}
+	// The same key for a destination with NO ladder running. The arm above
+	// covers a ladder that parked itself; this covers the states that never
+	// started one — needsInstall, needsUpgrade, and a host whose accepted
+	// upgrade left it with a stopped daemon and nothing to dial it. Without
+	// this the only way out of any of them is relaunching the client, which is
+	// a poor answer for a tool whose whole point is that sessions survive.
+	if p := m.cur(); p != nil && p.Offline != nil && p.Dest != "" && !m.linkOf(p.Dest).active {
+		if key, ok := msg.(tea.KeyPressMsg); ok && kbMatches(key.String(), reconnectResumeKey) {
+			return m.retryOfflineDest(p.Dest)
+		}
+	}
 	// A dead link drops input rather than queueing it. Placed ahead of the type
 	// switch so input decisions are made in one place instead of in a branch
 	// nobody updated.

--- a/internal/tui/offline.go
+++ b/internal/tui/offline.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"log"
 	"strings"
 	"time"
 
@@ -148,6 +149,47 @@ func (m *Model) promptNextUpgrade() {
 	m.confirmName = next.dest
 	m.confirmDetail = next.detail
 	m.confirmOfflineKind = next.kind
+}
+
+// finishDestUpgrade closes out an upgrade the user accepted from the offer.
+//
+// Success does NOT mean "attached". runRemoteSetup pushes the archive and STOPS
+// the remote daemon; what starts a new one is the next dial, because that is
+// what runs `quil --stdio` over there. So the host is handed back to the
+// reconnect ladder rather than left to a bespoke re-dial: the ladder already
+// owns backoff (the daemon needs a moment to come up), the banner, the parked
+// state, and adoption on success. dialDest is deliberately not used — its
+// destDialedMsg is filtered by projectFormDialing, the New Project dialog's
+// field, which is the same shape of bug this function exists to fix.
+//
+// Reclassifying to offlineRetrying is what makes the ladder eligible:
+// offlineNeedsUpgrade is deliberately not laddered, since retrying a version
+// mismatch re-fails forever. Once the binary is replaced that reasoning no
+// longer applies, and the state has to move with it.
+func (m Model) finishDestUpgrade(msg destInstalledMsg) (tea.Model, tea.Cmd) {
+	p := m.projectForDest(msg.dest)
+	if p == nil || p.Offline == nil {
+		// Disconnected or already back while the push ran. Nothing to report
+		// against, and nothing to reconnect.
+		return m, nil
+	}
+	if msg.err != nil {
+		// installedDests stays armed: a push that failed once fails the same
+		// way on a retry it did not ask for, and this dialog opens by itself.
+		// The command is named instead, which is the affordance the pane area
+		// already carries for every other unrepairable offline state.
+		p.Offline.Detail = "upgrade failed — run: quil remote setup " + msg.dest
+		log.Printf("remote upgrade %s: %v", msg.dest, msg.err)
+		return m, nil
+	}
+	p.Offline.Kind = offlineRetrying
+	p.Offline.Detail = "upgraded — reconnecting…"
+	// The ladder refuses a destination it has already woken, and this one was
+	// woken at launch. Clearing the mark is what lets the post-upgrade dial
+	// happen at all.
+	delete(m.offlineWoken, msg.dest)
+	dest := msg.dest
+	return m, func() tea.Msg { return offlineDestMsg{dest: dest} }
 }
 
 // SeedOfflineDest installs (or replaces) the stand-in rows for one destination.

--- a/internal/tui/project.go
+++ b/internal/tui/project.go
@@ -251,9 +251,19 @@ func (m Model) renderEmptyTabArea(w, h int) string {
 // not active.
 func (m Model) offlineTabAreaMsg(p *ProjectModel, w, h int) string {
 	lines := []string{sanitizeRemoteText(p.displayName()), ""}
+	// Everything appended after the reason is OPTIONAL and goes on in priority
+	// order while the frame still has rows for it: the way out first, the
+	// diagnostic second. PlaceVertical has the same no-clip escape hatch as its
+	// horizontal sibling, so a block taller than h pushes the status bar off
+	// rather than being trimmed — the reason has to be the part that always
+	// survives, and the hint has to outrank the detail because one is actionable
+	// and the other is only informative.
+	fits := func(n int) bool { return h >= len(lines)+n }
 	switch p.Offline.Kind {
 	case offlineNeedsUpgrade:
-		lines = append(lines, "That host runs a different version of Quil,", "so this client will not attach to it.")
+		lines = append(lines,
+			"That host runs a different version of Quil,",
+			"so this client will not attach to it.")
 	case offlineNeedsInstall:
 		lines = append(lines, "Quil is not installed on that host.")
 	case offlineRetrying:
@@ -273,12 +283,19 @@ func (m Model) offlineTabAreaMsg(p *ProjectModel, w, h int) string {
 	// both prints one sentence twice — once capitalised, once behind a "dial
 	// <host>:" prefix. The sentinel is the single source; this is the seam that
 	// keeps the two from drifting apart.
+	// The two kinds that never enter the ladder have no other way back, so the
+	// key that starts one is the only actionable thing on this screen.
+	if p.Offline.Kind == offlineNeedsUpgrade || p.Offline.Kind == offlineNeedsInstall {
+		if fits(2) {
+			lines = append(lines, "", "Press "+reconnectResumeKey+" to try again.")
+		}
+	}
 	detail := sanitizeRemoteText(firstErrLine(p.Offline.Detail))
 	if p.Offline.Kind == offlineNeedsInstall &&
 		strings.Contains(strings.ToLower(detail), strings.ToLower(ErrRemoteQuilMissing.Error())) {
 		detail = ""
 	}
-	if detail != "" && h >= len(lines)+2 {
+	if detail != "" && fits(2) {
 		lines = append(lines, "", detail)
 	}
 	for i, line := range lines {

--- a/internal/tui/reconnect.go
+++ b/internal/tui/reconnect.go
@@ -482,6 +482,42 @@ func (m Model) resumeReconnect() (tea.Model, tea.Cmd) {
 	return m.scheduleRedial(dest)
 }
 
+// retryOfflineDest is the way back for a destination no ladder is running for.
+//
+// The three offline kinds split into "waiting" and "acting", and only the
+// waiting one retries itself. needsInstall and needsUpgrade are deliberately
+// excluded from the ladder — retrying a missing binary or a version mismatch
+// re-fails until someone changes the far side — which is correct right up to
+// the moment the far side DOES change, and then there is nothing to notice it.
+// A host whose upgrade was accepted but whose completion never arrived sits in
+// exactly that hole: its daemon was stopped by the push, and the only thing
+// that starts a new one is a dial nothing was going to make.
+//
+// Manual on purpose, and cheap because it is: the user pressing a key IS the
+// new information the ladder cannot derive. That is also why the once-per-host
+// install guard is cleared here — it exists to break an automatic
+// install/retry/same-error loop, and an explicit keypress is not that loop. If
+// the far side really is still mismatched, the redial arm reclassifies and
+// re-offers the upgrade, which is the honest outcome rather than a silent
+// no-op.
+func (m Model) retryOfflineDest(dest string) (tea.Model, tea.Cmd) {
+	if dest == "" || !m.canReconnect(dest) {
+		return m, nil
+	}
+	p := m.projectForDest(dest)
+	if p == nil || p.Offline == nil {
+		return m, nil
+	}
+	log.Printf("remote: user retry for offline destination %s (kind=%v)", m.linkHost(dest), p.Offline.Kind)
+	p.Offline.Kind = offlineRetrying
+	p.Offline.Detail = "retrying…"
+	delete(m.offlineWoken, dest)
+	delete(m.installedDests, dest)
+	ls := m.linkFor(dest)
+	ls.parked, ls.attempt, ls.lastErr = false, 0, nil
+	return m.beginReconnect(dest, errors.New("retry requested"))
+}
+
 // isFreezeEscape reports whether a key should end a frozen session.
 func isFreezeEscape(key string, configuredQuit []string) bool {
 	for _, q := range configuredQuit {

--- a/internal/tui/sidebar_offline_test.go
+++ b/internal/tui/sidebar_offline_test.go
@@ -214,13 +214,14 @@ func TestEmptyTabArea_EmptyDetailAppendsNothing(t *testing.T) {
 		Offline: &OfflineState{Kind: offlineNeedsUpgrade},
 	}, 100, 30)
 
-	if got := strings.Count(without, "\n"); got != 3 {
-		t.Errorf("an empty detail produced %d newlines, want 3 (a 4-line block):\n%q", got, without)
+	// head, blank, two reason lines, blank, retry hint = 6 lines / 5 newlines.
+	if got := strings.Count(without, "\n"); got != 5 {
+		t.Errorf("an empty detail produced %d newlines, want 5 (a 6-line block):\n%q", got, without)
 	}
 	if strings.HasSuffix(without, "\n") {
 		t.Errorf("an empty detail left a trailing blank line: %q", without)
 	}
-	if strings.Count(withDetail, "\n") != 5 {
+	if strings.Count(withDetail, "\n") != 7 {
 		t.Errorf("a detail should add exactly two lines: %q", withDetail)
 	}
 }
@@ -233,11 +234,30 @@ func TestEmptyTabArea_ShortFrameDropsTheDetail(t *testing.T) {
 		Name: "api", Dest: "gpu01",
 		Offline: &OfflineState{Kind: offlineNeedsUpgrade, Detail: "gpu01 runs 1.0.0, this client runs 2.0.0"},
 	}
-	if got := strings.Count(Model{}.offlineTabAreaMsg(p, 100, 5), "\n"); got != 3 {
-		t.Errorf("a 5-row frame got %d newlines, want 3 — the detail must be dropped", got)
-	}
-	if got := strings.Count(Model{}.offlineTabAreaMsg(p, 100, 6), "\n"); got != 5 {
-		t.Errorf("a 6-row frame got %d newlines, want 5 — the detail fits", got)
+	// The optional tail goes on by priority while rows remain: the retry hint
+	// (the way OUT) before the detail (merely informative). The reason itself
+	// always survives, because PlaceVertical does not clip and an overflowing
+	// block pushes the status bar off screen.
+	for _, tc := range []struct {
+		h        int
+		newlines int
+		what     string
+	}{
+		{4, 3, "reason only — neither hint nor detail fits"},
+		{5, 3, "still no room for the hint's blank line plus the hint"},
+		{6, 5, "hint fits, detail does not"},
+		{7, 5, "still no room for the detail"},
+		{8, 7, "both fit"},
+		{30, 7, "everything fits"},
+	} {
+		if got := strings.Count(Model{}.offlineTabAreaMsg(p, 100, tc.h), "\n"); got != tc.newlines {
+			t.Errorf("h=%d got %d newlines, want %d (%s):\n%q",
+				tc.h, got, tc.newlines, tc.what, Model{}.offlineTabAreaMsg(p, 100, tc.h))
+		}
+		// Whatever was kept must fit the frame it was measured against.
+		if got := strings.Count(Model{}.offlineTabAreaMsg(p, 100, tc.h), "\n") + 1; got > tc.h {
+			t.Errorf("h=%d produced %d rows — PlaceVertical will not clip them", tc.h, got)
+		}
 	}
 }
 

--- a/internal/tui/upgrade_prompt_test.go
+++ b/internal/tui/upgrade_prompt_test.go
@@ -519,3 +519,103 @@ func TestUpgradePrompt_FormInstallPathStillHandled(t *testing.T) {
 		t.Errorf("the form install path no longer retries the dial: %q", got.projectFormDialing)
 	}
 }
+
+// IN-SESSION RECOVERY. needsInstall and needsUpgrade never enter the ladder —
+// correct, since retrying a missing binary or a version mismatch re-fails until
+// the far side changes — but that left NO way back inside a running client once
+// the far side did change. Relaunching was the only cure, which is a poor answer
+// from a tool whose whole point is that sessions survive.
+//
+// The concrete case that forced this: an accepted upgrade whose completion was
+// lost left the host with its daemon stopped by the push and nothing to dial it.
+func TestOfflineDest_RetryKeyRecoversAHostWithNoLadder(t *testing.T) {
+	for _, kind := range []OfflineKind{OfflineNeedsUpgrade, OfflineNeedsInstall} {
+		m, _ := upgradeModel(t)
+		m.SetRedialFunc("artyom@host", func(Client) (Client, error) { return nil, nil })
+		m.SeedOfflineDest("artyom@host", "artyom@host", kind, "stuck", nil)
+		// The offer is not what is under test here.
+		m.upgradeQueue = nil
+		m.installedDests = map[string]bool{"artyom@host": true}
+		// SeedOfflineDest APPENDS, so index 0 is still the fixture's own live
+		// project. The retry key is scoped to what the user is looking at, so
+		// the offline row has to be the active one for it to apply at all.
+		focusProject(t, &m, "artyom@host")
+
+		if m.linkOf("artyom@host").active {
+			t.Fatalf("kind=%v: fixture already has a ladder running", kind)
+		}
+
+		updated, cmd := m.Update(tea.KeyPressMsg{Code: 'r', Text: reconnectResumeKey})
+		got := updated.(Model)
+
+		p := got.projectForDest("artyom@host")
+		if p == nil || p.Offline == nil {
+			t.Fatalf("kind=%v: the host lost its offline row", kind)
+		}
+		if !p.Offline.Kind.laddered() {
+			t.Errorf("kind=%v: still %v after a retry — nothing will dial it", kind, p.Offline.Kind)
+		}
+		if !got.linkOf("artyom@host").active {
+			t.Errorf("kind=%v: no ladder started", kind)
+		}
+		if got.installedDests["artyom@host"] {
+			t.Errorf("kind=%v: the once-per-host guard survived an explicit retry, so a "+
+				"still-mismatched host could never be re-offered", kind)
+		}
+		if cmd == nil {
+			t.Errorf("kind=%v: retry produced no command", kind)
+		}
+	}
+}
+
+// The affordance has to be on screen, or it does not exist.
+func TestOfflineDest_PaneAreaAdvertisesTheRetryKey(t *testing.T) {
+	for _, kind := range []OfflineKind{OfflineNeedsUpgrade, OfflineNeedsInstall} {
+		m := Model{
+			width: 100, height: 30,
+			projects: []*ProjectModel{{
+				ID: "proj-1", Name: "api", Dest: "gpu01",
+				Offline: &OfflineState{Kind: kind, Detail: "stuck"},
+			}},
+			notifications: NewNotificationCenter(30, 50),
+		}
+		out := stripANSI(m.View().Content)
+		if !strings.Contains(out, "to try again") {
+			t.Errorf("kind=%v: the pane area offers no way back:\n%s", kind, out)
+		}
+	}
+}
+
+// A host with no dialer must not pretend to retry — beginReconnect would reach
+// redialCmd with a nil RedialFunc.
+func TestOfflineDest_RetryKeyIsARefusalWithNoDialer(t *testing.T) {
+	m, _ := upgradeModel(t)
+	m.SeedOfflineDest("artyom@host", "artyom@host", OfflineNeedsUpgrade, "stuck", nil)
+	m.upgradeQueue = nil
+	focusProject(t, &m, "artyom@host")
+
+	updated, _ := m.Update(tea.KeyPressMsg{Code: 'r', Text: reconnectResumeKey})
+	got := updated.(Model)
+	if got.linkOf("artyom@host").active {
+		t.Error("a destination with no dialer started a ladder anyway")
+	}
+	if p := got.projectForDest("artyom@host"); p != nil && p.Offline != nil && p.Offline.Kind.laddered() {
+		t.Error("a destination with no dialer was reclassified as laddered, so it now looks retryable and is not")
+	}
+}
+
+// focusProject makes the row for dest the ACTIVE project. SeedOfflineDest
+// appends, so a fixture that seeds one still has its own live project at index
+// 0 — and a key scoped to what the user is looking at would then be evaluated
+// against the wrong row (and, in these fixtures, forwarded to a pane whose
+// client is nil).
+func focusProject(t *testing.T, m *Model, dest string) {
+	t.Helper()
+	for i, p := range m.projects {
+		if p.Dest == dest {
+			m.activeProject = i
+			return
+		}
+	}
+	t.Fatalf("no project for dest %q in %d rows", dest, len(m.projects))
+}

--- a/internal/tui/upgrade_prompt_test.go
+++ b/internal/tui/upgrade_prompt_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -414,5 +415,107 @@ func TestUpgradePrompt_FirstInstallDoesNotThreatenPanes(t *testing.T) {
 	up := updated2.(Model).renderConfirmDialog()
 	if !strings.Contains(up, "Upgrade quil on") || !strings.Contains(up, "RESTARTS") {
 		t.Errorf("the upgrade confirm lost its own warning:\n%s", up)
+	}
+}
+
+// ACCEPTING THE OFFER HAS TO END SOMEWHERE. destInstalledMsg was filtered by
+// projectFormInstalling — the New Project dialog's field, which the upgrade
+// confirm never set — so the completion of an accepted upgrade matched nothing
+// and was dropped.
+//
+// That is not a cosmetic stall. runRemoteSetup STOPS the remote daemon as part
+// of the push, and the only thing that starts a new one is a dial, because a
+// dial is what runs `quil --stdio` over there. Dropping the completion left a
+// host with updated binaries, no daemon, dead panes, and a pane area still
+// reading "upgrading…". Observed on a real host for an hour and a half.
+func TestUpgradePrompt_AcceptedUpgradeReconnectsTheHost(t *testing.T) {
+	m, installed := upgradeModel(t)
+	m.SetRedialFunc("artyom@host", func(Client) (Client, error) { return nil, nil })
+	m.SeedOfflineDest("artyom@host", "artyom@host", OfflineNeedsUpgrade, mismatchDetail, nil)
+
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 44})
+	m = updated.(Model)
+	if m.dialog != dialogConfirm {
+		t.Fatalf("fixture raised no offer: %v", m.dialog)
+	}
+
+	updated, cmd := m.Update(tea.KeyPressMsg{Code: 'y', Text: "y"})
+	m = updated.(Model)
+	if cmd == nil {
+		t.Fatal("accepting produced no command")
+	}
+	if !m.upgradingDests["artyom@host"] {
+		t.Fatal("accepting did not claim the completion — destInstalledMsg will match nothing")
+	}
+	runCmd(cmd)
+	if len(*installed) != 1 {
+		t.Fatalf("install ran for %v, want one host", *installed)
+	}
+
+	// The push finished. This is the message that used to be discarded.
+	updated, cmd = m.Update(destInstalledMsg{dest: "artyom@host"})
+	got := updated.(Model)
+
+	p := got.projectForDest("artyom@host")
+	if p == nil || p.Offline == nil {
+		t.Fatal("the host lost its offline row")
+	}
+	if !p.Offline.Kind.laddered() {
+		t.Errorf("kind = %v after a successful upgrade; a non-laddered kind means "+
+			"nothing ever dials the host, so nothing starts the daemon the push stopped", p.Offline.Kind)
+	}
+	if got.upgradingDests["artyom@host"] {
+		t.Error("the completion claim was not released")
+	}
+	if cmd == nil {
+		t.Fatal("a successful upgrade produced no reconnect command")
+	}
+	if _, ok := cmd().(offlineDestMsg); !ok {
+		t.Errorf("a successful upgrade did not wake the reconnect ladder; got %T", cmd())
+	}
+}
+
+// A failed push must say so and name the way out, not sit on "upgrading…".
+func TestUpgradePrompt_FailedUpgradeReportsInsteadOfHanging(t *testing.T) {
+	m, _ := upgradeModel(t)
+	m.SeedOfflineDest("artyom@host", "artyom@host", OfflineNeedsUpgrade, mismatchDetail, nil)
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 44})
+	m = updated.(Model)
+	updated, cmd := m.Update(tea.KeyPressMsg{Code: 'y', Text: "y"})
+	m = updated.(Model)
+	runCmd(cmd)
+
+	updated, _ = m.Update(destInstalledMsg{dest: "artyom@host", err: errors.New("scp: permission denied")})
+	got := updated.(Model)
+
+	p := got.projectForDest("artyom@host")
+	if p == nil || p.Offline == nil {
+		t.Fatal("the host lost its offline row")
+	}
+	if strings.Contains(p.Offline.Detail, "upgrading") {
+		t.Errorf("a failed upgrade still claims to be upgrading: %q", p.Offline.Detail)
+	}
+	if !strings.Contains(p.Offline.Detail, "quil remote setup") {
+		t.Errorf("a failed upgrade names no way out: %q", p.Offline.Detail)
+	}
+	if p.Offline.Kind.laddered() {
+		t.Error("a failed upgrade entered the reconnect ladder; the binary is still wrong")
+	}
+}
+
+// The New Project dialog's own install path must keep working — it is the one
+// destInstalledMsg was originally written for, and it shares the message.
+func TestUpgradePrompt_FormInstallPathStillHandled(t *testing.T) {
+	m, _ := upgradeModel(t)
+	m.projectFormInstalling = "artyom@new"
+	m.dialog = dialogProjectNew
+
+	updated, _ := m.Update(destInstalledMsg{dest: "artyom@new"})
+	got := updated.(Model)
+	if got.projectFormInstalling != "" {
+		t.Error("the form install path no longer clears its marker")
+	}
+	if got.projectFormDialing != "artyom@new" {
+		t.Errorf("the form install path no longer retries the dial: %q", got.projectFormDialing)
 	}
 }


### PR DESCRIPTION
## Summary

Accepting the in-tool upgrade offer pushed the archive, stopped the remote daemon — `runRemoteSetup` does, so it can come back on the new binary — and then **did nothing at all**. The host was left updated, daemonless, with its panes stopped and the project still reading "upgrading — the daemon on that host restarts…".

`destInstalledMsg` is filtered by `projectFormInstalling` (`model.go:2155`), which is assigned in exactly one place: the **New Project dialog** (`model.go:2133`). The upgrade confirm (`dialog.go:1053`) never set it, so the completion of an accepted upgrade matched nothing and returned early. Nothing re-dialled — and a dial is the only thing that runs `quil --stdio` over there, which is the only thing that starts a remote daemon.

The offer now claims its own completion through `upgradingDests`, checked **before** the form's filter, and `finishDestUpgrade` closes it out.

## Observed

A real host, upgraded from the offer at 14:24 UTC:

```
14:24:30  ipc recv: shutdown
14:24:30  daemon stopping, writing final snapshot...
14:24:30  pane pane-6b663d64: process exited with code -1
14:24:30  pane pane-f75b3e46: process exited with code -1
          (nothing further — 100 minutes and counting)
```

Binaries at `~/.local/bin` updated, `quild.pid` stale, `pgrep quild` empty. The push worked perfectly; only the completion was lost. `workspace.json` survived, so the panes were recoverable — but only by a dial that nothing was going to make.

## Why the reconnect ladder rather than a re-dial

Success hands the host to the ladder instead of calling `dialDest`:

- `dialDest`'s `destDialedMsg` is filtered by `projectFormDialing` — the New Project dialog's other field. Reusing it would reproduce the same bug one message later.
- The ladder already owns backoff (the daemon needs a moment to come up), the reconnect banner, the parked state, and adoption on success.

Eligibility means reclassifying to `offlineRetrying`, which is correct rather than convenient: `needsUpgrade` is excluded from the ladder because retrying a version mismatch re-fails forever, and **replacing the binary is exactly the event that stops being true**.

A failed push is reported instead of swallowed, naming `quil remote setup` as the way to finish by hand. `installedDests` stays armed there: a push that failed once fails the same way on a retry nobody asked for, and this dialog opens by itself.

## Scope

Only reachable since #186 made the offer fire at launch. Before that the confirm was effectively unreachable, so its accept path had never run in anger — the completion handler was written for the dialog that existed at the time and never extended when a second caller appeared.

## Test plan

- `./scripts/dev.sh test internal/tui`, full `./scripts/dev.sh test`, `./scripts/dev.sh vet` — all green.
- `TestUpgradePrompt_AcceptedUpgradeReconnectsTheHost` — accepts the offer, runs the install seam, delivers `destInstalledMsg`, and asserts the host is reclassified to a laddered kind and a `offlineDestMsg` is emitted. Fails on the first new assertion without the fix (`upgradingDests` never claimed).
- `TestUpgradePrompt_FailedUpgradeReportsInsteadOfHanging` — a failed push clears "upgrading…", names the command, and does **not** enter the ladder.
- `TestUpgradePrompt_FormInstallPathStillHandled` — the New Project dialog's own install still clears its marker and retries its dial; the two flows share the message and must not shadow each other.

Not covered: a live TUI against a real host. The observed failure above is what prompted the fix; the tests pin the message routing that lost it.

---

## Second commit: no state should need a relaunch to escape

The fix above handles the upgrade that completes. It does not help a client already sitting in the hole, and "relaunch quil" is a poor answer from a tool whose premise is that sessions survive.

`needsInstall` and `needsUpgrade` never enter the reconnect ladder — correct, since retrying a missing binary or a version mismatch re-fails until the far side changes. But nothing noticed when the far side *did* change, so the state was terminal for the life of the client.

`r`, the key that already resumes a parked ladder, now also starts one for an offline destination that has none, and the pane area advertises it. Manual on purpose and cheap because of it: the keypress **is** the new information the ladder cannot derive. The once-per-host install guard is cleared with it — that guard breaks an automatic install/retry/same-error loop, and an explicit keypress is not that loop. If the host really is still mismatched, the redial arm reclassifies and re-offers the upgrade rather than failing silently.

The offline pane area's optional tail is now appended by priority while the frame has rows for it — the way out before the diagnostic — because the block grew and `PlaceVertical` does not clip. The reason is the part that always survives.

Added: `TestOfflineDest_RetryKeyRecoversAHostWithNoLadder` (both kinds, through `Update`), `..._PaneAreaAdvertisesTheRetryKey`, `..._RetryKeyIsARefusalWithNoDialer`, and a table over frame heights 4–30 asserting the block never exceeds the rows it was measured against.

One fixture note worth keeping: `SeedOfflineDest` **appends**, so a test that seeds an offline row still has the fixture's own live project at index 0. A key scoped to the active project is then evaluated against the wrong row — and in these fixtures falls through to pane input on a nil client, which panics. `focusProject` makes the intent explicit.
