### PR TITLE
fix(site): consolidate duplicate URLs and repair SEO metadata

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -66,6 +66,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Full history: astro.config.mjs derives each page's sitemap
+          # <lastmod> from `git log -1 --format=%cI -- <file>`. The default
+          # depth-1 clone has exactly one commit, so that command returns
+          # the SAME date for every file — the deploy time — and every URL
+          # in the sitemap claims to have changed on every deploy.
+          #
+          # It fails silently and looks correct: the sitemap validates, the
+          # dates are real, and only comparing two of them reveals they are
+          # identical. Measured 2026-08-23: all 14 URLs carried
+          # lastmod 2026-08-23T13:32:28Z.
+          fetch-depth: 0
 
       - name: Set up Node
         uses: actions/setup-node@v4

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -66,10 +66,16 @@ function gitLastMod(file) {
 }
 
 /**
- * Route → source file map. Astro's sitemap hook sees normalised URLs
- * without trailing slashes, which matches our trailingSlash: "never"
- * config. Every route we publish needs an entry here; a missing
- * entry falls back to the build time (harmless but less accurate).
+ * Route → source file map. The keys are SLASHLESS because that is the
+ * form Astro's sitemap hook normalises URLs to before calling
+ * `serialize` — it is NOT a statement about the site's config, which is
+ * `trailingSlash: "always"` (see below). This comment used to claim
+ * `trailingSlash: "never"`, which is the opposite of the truth and
+ * exactly the sort of stale note that gets trusted during a debugging
+ * session.
+ *
+ * Every route we publish needs an entry here; a missing entry falls
+ * back to the build time (harmless but less accurate).
  *
  * @type {Record<string, string>}
  */

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@astrojs/check": "^0.9.4",
+        "@astrojs/rss": "^4.0.19",
         "@astrojs/sitemap": "^3.2.1",
         "@tailwindcss/vite": "^4.2.0",
         "astro": "^5.0.0",
@@ -126,6 +127,17 @@
       },
       "engines": {
         "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+      }
+    },
+    "node_modules/@astrojs/rss": {
+      "version": "4.0.19",
+      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-4.0.19.tgz",
+      "integrity": "sha512-e+z5wYeYtffQdHQO8c2tkSd2JEBdAuRXJV4ZEU5IxkYeE6e39woDd7nw1PH1Kk2tEYNCYuKdylnnbhGmt61awA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-parser": "^5.5.7",
+        "piccolore": "^0.1.3",
+        "zod": "^4.3.6"
       }
     },
     "node_modules/@astrojs/sitemap": {
@@ -278,27 +290,6 @@
       "resolved": "https://registry.npmjs.org/@emmetio/stream-reader-utils/-/stream-reader-utils-0.1.0.tgz",
       "integrity": "sha512-ZsZ2I9Vzso3Ho/pjZFsmmZ++FWeEd/txqybHTm4OgaZzdS8V9V/YYWQwg5TC38Z7uLWUV1vavpLLbjJtKubR1A==",
       "license": "MIT"
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.0",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.0",
@@ -1255,6 +1246,18 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-3.0.0.tgz",
+      "integrity": "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@oslojs/encoding": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
@@ -1266,7 +1269,6 @@
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.123.0.tgz",
       "integrity": "sha512-YtECP/y8Mj1lSHiUWGSRzy/C6teUKlS87dEfuVKT09LgQbUsBW1rNg+MiJ4buGu3yuADV60gbIvo9/HplA56Ew==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
@@ -1283,7 +1285,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1300,7 +1301,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1317,7 +1317,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1334,7 +1333,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1351,7 +1349,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1368,7 +1365,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1385,7 +1381,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1402,7 +1397,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1419,7 +1413,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1436,7 +1429,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1453,7 +1445,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1470,7 +1461,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1484,7 +1474,6 @@
       ],
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/core": "1.9.1",
         "@emnapi/runtime": "1.9.1",
@@ -1500,7 +1489,6 @@
       "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1517,7 +1505,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1534,7 +1521,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1543,8 +1529,7 @@
       "version": "1.0.0-rc.13",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.13.tgz",
       "integrity": "sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@rollup/pluginutils": {
       "version": "5.3.0",
@@ -2418,6 +2403,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -2541,6 +2527,18 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/anynum": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/arg": {
       "version": "5.0.2",
@@ -3195,6 +3193,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -3861,6 +3860,7 @@
       "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -3959,6 +3959,45 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.1.tgz",
+      "integrity": "sha512-pIM/1n3ntFXKYrUZwW7QCK0gAW7XY+wzj1YMIV3tLDvPj/V+zTGJK5e3/4WJfwj0qWw2ElNXiTixda/R+3YSug==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.6.2",
+        "xml-naming": "^0.3.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.11.0.tgz",
+      "integrity": "sha512-9IGxMqvqLOnqP+Egi1nqDHKv5k8aZ7r9n558enxcucmyVGEBNPAU+MOg/8jPIS7rO7sSq4gFm1/nHtiaubMruw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^3.0.0",
+        "fast-xml-builder": "^1.2.0",
+        "is-unsafe": "^2.0.0",
+        "path-expression-matcher": "^1.6.2",
+        "strnum": "^2.4.2",
+        "xml-naming": "^0.3.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -4342,6 +4381,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-unsafe": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.2.tgz",
+      "integrity": "sha512-HgbIHPBH0KHHCcjLfGsCvhtPTVxjaAZlXjwdz7/GQC40SjSe4sfQsar8J5VFo8JOSbarkpV0OLG95bbaNd9aAQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/is-wsl": {
       "version": "3.1.1",
@@ -5705,6 +5756,21 @@
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
       "license": "MIT"
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+      "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/piccolore": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
@@ -5762,6 +5828,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -6088,7 +6155,6 @@
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.13.tgz",
       "integrity": "sha512-bvVj8YJmf0rq4pSFmH7laLa6pYrhghv3PRzrCdRAr23g66zOKVJ4wkvFtgohtPLWmthgg8/rkaqRHrpUEh0Zbw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.123.0",
         "@rolldown/pluginutils": "1.0.0-rc.13"
@@ -6122,6 +6188,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
       "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -6351,6 +6418,21 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/strnum": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.2.tgz",
+      "integrity": "sha512-rDG3Ah4TV0k1hWvLSzkZtMmLN9+eS+h3knq4MP6A42Y3Yh5qGNnOUs1jJkoSr8FG5dsL28c7KgkIBzSEykqtuw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.1"
+      }
+    },
     "node_modules/svgo": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.1.tgz",
@@ -6496,6 +6578,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7241,6 +7324,21 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/xml-naming": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+      "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/xxhash-wasm": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
@@ -7423,6 +7521,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/site/package.json
+++ b/site/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "astro dev",
-    "build": "node scripts/check-header-stacking.mjs && astro check && astro build",
+    "build": "node scripts/check-header-stacking.mjs && node scripts/check-trailing-slash.mjs && astro check && astro build",
     "preview": "astro preview --host 0.0.0.0 --port 4321",
     "astro": "astro",
     "og:svg": "node scripts/build-og.mjs",
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@astrojs/check": "^0.9.4",
+    "@astrojs/rss": "^4.0.19",
     "@astrojs/sitemap": "^3.2.1",
     "@tailwindcss/vite": "^4.2.0",
     "astro": "^5.0.0",

--- a/site/scripts/check-trailing-slash.mjs
+++ b/site/scripts/check-trailing-slash.mjs
@@ -1,0 +1,173 @@
+/**
+ * Guard: every internal href must carry its trailing slash.
+ *
+ * The site is built with `trailingSlash: "always"` and
+ * `build.format: "directory"`, `canonical()` appends the slash, the
+ * sitemap emits slashed URLs, and GitHub Pages 301s the slashless form
+ * to the slashed one. All of that agrees. The internal link graph did
+ * not: every nav link, footer link and CTA named the slashless URL.
+ *
+ * That is not cosmetic, because a redirect is a hint and a link is a
+ * vote. On a 14-page site the ~19 sitewide nav links are the
+ * overwhelming majority of the canonicalization signal, and Google
+ * weighs the whole graph against the declaration. Measured on
+ * quil.cc in August 2026, it split the difference:
+ *
+ *   /vs/herdr   indexed and served separately from /vs/herdr/
+ *   /blog       indexed and served separately from /blog/
+ *
+ * Both members of each pair ranked, for the same content, dividing the
+ * signals between two URLs — while six OTHER URLs landed in Search
+ * Console's "Page with redirect" bucket, which is the same phenomenon
+ * with the declaration winning instead. Search Console reports that
+ * bucket as `source: Website`, i.e. "your own markup keeps emitting
+ * these", which is exactly what an unguarded href does on every build.
+ *
+ * Greping for `href="/install"` would not stay green on its own: the
+ * hrefs live in four different syntactic forms across the codebase
+ * (attribute, expression, template literal, and object literal inside a
+ * nav data array), and the Footer's are the object-literal kind, which
+ * an attribute-only sweep silently reports as clean.
+ *
+ * Run: node scripts/check-trailing-slash.mjs
+ */
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve, relative, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const SRC = resolve(here, "..", "src");
+
+/** Files whose hrefs reach the rendered page. */
+const EXT = /\.(astro|ts|tsx|js|mjs|md)$/;
+
+/**
+ * Paths that are files rather than pages, and so never take a slash.
+ * Matched on the last segment having an extension — /favicon.svg,
+ * /og/home.png, /sitemap-index.xml, /site.webmanifest.
+ *
+ * The bound is 12 rather than a tidy 4 because "webmanifest" is eleven
+ * characters; a shorter cap reports /site.webmanifest as a page that
+ * forgot its slash, and "add a slash to the manifest link" is a fix
+ * that breaks the manifest.
+ */
+const LOOKS_LIKE_FILE = /\.[a-z0-9]{2,12}$/i;
+
+function walk(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...walk(full));
+    else if (EXT.test(entry)) out.push(full);
+  }
+  return out;
+}
+
+/**
+ * Extract every internal link target from a source file.
+ *
+ * Four forms, because the codebase uses all four and a sweep that
+ * models fewer than all four reports a clean run over a real bug:
+ *
+ *   href="/install"                 attribute
+ *   href={"/install"}               expression
+ *   href={`/vs/${slug}`}            template literal
+ *   { href: "/install", text: … }   object literal in a data array
+ *
+ * Template literals are normalised by replacing every `${…}` with a
+ * placeholder segment, so `/vs/${slug}` is judged on its tail — which
+ * is where the slash goes — rather than being skipped for being
+ * dynamic. A dynamic tail (`href={`${base}`}`) is unreadable here and
+ * is reported as unmodelled rather than passed.
+ */
+function extract(src) {
+  const hits = [];
+  const push = (raw, index) => hits.push({ raw, index });
+
+  // href="…" | href='…' | href={"…"} | href={'…'}
+  for (const m of src.matchAll(/href\s*=\s*\{?\s*["']([^"'`]*)["']\s*\}?/g)) {
+    push(m[1], m.index);
+  }
+  // href={`…`}
+  for (const m of src.matchAll(/href\s*=\s*\{\s*`([^`]*)`\s*\}/g)) {
+    push(m[1], m.index);
+  }
+  // { href: "…" } — nav/footer data arrays
+  for (const m of src.matchAll(/\bhref\s*:\s*["']([^"'`]*)["']/g)) {
+    push(m[1], m.index);
+  }
+  // { href: `…` }
+  for (const m of src.matchAll(/\bhref\s*:\s*`([^`]*)`/g)) {
+    push(m[1], m.index);
+  }
+  return hits;
+}
+
+const failures = [];
+const unmodelled = [];
+
+for (const file of walk(SRC)) {
+  const src = readFileSync(file, "utf8");
+  const rel = relative(resolve(here, ".."), file).replace(/\\/g, "/");
+  const lineOf = (i) => src.slice(0, i).split("\n").length;
+
+  for (const { raw, index } of extract(src)) {
+    // Interpolation is only a problem when it lands at the very end,
+    // where the slash would be. Anywhere else it is just a path segment.
+    const endsDynamic = /\$\{[^}]*\}$/.test(raw);
+    const path = raw.replace(/\$\{[^}]*\}/g, "X");
+
+    // External, protocol-relative, anchors, mailto:, and expressions
+    // that are not literal paths at all.
+    if (!path.startsWith("/")) continue;
+    if (path.startsWith("//")) continue;
+
+    // Split off a fragment: /features#remote-daemon-ssh still needs the
+    // slash on the path part, and this is the form most likely to be
+    // missed by eye.
+    const [pathPart, fragment] = path.split("#");
+    if (pathPart === "") continue; // bare "#anchor"
+    if (pathPart === "/") continue; // home
+    if (LOOKS_LIKE_FILE.test(pathPart)) continue;
+
+    if (endsDynamic && !fragment) {
+      unmodelled.push(
+        `${rel}:${lineOf(index)}  href \`${raw}\` ends in an interpolation — ` +
+          `cannot tell whether the value carries its slash`,
+      );
+      continue;
+    }
+
+    if (!pathPart.endsWith("/")) {
+      const fixed = pathPart + "/" + (fragment ? "#" + fragment : "");
+      failures.push(
+        `${rel}:${lineOf(index)}  "${raw}" → should be "${fixed.replace(/X/g, "${…}")}"`,
+      );
+    }
+  }
+}
+
+// Abstentions print alongside the verdict rather than silently passing:
+// an href this cannot read is exactly where the next slashless link hides.
+if (unmodelled.length) {
+  console.warn("check-trailing-slash: cannot model these hrefs —\n");
+  for (const u of unmodelled) console.warn(`  ? ${u}`);
+  console.warn(
+    "\n  Verify by hand that the interpolated value ends in a slash.\n",
+  );
+}
+
+if (failures.length) {
+  console.error(
+    `check-trailing-slash: FAIL — ${failures.length} internal href(s) missing a trailing slash\n`,
+  );
+  for (const f of failures) console.error(`  - ${f}`);
+  console.error(
+    "\n  The site is trailingSlash: \"always\". A slashless internal href is a\n" +
+      "  vote for a URL that 301s, which splits ranking signals across two\n" +
+      "  URLs for the same page. Add the slash.\n",
+  );
+  process.exit(1);
+}
+
+console.log("check-trailing-slash: ok  (all internal hrefs carry a trailing slash)");

--- a/site/src/components/BaseHead.astro
+++ b/site/src/components/BaseHead.astro
@@ -15,20 +15,29 @@
 // Pages should import Page.astro which wraps this; they never touch
 // BaseHead directly.
 
-import { SITE, canonical, type Page } from "@/data/seo";
+import { SITE, canonical, absoluteURL, type Page } from "@/data/seo";
 
 type Props = Page;
-const { title, description, path, ogImage, keywords } = Astro.props;
+const {
+  title,
+  description,
+  path,
+  ogImage,
+  keywords,
+  seoTitle,
+  brandSuffix = true,
+  ogType = "website",
+} = Astro.props;
 
-const fullTitle = `${title} · ${SITE.name}`;
+// `seoTitle` overrides the editorial title for the SERP only; `brandSuffix`
+// is separate because the two decisions are independent — a post wants a
+// rewritten stem AND the suffix, a /vs page wants its own stem WITHOUT one.
+const titleStem = seoTitle ?? title;
+const fullTitle = brandSuffix ? `${titleStem} · ${SITE.name}` : titleStem;
 const canonicalURL = canonical(path);
-// ogImage may be a site-relative path ("/og/home.png") or an absolute
-// URL (a CDN-hosted card). Only prefix the origin for relative paths,
-// otherwise an absolute URL gets double-prefixed (https://quil.cchttps://…).
-const ogImageURL =
-  ogImage && /^https?:\/\//.test(ogImage)
-    ? ogImage
-    : SITE.url + (ogImage ?? SITE.defaultOgImage);
+// Relative-or-absolute handling lives in absoluteURL (see seo.ts) so the
+// JSON-LD path in the blog template resolves images the same way.
+const ogImageURL = absoluteURL(ogImage ?? SITE.defaultOgImage);
 ---
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -78,7 +87,7 @@ const ogImageURL =
 <link rel="canonical" href={canonicalURL} />
 
 <!-- Open Graph -->
-<meta property="og:type" content="website" />
+<meta property="og:type" content={ogType} />
 <meta property="og:site_name" content={SITE.name} />
 <meta property="og:title" content={fullTitle} />
 <meta property="og:description" content={description} />
@@ -103,8 +112,14 @@ const ogImageURL =
 <meta name="application-name" content="Quil" />
 <meta name="format-detection" content="telephone=no" />
 
-<!-- Sitemap discovery -->
+<!-- Sitemap + feed discovery -->
 <link rel="sitemap" href="/sitemap-index.xml" />
+<link
+  rel="alternate"
+  type="application/rss+xml"
+  title={`${SITE.name} — blog`}
+  href="/rss.xml"
+/>
 <meta name="robots" content="index, follow" />
 
 <!-- Generator tag (informational, not SEO-critical) -->

--- a/site/src/components/ComparePage.astro
+++ b/site/src/components/ComparePage.astro
@@ -33,8 +33,12 @@ const article = /^[aeiou]/i.test(info.name) ? "an" : "a";
 
 const seo = {
   title: `Quil vs ${info.name}`,
+  // The default stem already contains the brand, so the suffix would say
+  // it twice and spend ~7 of the ~60 usable characters doing it.
+  seoTitle: info.seoTitle,
+  brandSuffix: false,
   description: `Looking for ${article} ${info.name} alternative? Quil is a reboot-proof terminal multiplexer with AI session resume, typed panes, and an MCP server — see how it compares to ${info.name}.`,
-  path: `/vs/${slug}`,
+  path: `/vs/${slug}/`,
   ogImage: `/og/vs-${slug}.png`,
   keywords: [
     `quil vs ${slug}`,
@@ -48,8 +52,8 @@ const seo = {
 const schemas = [
   breadcrumbSchema([
     { name: "Quil",   path: "/" },
-    { name: "Compare", path: `/vs/${slug}` },
-    { name: info.name, path: `/vs/${slug}` },
+    { name: "Compare", path: `/vs/${slug}/` },
+    { name: info.name, path: `/vs/${slug}/` },
   ]),
   faqSchema(info.faq),
 ];
@@ -190,7 +194,7 @@ function cellGlyph(support: Support): CellGlyph {
       <h2 class="h2" style="margin-top:10px; font-size:28px;">Other comparisons.</h2>
       <div class="compare-tiles" style="margin-top:24px; grid-template-columns: repeat(3, 1fr);">
         {otherCompetitors.map((other) => (
-          <a href={`/vs/${other}`} class="compare-tile">
+          <a href={`/vs/${other}/`} class="compare-tile">
             <span class="vs">vs ·</span>
             <span class="name">{competitors[other].name}</span>
             <span class="arrow">→ compare</span>
@@ -209,8 +213,8 @@ function cellGlyph(support: Support): CellGlyph {
         </h2>
         <p>Quil installs side-by-side with {info.name}. Nothing to uninstall first.</p>
         <div class="actions">
-          <a href="/install" class="btn btn-primary">▸ install quil</a>
-          <a href="/features" class="btn btn-outline">every capability →</a>
+          <a href="/install/" class="btn btn-primary">▸ install quil</a>
+          <a href="/features/" class="btn btn-outline">every capability →</a>
         </div>
       </div>
     </div>

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -22,21 +22,21 @@ const sections: FooterSection[] = [
   {
     title: "Product",
     links: [
-      { href: "/features", text: "Features" },
-      { href: "/plugins",  text: "Plugins"  },
-      { href: "/install",  text: "Install"  },
-      { href: "/docs",     text: "Documentation" },
+      { href: "/features/", text: "Features" },
+      { href: "/plugins/",  text: "Plugins"  },
+      { href: "/install/",  text: "Install"  },
+      { href: "/docs/",     text: "Documentation" },
     ],
   },
   {
     title: "Compare",
     links: [
-      { href: "/vs/herdr",   text: "vs herdr"           },
-      { href: "/vs/aoe",     text: "vs Agent of Empires" },
-      { href: "/vs/tmux",    text: "vs tmux"       },
-      { href: "/vs/zellij",  text: "vs Zellij"     },
-      { href: "/vs/wezterm", text: "vs WezTerm"    },
-      { href: "/vs/screen",  text: "vs GNU Screen" },
+      { href: "/vs/herdr/",   text: "vs herdr"           },
+      { href: "/vs/aoe/",     text: "vs Agent of Empires" },
+      { href: "/vs/tmux/",    text: "vs tmux"       },
+      { href: "/vs/zellij/",  text: "vs Zellij"     },
+      { href: "/vs/wezterm/", text: "vs WezTerm"    },
+      { href: "/vs/screen/",  text: "vs GNU Screen" },
     ],
   },
   {
@@ -56,7 +56,7 @@ const sections: FooterSection[] = [
       { href: SITE.github,               text: "GitHub",   external: true },
       { href: SITE.github + "/issues",   text: "Issues",   external: true },
       { href: SITE.github + "/releases/latest", text: "Releases", external: true },
-      { href: "/legal",                  text: "Legal" },
+      { href: "/legal/",                  text: "Legal" },
     ],
   },
 ];

--- a/site/src/components/Header.astro
+++ b/site/src/components/Header.astro
@@ -13,26 +13,35 @@
  */
 import { SITE } from "@/data/seo";
 
+// Every internal href carries its trailing slash — see
+// scripts/check-trailing-slash.mjs for why a slashless one is a bug and
+// not a cosmetic difference.
 const navLinks = [
-  { href: "/features", label: "features" },
-  { href: "/plugins",  label: "plugins"  },
-  { href: "/install",  label: "install"  },
-  { href: "/docs",     label: "docs"     },
-  { href: "/blog",     label: "blog"     },
+  { href: "/features/", label: "features" },
+  { href: "/plugins/",  label: "plugins"  },
+  { href: "/install/",  label: "install"  },
+  { href: "/docs/",     label: "docs"     },
+  { href: "/blog/",     label: "blog"     },
 ];
 
 const compareLinks = [
-  { href: "/vs/tmux",    label: "vs tmux"       },
-  { href: "/vs/zellij",  label: "vs Zellij"     },
-  { href: "/vs/wezterm", label: "vs WezTerm"    },
-  { href: "/vs/screen",  label: "vs GNU Screen" },
+  { href: "/vs/tmux/",    label: "vs tmux"       },
+  { href: "/vs/zellij/",  label: "vs Zellij"     },
+  { href: "/vs/wezterm/", label: "vs WezTerm"    },
+  { href: "/vs/screen/",  label: "vs GNU Screen" },
 ];
 
-const currentPath = Astro.url.pathname.replace(/\/$/, "") || "/";
+// Both sides are compared slash-stripped. The hrefs above are canonical
+// (trailing slash) while `pathname` may arrive either way depending on
+// how the page was reached, so normalising only one side makes every
+// nav item compare unequal and quietly drops the active state sitewide.
+const strip = (p: string) => p.replace(/\/+$/, "") || "/";
+const currentPath = strip(Astro.url.pathname);
 
 function isActive(href: string): boolean {
-  if (href === "/") return currentPath === "/";
-  return currentPath === href || currentPath.startsWith(href + "/");
+  const target = strip(href);
+  if (target === "/") return currentPath === "/";
+  return currentPath === target || currentPath.startsWith(target + "/");
 }
 
 const compareOpen = compareLinks.some((link) => isActive(link.href));

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -17,8 +17,20 @@ import { glob } from "astro/loaders";
 const blog = defineCollection({
   loader: glob({ pattern: "**/[^_]*.md", base: "./src/content/blog" }),
   schema: z.object({
-    /** Post title — also the <h1>, the <title> stem, and og:title. */
+    /** Post title — the <h1> and, unless `seoTitle` overrides it, the
+     *  <title> stem and og:title. */
     title: z.string(),
+    /**
+     * Optional <title> stem for search results, replacing `title`.
+     * The " · Quil" suffix is still appended, so budget ~53 characters.
+     *
+     * The <h1> deliberately keeps `title`. These serve different readers:
+     * the heading is read by someone already on the page, the <title> by
+     * someone choosing between ten blue links. Google truncates the
+     * latter near 60 characters — this post's editorial title ran to ~77
+     * and was cut mid-phrase in the SERP.
+     */
+    seoTitle: z.string().optional(),
     /** 120–160 char meta description, unique per post. */
     description: z.string(),
     /** Publish date (ISO, e.g. 2026-06-14). Drives sort order + schema. */

--- a/site/src/content/blog/resume-claude-code-session-after-reboot.md
+++ b/site/src/content/blog/resume-claude-code-session-after-reboot.md
@@ -1,6 +1,7 @@
 ---
 title: "How to Resume Your Claude Code Session After a Reboot — Automatically"
-description: "Reboot your machine and your Claude Code conversation is gone. Here's the manual fix with claude --resume, why it doesn't scale, and how to make it automatic."
+seoTitle: "Resume Claude Code Sessions After a Reboot, Automatically"
+description: "Claude Code forgets nothing — the process just dies. The claude --resume fix, why it breaks with multiple agents and projects, and how to make resume automatic."
 pubDate: 2026-06-14
 updatedDate: 2026-07-24
 ogImage: "https://cdn.stukans.com/quil/screenshots/pane-restoration-og.png"

--- a/site/src/data/competitors.ts
+++ b/site/src/data/competitors.ts
@@ -191,6 +191,16 @@ export interface CompetitorInfo {
   matrix?: VsRow[];
   /** Optional override for the "where Quil takes over" headline. */
   quilHeadline?: string;
+  /**
+   * Optional <title> override, used verbatim (ComparePage suppresses the
+   * brand suffix, so "Quil vs tmux · Quil" can't happen).
+   *
+   * The default stem is "Quil vs <name>", which targets a phrase almost
+   * nobody types — the query with the demand is "<name> alternative".
+   * Set this where a competitor has a real alternative-seeking audience;
+   * leave it unset for herdr/aoe, whose names are searched directly.
+   */
+  seoTitle?: string;
   /** Per-page FAQ — 3-4 Q&A pairs. */
   faq: { question: string; answer: string }[];
 }
@@ -199,6 +209,7 @@ export const competitors: Record<CompetitorInfo["slug"], CompetitorInfo> = {
   tmux: {
     slug: "tmux",
     name: "tmux",
+    seoTitle: "Quil vs tmux — a tmux alternative that survives reboots",
     description:
       "The de-facto Unix terminal multiplexer. Server-side sessions, scriptable plugins, steep learning curve, shipped by default on most distros alongside screen.",
     positioning:
@@ -241,6 +252,7 @@ export const competitors: Record<CompetitorInfo["slug"], CompetitorInfo> = {
   zellij: {
     slug: "zellij",
     name: "Zellij",
+    seoTitle: "Quil vs Zellij — what a reboot does to each",
     description:
       "Modern Rust terminal multiplexer with a friendly UX, WASM plugins, and sane defaults. Released in 2021.",
     positioning:
@@ -273,6 +285,7 @@ export const competitors: Record<CompetitorInfo["slug"], CompetitorInfo> = {
   wezterm: {
     slug: "wezterm",
     name: "WezTerm",
+    seoTitle: "Quil vs WezTerm — what survives when the terminal closes",
     description:
       "A GPU-accelerated cross-platform terminal emulator with built-in multiplexer features, written in Rust, extensible via Lua. Released by Wez Furlong.",
     positioning:
@@ -305,6 +318,7 @@ export const competitors: Record<CompetitorInfo["slug"], CompetitorInfo> = {
   screen: {
     slug: "screen",
     name: "GNU Screen",
+    seoTitle: "Quil vs GNU Screen — persistence in 2026",
     description:
       "The original Unix terminal multiplexer, first released in 1987. Still shipped by default on most Unix distributions.",
     positioning:

--- a/site/src/data/seo.ts
+++ b/site/src/data/seo.ts
@@ -56,7 +56,13 @@ export const SITE = {
 } as const;
 
 export interface Page {
-  /** Required: page title without the brand suffix (BaseHead adds " · Quil"). */
+  /** Required: page title without the brand suffix (BaseHead adds " · Quil").
+   *  This is the EDITORIAL title — it is what the page calls itself, and on
+   *  a blog post it is also the <h1>. When the SERP wants different words
+   *  from the ones on the page, override the <title> with `seoTitle` rather
+   *  than bending this one; the visible heading and the search result are
+   *  allowed to differ, and pretending otherwise is how headings end up
+   *  written for a crawler instead of a reader. */
   title: string;
   /** Required: 120-160 char meta description, unique per page. */
   description: string;
@@ -66,6 +72,31 @@ export interface Page {
   ogImage?: string;
   /** Optional: keywords array — not used by Google but useful for Bing / Yandex. */
   keywords?: string[];
+  /**
+   * Optional: replaces `title` as the <title> / og:title stem. The brand
+   * suffix is still appended unless `brandSuffix` is false.
+   *
+   * Exists because Google truncates a <title> around 60 characters and
+   * the flagship post's editorial title ran to ~77 with the suffix — the
+   * result was a search listing that stopped mid-phrase.
+   */
+  seoTitle?: string;
+  /**
+   * Optional: append " · Quil" to the title. Default true.
+   *
+   * Set false where the brand already appears in the stem. "Quil vs tmux
+   * · Quil" says the name twice and spends ~7 of the ~60 usable
+   * characters doing it.
+   */
+  brandSuffix?: boolean;
+  /**
+   * Optional: og:type. Default "website".
+   *
+   * A blog post is "article" — the difference is what a share card and a
+   * crawler each expect to find, and "website" on a post suppresses the
+   * article-level fields entirely.
+   */
+  ogType?: "website" | "article";
 }
 
 /**
@@ -80,6 +111,28 @@ export interface Page {
  *
  * The home URL keeps its single trailing slash ("/").
  */
+/**
+ * Resolve an asset reference to an absolute URL.
+ *
+ * An `ogImage` is either site-relative ("/og/home.png") or already
+ * absolute (a CDN-hosted card on cdn.stukans.com). Prefixing the origin
+ * unconditionally turns the second kind into
+ * `https://quil.cchttps://cdn.stukans.com/…` — a string that is not a
+ * URL and that no consumer reports as an error; it simply renders no
+ * image.
+ *
+ * This lives here, next to `canonical`, because the guard previously
+ * existed ONLY inside BaseHead. The blog template built its
+ * BlogPosting `image` with a bare `SITE.url + …` twenty lines away in
+ * another file and inherited nothing — so the page carrying 64% of the
+ * site's impressions shipped the malformed form in its JSON-LD while
+ * its OG tags were correct. Two call sites, one rule: the rule has to
+ * be somewhere both can reach it.
+ */
+export function absoluteURL(ref: string): string {
+  return /^https?:\/\//.test(ref) ? ref : SITE.url + ref;
+}
+
 export function canonical(path: string): string {
   if (path === "/") return SITE.url + "/";
   const withLeadingSlash = path.startsWith("/") ? path : "/" + path;

--- a/site/src/layouts/Page.astro
+++ b/site/src/layouts/Page.astro
@@ -19,14 +19,18 @@ interface Props extends Page {
   schemas?: Record<string, unknown>[];
 }
 
-const { title, description, path, ogImage, keywords, schemas = [] } = Astro.props;
+// Everything except `schemas` is a BaseHead concern and is forwarded
+// verbatim. Spreading rather than re-listing each field means a new
+// optional on `Page` reaches <head> without a second edit here — the
+// class of bug where a page sets `ogType` and silently gets the default.
+const { schemas = [], ...page } = Astro.props;
 
 const sitewideSchemas = [organizationSchema(), websiteSchema(), ...schemas];
 ---
 <!doctype html>
 <html lang={SITE.htmlLang}>
   <head>
-    <BaseHead {title} {description} {path} {ogImage} {keywords} />
+    <BaseHead {...page} />
     <JsonLd data={sitewideSchemas} />
   </head>
   <body class="min-h-screen flex flex-col">

--- a/site/src/pages/404.astro
+++ b/site/src/pages/404.astro
@@ -44,7 +44,7 @@ const seo = {
 
         <div class="actions">
           <a href="/" class="btn btn-primary">▸ back to home</a>
-          <a href="/install" class="btn btn-outline">install quil</a>
+          <a href="/install/" class="btn btn-outline">install quil</a>
         </div>
       </div>
     </div>

--- a/site/src/pages/blog/[...slug].astro
+++ b/site/src/pages/blog/[...slug].astro
@@ -11,7 +11,7 @@
 import { getCollection, render } from "astro:content";
 import Page from "@/layouts/Page.astro";
 import Faq from "@/components/Faq.astro";
-import { SITE, canonical } from "@/data/seo";
+import { SITE, canonical, absoluteURL } from "@/data/seo";
 import { breadcrumbSchema, faqSchema } from "@/data/schemas";
 
 export async function getStaticPaths() {
@@ -48,7 +48,7 @@ const blogPosting = {
   url: canonical(path),
   inLanguage: SITE.htmlLang,
   keywords: post.data.keywords,
-  ...(post.data.ogImage ? { image: SITE.url + post.data.ogImage } : {}),
+  ...(post.data.ogImage ? { image: absoluteURL(post.data.ogImage) } : {}),
 };
 
 const schemas = [
@@ -58,7 +58,7 @@ const schemas = [
   ...(post.data.faq.length > 0 ? [faqSchema(post.data.faq)] : []),
   breadcrumbSchema([
     { name: "Home", path: "/" },
-    { name: "Blog", path: "/blog" },
+    { name: "Blog", path: "/blog/" },
     { name: post.data.title, path },
   ]),
 ];
@@ -73,6 +73,8 @@ const displayDate = post.data.pubDate.toLocaleDateString("en-US", {
 ---
 <Page
   title={post.data.title}
+  seoTitle={post.data.seoTitle}
+  ogType="article"
   description={post.data.description}
   path={path}
   ogImage={post.data.ogImage}

--- a/site/src/pages/features.astro
+++ b/site/src/pages/features.astro
@@ -163,7 +163,7 @@ for (const feature of features) {
           and you're in.
         </p>
         <div class="actions">
-          <a href="/install" class="btn btn-primary">▸ install quil</a>
+          <a href="/install/" class="btn btn-primary">▸ install quil</a>
           <a href="/" class="btn btn-outline">← back home</a>
         </div>
       </div>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -23,6 +23,13 @@ import { homeFaq } from "@/data/faq";
 
 const seo = {
   title: "Reboot-proof terminal multiplexer for AI development",
+  // Brand-first, and the suffix suppressed because the stem already
+  // opens with it. "quil" is a contested SERP — Rigetti's quantum
+  // language, the Clojure library, Quill.org — so a searcher who does
+  // mean this Quil has to recognise it in the first word or they scan
+  // past. The old form buried the name at character 52.
+  seoTitle: "Quil — the reboot-proof terminal multiplexer for AI coding agents",
+  brandSuffix: false,
   description:
     "Quil is a reboot-proof terminal multiplexer for AI-native developers. Typed panes, auto-resuming Claude Code sessions, remote attach over SSH, and an MCP server. One static binary per platform.",
   path: "/",
@@ -73,7 +80,7 @@ const topFeatures = [
     number: "◇ 05",
     title: "Panes on another machine",
     tag: "← REMOTE · BETA",
-    body: `<span class="mono" style="color:var(--flame);">quil --remote gpu01</span> puts the daemon on the server and the TUI on your laptop. No port is opened — it is <span class="mono">ssh -T</span> and one channel. Close the lid and the panes keep working; reopen and an amber bar reconnects on its own. Every directory picker reads the <b>server's</b> disk, not yours. <a href="/features#remote-daemon-ssh" style="color:var(--flame); white-space:nowrap;">How remote attach works →</a>`,
+    body: `<span class="mono" style="color:var(--flame);">quil --remote gpu01</span> puts the daemon on the server and the TUI on your laptop. No port is opened — it is <span class="mono">ssh -T</span> and one channel. Close the lid and the panes keep working; reopen and an amber bar reconnects on its own. Every directory picker reads the <b>server's</b> disk, not yours. <a href="/features/#remote-daemon-ssh" style="color:var(--flame); white-space:nowrap;">How remote attach works →</a>`,
   },
   {
     number: "◇ 06",
@@ -148,7 +155,7 @@ const revTimestamp = new Date().toISOString().slice(0, 10).replace(/-/g, "");
           </p>
 
           <div class="hero-actions">
-            <a href="/install" class="btn btn-primary"><span>▸ install in 30 seconds</span></a>
+            <a href="/install/" class="btn btn-primary"><span>▸ install in 30 seconds</span></a>
             <a href="#demo" class="btn btn-outline">try the demo</a>
             <a href={SITE.github} class="btn btn-ghost" rel="noopener external">★ star on github</a>
           </div>
@@ -242,7 +249,7 @@ const revTimestamp = new Date().toISOString().slice(0, 10).replace(/-/g, "");
       </div>
 
       <div style="margin-top:28px;">
-        <a href="/features" class="btn btn-outline">see every capability →</a>
+        <a href="/features/" class="btn btn-outline">see every capability →</a>
       </div>
     </div>
   </section>
@@ -339,8 +346,8 @@ const revTimestamp = new Date().toISOString().slice(0, 10).replace(/-/g, "");
             <div class="section-tag"><span class="dot"></span>THE DIRECT RIVALS</div>
             <p style="margin-top:12px; color:var(--ink-2); font-size:14px; line-height:1.6; max-width:52ch;">
               Building the same thing for agents? So are
-              <a href="/vs/herdr" style="color:var(--flame);">herdr</a> and
-              <a href="/vs/aoe" style="color:var(--flame);">Agent of Empires</a>.
+              <a href="/vs/herdr/" style="color:var(--flame);">herdr</a> and
+              <a href="/vs/aoe/" style="color:var(--flame);">Agent of Empires</a>.
               They ship broader agent support and a web dashboard; Quil answers
               with native Windows, an MCP server, and pane notes. See the honest
               side-by-side — gaps included.
@@ -374,7 +381,7 @@ const revTimestamp = new Date().toISOString().slice(0, 10).replace(/-/g, "");
 
         <div class="compare-tiles">
           {compareTiles.map((tile) => (
-            <a href={`/vs/${tile.slug}`} class="compare-tile">
+            <a href={`/vs/${tile.slug}/`} class="compare-tile">
               <span class="vs">vs ·</span>
               <span class="name">{tile.label}</span>
               <span style="font-size:12px; color:var(--ink-3); line-height:1.5;">{tile.blurb}</span>
@@ -445,7 +452,7 @@ const revTimestamp = new Date().toISOString().slice(0, 10).replace(/-/g, "");
         </div>
 
         <div class="actions">
-          <a href="/install" class="btn btn-primary">▸ install quil</a>
+          <a href="/install/" class="btn btn-primary">▸ install quil</a>
           <a href={SITE.github} class="btn btn-outline" rel="noopener external">★ star on github</a>
         </div>
       </div>

--- a/site/src/pages/install.astro
+++ b/site/src/pages/install.astro
@@ -178,7 +178,7 @@ systemctl --user start quild</pre>
                 and extracts it to <code>~/.quil/conpty/</code> on first run, so
                 TUIs render correctly despite the older Windows 10 console host.
                 Windows 11 uses its built-in host and extracts nothing. See
-                <a href="/legal">third-party software</a>.
+                <a href="/legal/">third-party software</a>.
               </p>
             </div>
           </div>
@@ -294,8 +294,8 @@ systemctl --user start quild</pre>
 │                                                    │
 └────────────────────────────────────────────────────┘</pre>
         <div class="actions">
-          <a href="/features" class="btn btn-primary">explore features</a>
-          <a href="/plugins" class="btn btn-outline">write a plugin</a>
+          <a href="/features/" class="btn btn-primary">explore features</a>
+          <a href="/plugins/" class="btn btn-outline">write a plugin</a>
         </div>
       </div>
     </div>

--- a/site/src/pages/plugins.astro
+++ b/site/src/pages/plugins.astro
@@ -121,7 +121,7 @@ type PluginEntry = (typeof plugins)[number];
           Write one. <span class="flame-text">Reload on save.</span>
         </h2>
         <div class="actions">
-          <a href="/install" class="btn btn-primary">▸ install quil</a>
+          <a href="/install/" class="btn btn-primary">▸ install quil</a>
           <a href={pluginAuthoringRef} class="btn btn-outline" rel="noopener external">plugin reference →</a>
         </div>
       </div>

--- a/site/src/pages/rss.xml.ts
+++ b/site/src/pages/rss.xml.ts
@@ -1,0 +1,43 @@
+// RSS feed for /blog.
+//
+// Endpoint rather than a page: this returns XML, so it bypasses the
+// Page layout entirely and Astro serves it at /rss.xml verbatim.
+//
+// Worth having for a one-post blog because the consumers that matter
+// here are not human subscribers — they are the readers and answer
+// engines that look for a feed to discover new posts, and a feed that
+// only starts existing once there is "enough" content misses the
+// discovery window for every post published before it.
+
+import rss from "@astrojs/rss";
+import { getCollection } from "astro:content";
+import { SITE, canonical } from "@/data/seo";
+
+export async function GET(context: { site?: URL }) {
+  const posts = await getCollection("blog", ({ data }) => !data.draft);
+
+  // Newest first. `pubDate` is a Date (coerced by the collection schema),
+  // so this is a numeric sort, not a lexical one on ISO strings.
+  posts.sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
+
+  return rss({
+    title: `${SITE.name} — blog`,
+    description: SITE.tagline,
+    // context.site comes from `site` in astro.config.mjs; SITE.url is the
+    // same origin and keeps this working if the endpoint is ever rendered
+    // without that context.
+    site: context.site?.toString() ?? SITE.url,
+    items: posts.map((post) => ({
+      title: post.data.title,
+      description: post.data.description,
+      pubDate: post.data.pubDate,
+      // Absolute, trailing-slashed, and identical to the canonical the
+      // page itself declares — a feed pointing at the slashless form
+      // would reintroduce the exact duplicate-URL split that
+      // scripts/check-trailing-slash.mjs exists to prevent.
+      link: canonical(`/blog/${post.id}/`),
+      categories: post.data.keywords,
+    })),
+    customData: `<language>${SITE.htmlLang}</language>`,
+  });
+}


### PR DESCRIPTION
Four defects found while auditing Search Console for quil.cc. Each was invisible on its own; together they explain a fair share of 3,022 impressions converting to 8 clicks over 28 days.

## Trailing slashes — the structural one

The site is `trailingSlash: "always"`, and `canonical()`, the sitemap and the GitHub Pages 301s all agree. The internal link graph did not: every sitewide nav link named the slashless URL.

A redirect is a hint; a link is a vote. On a 14-page site the ~19 nav links are the bulk of the canonicalization signal, and Google split the difference:

| URL | Impressions | Position |
|---|---|---|
| `/vs/herdr` | 6 | 4.3 |
| `/vs/herdr/` | 32 | 11.2 |
| `/blog` | 3 | 5.0 |
| `/blog/` | 7 | 31.9 |

Both members of each pair indexed and served, for identical content, splitting signals between two URLs — while six *other* URLs landed in Search Console's "Page with redirect" bucket, which is the same phenomenon with the declaration winning. That bucket is reported as `source: Website`, i.e. "your own markup keeps emitting these".

Corrects 26 hrefs and adds `scripts/check-trailing-slash.mjs` to `npm run build`. The guard models all four syntactic forms in use — attribute, expression, template literal, and object literal in a nav data array. The Footer's are the last kind, which an attribute-only sweep reports as clean.

`Header.astro`'s `isActive()` compared a slash-stripped `pathname` against those hrefs, so slashing them alone would have silently dropped the active nav state on every page. Both sides now normalise.

## Sitemap lastmod was dead

`astro.config.mjs` derives each page's `lastmod` from `git log -1 -- <file>`, but the workflow's default depth-1 checkout has one commit, so every file returned the same date and all 14 URLs claimed to change on every deploy. It validated, the dates were real, and only comparing two of them revealed the problem.

`fetch-depth: 0` restores it — 8 distinct dates across 14 URLs locally.

## Malformed BlogPosting image

The blog template built its schema image with a bare `SITE.url + ogImage`, while that post's `ogImage` is already absolute — emitting `https://quil.cchttps://cdn.stukans.com/...` on the page carrying 64% of the site's impressions.

`BaseHead` already guarded this exact case, twenty lines away in another file. The guard moved to `absoluteURL()` in `seo.ts` and both call sites now share it.

## Titles

Adds `seoTitle`, `brandSuffix` and `ogType` to the `Page` interface, forwarded through `Page.astro` by rest-spread so a future field can't be silently dropped.

| Page | Before | After |
|---|---|---|
| `/` | Reboot-proof terminal multiplexer for AI development · Quil | Quil — the reboot-proof terminal multiplexer for AI coding agents |
| flagship post | How to Resume Your Claude Code Session After a Reboot — Automatically · Quil (~77 chars, truncated) | Resume Claude Code Sessions After a Reboot, Automatically · Quil |
| `/vs/tmux/` | Quil vs tmux · Quil | Quil vs tmux — a tmux alternative that survives reboots |

The home title leads with the brand because `quil` is a contested SERP shared with Rigetti's quantum language, the Clojure library and Quill.org — a searcher who does mean this Quil has to recognise it in the first word. The post's `<h1>` deliberately keeps the editorial title; the heading and the search listing serve different readers.

## Also

- RSS feed at `/rss.xml` with sitewide `<link rel="alternate">` discovery.
- Corrected a comment in `astro.config.mjs` claiming `trailingSlash: "never"` — the opposite of the config, and the sort of stale note that gets trusted mid-debug.

## Verification

- `npm run build` — `astro check` reports 0 errors, 0 warnings; both guards pass; 15 pages + `/rss.xml`.
- `check-trailing-slash.mjs` mutation-tested: reverting one href fails the build with file, line and fix.
- Built output confirmed — no slashless internal hrefs, no `quil.cchttps` anywhere in `dist/`, `og:type=article` on the post, active nav and compare dropdown still correct.
- No changelog fragment: `site/` and `.github/` are in both gates' denylists, so this is exempt and cuts no release.
