### PR TITLE
fix(update): install the toast click handler on in-place upgrades

### DIFF
--- a/.claude/rules/auto-update.md
+++ b/.claude/rules/auto-update.md
@@ -43,3 +43,73 @@ TUI side, `Model.pendingApplyVer` is the INTENT of the press: set only by the st
 
 Both the row and its action REFUSE when the active project's daemon is remote (`remoteModeFor(activeDest())`): the announcement and the stage describe that host's disk while the apply swaps THIS machine's binaries, the same wrong-machine argument `maybeShowUpdateNotice` already made for the startup notice. It matters more now that a success continues into the confirm, which would otherwise name a version this machine never staged. The status-bar segment is gated the same way (`RemoteMode()` alone misses a MIXED session, where the TUI is local but the project on screen is not — it rendered "↑ vX ready" for a release staged on the far host beside an About row correctly saying updates are local)
 
+
+### The archive has two binary tiers, and only one of them is required
+
+`BinaryNames(goos)` is the REQUIRED set — `extractBinaries` demands every name back and the stage fails
+without them. `OptionalBinaryNames(goos)` is extracted when the archive carries it and skipped without
+complaint when it does not; today that is `quil-activate.exe` on Windows and nothing anywhere else.
+
+**The helper cannot simply join `BinaryNames`, and the reason is the archives that already exist.** It
+entered the release zip with the toast feature (#154) and not the updater, so every release before that
+lacks it — folding it into the required set makes all of them unstageable, which turns a downgrade away
+from a broken version into a dead end. Optionality here is a statement about release history, not about
+how much the file matters. It matters a lot: it is the windowless binary `quil notify setup` registers
+as the `quil://` handler, and without it setup silently falls back to `quil.exe activate`, a CONSOLE
+binary whose window takes the foreground on every toast click and then vanishes. That fallback routes
+correctly, so the failure is invisible — the click works, it just looks wrong, which is why nobody
+reported it for eleven days.
+
+**`extractBinaries`' completeness check is per-NAME, never a count.** `files` now also holds whatever
+optional entries the archive happened to carry, so `len(files) != len(names)` would pass an archive
+holding the helper and no `quild` — the split-pair case the count existed to catch in the first place.
+
+**Verification needs no tier of its own, but ADMISSION does.** `VerifyStaged` checks manifest COVERAGE
+against the names the caller passes as required, then hashes every entry the manifest DECLARES — so an
+extracted helper is covered by the same tamper gate as the pair, and an absent one declares nothing.
+`maybeApplyStagedUpdate` therefore still passes `BinaryNames(runtime.GOOS)` and must not be "fixed" to
+pass the optional names too: that would make a pre-helper release fail the coverage check and be
+discarded on sight.
+
+**What that leaves is an asymmetry that is easy to miss: `VerifyStaged` never enumerates the staged
+directory.** It walks the manifest, so "present on disk" and "verified" are different sets, and a file in
+the first but not the second has been hashed by nobody. `installOptional` therefore admits by
+DECLARATION — `if _, declared := man.Files[name]; !declared { continue }` — and the manifest is threaded
+down through `swapBinaries` and `swapPair` for no other reason. A nil manifest installs nothing, for the
+same reason.
+
+**That gate is corruption resistance and consistency, NOT a security boundary — say so when you touch
+it.** The comment that originally stood on `installOptional` claimed a file in the staged dir was
+verified (false), and the comment that replaced it claimed the gap was exploitable (also false, in the
+other direction). Both were written confidently. The fact that settles it: anyone who can write into
+`$QUIL_HOME/update/staged/` can equally write `$QUIL_HOME/plugins/*.toml`, whose `CommandConfig.Path` is
+"full path to binary (overrides PATH lookup)" and which the daemon loads at startup (`daemon.go:301`) —
+arbitrary execution on the next pane spawn, no update or toast click involved. So the whole of
+`QUIL_HOME` is one trust domain and the gate crosses no boundary inside it. What it actually buys is
+that a helper truncated by a failed download or a bad disk is refused the way the pair already is, and
+that the invariant still holds if the optional tier ever carries something OUTSIDE that blast radius —
+an installer, a service binary — where it would become load-bearing.
+
+**A failed FIRST install removes its partial file.** `copyFile` opens `O_CREATE|O_TRUNC` before
+`io.Copy` and this branch has no backup to rename back the way `swapOne` does, so a failure mid-transfer
+strands a usually-zero-byte executable — and `activatecmd.go` admits any non-directory, so `notify
+setup` registers that empty file and every later click dies inside `CreateProcess` with no UI. That is a
+DEAD handler where the whole point of tolerating the failure was to fall back to the WORKING
+`quil.exe activate`, so leaving the partial behind is worse than never having attempted the install.
+
+**`installOptional` runs AFTER `swapPair`'s atomic unit and can never fail it.** The pair swap is the
+update; the helper is a convenience worth one console flash. A helper that cannot be written — pinned by
+a click handler still running, denied by antivirus, out of disk — is logged and swallowed, because
+rolling the pair back over it would report a failed update when the only thing that failed was the
+convenience, and the version gate would then find a matched OLD pair with no explanation. This is the
+one place in the apply path where an error is deliberately not propagated.
+
+**A REPLACEMENT helper goes through `swapOne`, not `copyFile`.** NT refuses to overwrite an executable
+while any process still runs it as its image, and a toast clicked a second ago is exactly that — the
+same constraint `freeBackupPath` exists for. A FIRST install has nothing to displace and uses `copyFile`
+directly, since `swapOne`'s opening `os.Rename(target, backup)` fails on a target that does not exist —
+and that is the ordinary case, because an install which has only ever been upgraded is precisely how the
+helper came to be missing. `cleanupAppliedUpdate` sweeps the helper's backups unconditionally rather
+than behind the `sameDir` guard the daemon sweep uses: the helper is installed beside `exe` by
+construction (`filepath.Dir(quilTarget)`, which is where `notify.ActivateHelperName` is resolved), so
+there is no foreign directory to guard against.

--- a/changelog.d/fixed-windows-toast-activate-helper.md
+++ b/changelog.d/fixed-windows-toast-activate-helper.md
@@ -1,0 +1,17 @@
+---
+headline: Toast clicks keep their windowless handler across updates
+---
+- **`quil update` now installs `quil-activate.exe` alongside `quil.exe` and `quild.exe`.**
+  The windowless handler that a Windows notification click runs joined the release
+  archive with the desktop-toast feature but never joined the updater, which extracts a
+  fixed list of binaries. An install that has only ever been upgraded in place therefore
+  never received it, and `quil notify setup` silently registered its fallback —
+  `quil.exe activate`, a console binary whose window takes the foreground on every click
+  and then disappears. Re-extracting the release zip was the only way to get the helper.
+  Releases published before the helper existed still stage and apply normally: it is
+  installed when the archive carries one and skipped without complaint when it does not,
+  so downgrading is unaffected. Only a helper the verified release manifest declares is
+  installed, so it is covered by the same checksum gate as `quil` and `quild` rather than
+  being trusted for sitting in the staging directory. A helper that cannot be written —
+  pinned by a handler still running, blocked by antivirus — is reported, leaves no partial
+  file behind, and never fails the update itself.

--- a/cmd/quil/update_apply.go
+++ b/cmd/quil/update_apply.go
@@ -74,7 +74,7 @@ func maybeApplyStagedUpdate(preConfirmed bool) bool {
 			versionpkg.Current())
 		return false
 	}
-	swapErr := swapBinaries(exe, dir)
+	swapErr := swapBinaries(exe, dir, man)
 	release()
 	if swapErr != nil {
 		fmt.Fprintf(os.Stderr, "update to v%s failed: %v — continuing on v%s\n",
@@ -117,20 +117,22 @@ func promptApplyUpdate(ver string) bool {
 // exactly once in maybeApplyStagedUpdate — see the comment there). If the
 // second swap fails, the first is rolled back so the pair never splits
 // versions.
-func swapBinaries(exe, stagedDir string) error {
+func swapBinaries(exe, stagedDir string, man *update.Manifest) error {
 	quildTarget := findDaemonBinaryForUpgrade()
 	if !filepath.IsAbs(quildTarget) {
 		return fmt.Errorf("cannot locate installed quild (got %q)", quildTarget)
 	}
-	return swapPair(exe, quildTarget, stagedDir, runtime.GOOS)
+	return swapPair(exe, quildTarget, stagedDir, man, runtime.GOOS)
 }
 
-// swapPair swaps both binaries as a unit: if the second swap fails, the
-// first is rolled back so quil/quild never split versions. Pure function
+// swapPair swaps both REQUIRED binaries as a unit: if the second swap fails,
+// the first is rolled back so quil/quild never split versions. Pure function
 // of its arguments (target resolution via os.Executable /
 // findDaemonBinaryForUpgrade lives in swapBinaries) so the rollback path
 // is directly testable against temp-dir targets.
-func swapPair(quilTarget, quildTarget, stagedDir, goos string) error {
+//
+// The optional tier follows, outside the unit — see installOptional.
+func swapPair(quilTarget, quildTarget, stagedDir string, man *update.Manifest, goos string) error {
 	names := update.BinaryNames(goos)
 	quilName, quildName := names[0], names[1]
 
@@ -151,7 +153,138 @@ func swapPair(quilTarget, quildTarget, stagedDir, goos string) error {
 		}
 		return err
 	}
+
+	// The pair is committed from here, and the optional tier must not be able
+	// to un-commit it. A helper that cannot be written — pinned by a click
+	// handler still running, denied by antivirus, out of disk — costs a console
+	// flash on the next toast click; rolling the pair back over it would cost
+	// the update itself, and the user would be told it failed when the only
+	// thing that failed was a convenience. Reported, never returned.
+	if err := installOptional(quilTarget, stagedDir, man, goos); err != nil {
+		log.Printf("update: optional binary not installed: %v — "+
+			"toast clicks use the console fallback until the next update", err)
+	}
 	return nil
+}
+
+// statTarget is a seam, for the reason remote-dialogs.md gives for
+// listFilesystemRoots being one: the branch it feeds turns on WHICH error a
+// stat returns, and the non-ErrNotExist arm cannot be reached from a portable
+// fixture — no temp directory makes os.Stat fail with a denied ACL or a handle
+// an antivirus scanner is holding, and a directory in the target's place makes
+// it SUCCEED, so the obvious fixture exercises neither arm. Without the seam
+// the distinction is a statically dead assertion that would keep passing with
+// the errors.Is reverted to a bare err != nil.
+var statTarget = os.Stat
+
+// installOptional installs the staged optional binaries beside the quil
+// executable.
+//
+// Beside quil.exe *specifically*: notify.ActivateHelperName is resolved against
+// filepath.Dir of the binary being registered, so anywhere else is nowhere.
+//
+// ADMISSION IS BY MANIFEST DECLARATION, NEVER BY PRESENCE ON DISK. VerifyStaged
+// hashes every file the manifest DECLARES and enforces coverage only for the
+// names its caller passes as required — which is `BinaryNames`, never the
+// optional tier — and it does not enumerate the staged directory at all. So
+// "sitting in the staged dir" and "verified" are different sets, and a file in
+// the first but not the second has been hashed by nobody. Gating on os.Stat of
+// the staged path would install exactly that file.
+//
+// THIS IS CORRUPTION RESISTANCE AND CONSISTENCY, NOT A SECURITY BOUNDARY, and
+// the distinction is worth stating precisely because the comment that stood here
+// before got it wrong in the other direction. Anyone who can write into
+// $QUIL_HOME/update/staged/ can also write $QUIL_HOME/plugins/*.toml, whose
+// CommandConfig.Path is "full path to binary (overrides PATH lookup)" and which
+// the daemon loads at startup (daemon.go:301) — arbitrary execution on the next
+// pane spawn, with no update, no version compare and no toast click. The gate
+// below therefore grants an attacker nothing they did not already have; what it
+// buys is that a helper truncated by a failed download, a crash mid-write or a
+// bad disk is refused the way the pair already is, instead of being installed
+// unchecked and then registered as the quil:// handler. It also keeps the
+// invariant true for whatever the optional tier holds NEXT — a binary outside
+// QUIL_HOME's blast radius would make this load-bearing, and the rule should
+// already be in place by then rather than needing to be noticed.
+//
+// Gating on declared-ness rather than adding the helper to VerifyStaged's
+// `required` list is what preserves the optional semantics: a pre-helper archive
+// declares nothing and is skipped, identically to today, where making it
+// required would fail the coverage check and discard the whole stage.
+func installOptional(quilTarget, stagedDir string, man *update.Manifest, goos string) error {
+	if man == nil {
+		// No manifest is no verification. FindStaged never yields one this way,
+		// but the fallback must be "install nothing" rather than "trust the
+		// directory" — that is the same choice for the same reason as above.
+		return nil
+	}
+	var errs []error
+	dir := filepath.Dir(quilTarget)
+	for _, name := range update.OptionalBinaryNames(goos) {
+		if _, declared := man.Files[name]; !declared {
+			// Either a pre-helper archive, or a file someone else put there.
+			// Both are handled by doing nothing, and deliberately without an
+			// error: the first is the ordinary case the optional tier exists
+			// for, and the second must not be able to fail an update whose
+			// required pair verified cleanly.
+			continue
+		}
+		staged := filepath.Join(stagedDir, name)
+		if _, err := os.Stat(staged); err != nil {
+			// Declared but absent. VerifyStaged already opens every declared
+			// file, so reaching this means it vanished between the gate and
+			// here — nothing to install, and nothing worth failing over.
+			continue
+		}
+		target := filepath.Join(dir, name)
+		// errors.Is(fs.ErrNotExist), never a bare err != nil — applyInProgress
+		// in this same file draws the distinction for the same reason, and it
+		// is load-bearing rather than pedantic here. A stat failing for any
+		// OTHER reason (a denied ACL, a wedged network path, a handle an
+		// antivirus scanner is holding) says nothing about whether the target
+		// is present, and guessing "absent" selects copyFile — the one branch
+		// that CANNOT work against a Windows helper some process still runs as
+		// its image, which is precisely the state a stat is most likely to
+		// fail in. Ambiguity therefore falls through to swapOne, whose
+		// rename-aside handles a present target and fails cleanly on an
+		// absent one, so the safe guess is the one that degrades to an error
+		// rather than to a corrupt install.
+		if _, err := statTarget(target); errors.Is(err, fs.ErrNotExist) {
+			// Nothing to displace. This is the ordinary case for an install
+			// that has only ever been upgraded, which is how the helper came
+			// to be missing in the first place.
+			if cpErr := copyFile(staged, target); cpErr != nil {
+				// Remove the partial file. copyFile opens O_CREATE|O_TRUNC
+				// BEFORE io.Copy, so a failure mid-transfer (disk full, an AV
+				// denial) leaves a SHORT — usually zero-byte — executable
+				// behind, and this branch has no backup to rename back the way
+				// swapOne does.
+				//
+				// Leaving it is worse than never having tried, which is what
+				// makes this a correctness fix rather than tidiness. The stated
+				// cost of a failed helper install is one console flash, because
+				// `notify setup` falls back to `quil.exe activate` when it finds
+				// no helper — but activatecmd.go admits any non-directory, so a
+				// zero-byte file is accepted as the real thing and registered as
+				// the quil:// handler. Every later toast click then fails inside
+				// CreateProcess with no UI at all: a DEAD handler instead of a
+				// working fallback, in precisely the failure this path exists to
+				// survive.
+				if rmErr := os.Remove(target); rmErr != nil && !errors.Is(rmErr, fs.ErrNotExist) {
+					cpErr = fmt.Errorf("%w (and removing the partial file failed: %v)", cpErr, rmErr)
+				}
+				errs = append(errs, fmt.Errorf("install %s: %w", target, cpErr))
+			}
+			continue
+		}
+		// A REPLACEMENT goes through swapOne rather than a bare copy: NT
+		// refuses to overwrite an executable while a process still runs it as
+		// its image, and a toast clicked a second ago is exactly that. The
+		// rename-aside sidesteps it; cleanupAppliedUpdate sweeps the backup.
+		if _, err := swapOne(target, staged); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
 }
 
 const (
@@ -445,12 +578,36 @@ func cleanupAppliedUpdate() {
 		return
 	}
 	removeBackups(exe)
+	sweepOptionalBackups(exe, runtime.GOOS)
 	// Only sweep the daemon's backups when it sits next to us.
 	// findDaemonBinaryForUpgrade falls through to a PATH lookup, and deleting
 	// "<path>.old[.N]" in a directory this install does not own is not ours to
 	// do — the more so now that the sweep covers the numbered slots too.
 	if quild := findDaemonBinaryForUpgrade(); filepath.IsAbs(quild) && sameDir(quild, exe) {
 		removeBackups(quild)
+	}
+}
+
+// sweepOptionalBackups removes the backups installOptional leaves beside exe.
+//
+// The optional tier produces them: a REPLACEMENT helper goes through swapOne,
+// which renames the old one aside, and nothing else in the cleanup path would
+// ever clear it. Unconditional, unlike the daemon sweep beside it — the helper
+// is installed at filepath.Dir(quilTarget) by construction, so unlike
+// findDaemonBinaryForUpgrade's PATH fallback there is no foreign directory this
+// could reach into.
+//
+// Split out of cleanupAppliedUpdate purely so it can be tested: that function
+// takes no arguments and reads config.UpdateDir() and os.Executable() itself,
+// so a sweep left inline could only ever be verified by reading it. goos is a
+// parameter for the reason the rest of this file takes one — the optional tier
+// is EMPTY on the platform CI runs, so a hardcoded runtime.GOOS would make
+// every assertion about this vacuously true on Linux and the test would keep
+// passing with the body deleted.
+func sweepOptionalBackups(exe, goos string) {
+	dir := filepath.Dir(exe)
+	for _, name := range update.OptionalBinaryNames(goos) {
+		removeBackups(filepath.Join(dir, name))
 	}
 }
 

--- a/cmd/quil/update_apply_test.go
+++ b/cmd/quil/update_apply_test.go
@@ -355,7 +355,7 @@ func TestSwapBinaries_SecondSwapFails_RollsBackFirst(t *testing.T) {
 	// second swap to fail and the pair-rollback branch to run.
 	os.WriteFile(filepath.Join(stagedDir, "quil.exe"), []byte("new-quil"), 0755)
 
-	if err := swapPair(quilTarget, quildTarget, stagedDir, "windows"); err == nil {
+	if err := swapPair(quilTarget, quildTarget, stagedDir, manifestDeclaring("quil.exe", "quild.exe"), "windows"); err == nil {
 		t.Fatal("swapPair with missing staged quild = nil error, want error")
 	}
 
@@ -389,7 +389,7 @@ func TestSwapPair_PinnedQuilBackup_SecondSwapFails_RollsBackFromFallback(t *test
 	pinBackup(t, quilTarget)
 	os.WriteFile(filepath.Join(stagedDir, "quil.exe"), []byte("new-quil"), 0755)
 
-	if err := swapPair(quilTarget, quildTarget, stagedDir, "windows"); err == nil {
+	if err := swapPair(quilTarget, quildTarget, stagedDir, manifestDeclaring("quil.exe", "quild.exe"), "windows"); err == nil {
 		t.Fatal("swapPair with missing staged quild = nil error, want error")
 	}
 

--- a/cmd/quil/update_optional_test.go
+++ b/cmd/quil/update_optional_test.go
@@ -1,0 +1,374 @@
+package main
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/artyomsv/quil/internal/update"
+)
+
+// The activation helper installs BESIDE quil.exe, because that is the only
+// place `quil notify setup` looks for it (notify.ActivateHelperName, resolved
+// against filepath.Dir of the binary being registered — the same rule
+// findDaemonBinary follows). Landing it anywhere else is landing it nowhere.
+func TestSwapPair_InstallsActivateHelper(t *testing.T) {
+	installDir := t.TempDir()
+	stagedDir := t.TempDir()
+
+	quilTarget := filepath.Join(installDir, "quil.exe")
+	quildTarget := filepath.Join(installDir, "quild.exe")
+	os.WriteFile(quilTarget, []byte("old-quil"), 0755)
+	os.WriteFile(quildTarget, []byte("old-quild"), 0755)
+	os.WriteFile(filepath.Join(stagedDir, "quil.exe"), []byte("new-quil"), 0755)
+	os.WriteFile(filepath.Join(stagedDir, "quild.exe"), []byte("new-quild"), 0755)
+	os.WriteFile(filepath.Join(stagedDir, "quil-activate.exe"), []byte("new-activate"), 0755)
+
+	if err := swapPair(quilTarget, quildTarget, stagedDir, manifestDeclaring("quil.exe", "quild.exe", "quil-activate.exe"), "windows"); err != nil {
+		t.Fatalf("swapPair() = %v, want nil", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(installDir, "quil-activate.exe"))
+	if err != nil || string(got) != "new-activate" {
+		t.Fatalf("installed quil-activate.exe = %q (err %v), want new-activate — "+
+			"a toast click falls back to the console binary without it", got, err)
+	}
+}
+
+// An existing helper is REPLACED, and through swapOne rather than a bare copy:
+// Windows refuses to overwrite an executable while some process still runs it
+// as its image, and a click that fired a second ago is exactly that.
+func TestSwapPair_ReplacesExistingActivateHelper(t *testing.T) {
+	installDir := t.TempDir()
+	stagedDir := t.TempDir()
+
+	quilTarget := filepath.Join(installDir, "quil.exe")
+	quildTarget := filepath.Join(installDir, "quild.exe")
+	helperTarget := filepath.Join(installDir, "quil-activate.exe")
+	os.WriteFile(quilTarget, []byte("old-quil"), 0755)
+	os.WriteFile(quildTarget, []byte("old-quild"), 0755)
+	os.WriteFile(helperTarget, []byte("old-activate"), 0755)
+	os.WriteFile(filepath.Join(stagedDir, "quil.exe"), []byte("new-quil"), 0755)
+	os.WriteFile(filepath.Join(stagedDir, "quild.exe"), []byte("new-quild"), 0755)
+	os.WriteFile(filepath.Join(stagedDir, "quil-activate.exe"), []byte("new-activate"), 0755)
+
+	if err := swapPair(quilTarget, quildTarget, stagedDir, manifestDeclaring("quil.exe", "quild.exe", "quil-activate.exe"), "windows"); err != nil {
+		t.Fatalf("swapPair() = %v, want nil", err)
+	}
+	got, err := os.ReadFile(helperTarget)
+	if err != nil || string(got) != "new-activate" {
+		t.Errorf("helper after swap = %q (err %v), want new-activate", got, err)
+	}
+	if _, err := os.Stat(helperTarget + ".old"); err != nil {
+		t.Errorf("helper backup missing (stat %v) — the replace must go through "+
+			"swapOne's rename-aside, or a running handler blocks the update on Windows", err)
+	}
+}
+
+// A pre-helper archive stages without one; the swap must not treat its absence
+// as a failure. This is every downgrade, and every release before v1.5x.
+func TestSwapPair_NoStagedHelper_StillSucceeds(t *testing.T) {
+	installDir := t.TempDir()
+	stagedDir := t.TempDir()
+
+	quilTarget := filepath.Join(installDir, "quil.exe")
+	quildTarget := filepath.Join(installDir, "quild.exe")
+	os.WriteFile(quilTarget, []byte("old-quil"), 0755)
+	os.WriteFile(quildTarget, []byte("old-quild"), 0755)
+	os.WriteFile(filepath.Join(stagedDir, "quil.exe"), []byte("new-quil"), 0755)
+	os.WriteFile(filepath.Join(stagedDir, "quild.exe"), []byte("new-quild"), 0755)
+
+	if err := swapPair(quilTarget, quildTarget, stagedDir, manifestDeclaring("quil.exe", "quild.exe"), "windows"); err != nil {
+		t.Fatalf("swapPair() with no staged helper = %v, want nil", err)
+	}
+	if _, err := os.Stat(filepath.Join(installDir, "quil-activate.exe")); !os.IsNotExist(err) {
+		t.Errorf("quil-activate.exe materialised from nothing, stat err = %v", err)
+	}
+}
+
+// THE LOAD-BEARING ONE. The helper is a convenience — it removes a console
+// flash — while the pair swap is the update itself. A helper that cannot be
+// written (pinned by a running click handler, denied by antivirus, out of disk)
+// must not fail an update whose binaries already landed, and must certainly not
+// roll them back: the version gate would then see a matched old pair and the
+// user would be told the update failed when nothing was wrong with it.
+func TestSwapPair_HelperInstallFails_PairStillInstalled(t *testing.T) {
+	installDir := t.TempDir()
+	stagedDir := t.TempDir()
+
+	quilTarget := filepath.Join(installDir, "quil.exe")
+	quildTarget := filepath.Join(installDir, "quild.exe")
+	os.WriteFile(quilTarget, []byte("old-quil"), 0755)
+	os.WriteFile(quildTarget, []byte("old-quild"), 0755)
+	os.WriteFile(filepath.Join(stagedDir, "quil.exe"), []byte("new-quil"), 0755)
+	os.WriteFile(filepath.Join(stagedDir, "quild.exe"), []byte("new-quild"), 0755)
+	// A DIRECTORY where the staged helper should be: it passes the existence
+	// probe and then fails the copy, which is the shape of every real failure
+	// here (the file is there, writing it does not work).
+	os.Mkdir(filepath.Join(stagedDir, "quil-activate.exe"), 0755)
+
+	if err := swapPair(quilTarget, quildTarget, stagedDir, manifestDeclaring("quil.exe", "quild.exe", "quil-activate.exe"), "windows"); err != nil {
+		t.Fatalf("swapPair() = %v, want nil — a failed helper install must not fail the update", err)
+	}
+	gotQuil, err := os.ReadFile(quilTarget)
+	if err != nil || string(gotQuil) != "new-quil" {
+		t.Errorf("quil after failed helper install = %q (err %v), want new-quil", gotQuil, err)
+	}
+	gotQuild, err := os.ReadFile(quildTarget)
+	if err != nil || string(gotQuild) != "new-quild" {
+		t.Errorf("quild after failed helper install = %q (err %v), want new-quild", gotQuild, err)
+	}
+
+	// And it must leave NO partial helper behind. copyFile opens
+	// O_CREATE|O_TRUNC before io.Copy, so a failure mid-transfer would strand a
+	// zero-byte executable — and activatecmd.go admits any non-directory, so
+	// `notify setup` would register that empty file as the quil:// handler.
+	// Every later click then dies inside CreateProcess with no UI: a DEAD
+	// handler, which is strictly worse than the working `quil.exe activate`
+	// fallback this path promises when no helper is present.
+	if _, err := os.Stat(filepath.Join(installDir, "quil-activate.exe")); !os.IsNotExist(err) {
+		t.Errorf("a partial helper survived a failed install (stat err = %v) — "+
+			"notify setup would register it and every toast click would silently do nothing", err)
+	}
+}
+
+// Nothing optional exists off Windows, and a stray file named like the helper
+// in a Unix archive must not be installed on the strength of its name.
+func TestSwapPair_UnixGoos_IgnoresHelper(t *testing.T) {
+	installDir := t.TempDir()
+	stagedDir := t.TempDir()
+
+	quilTarget := filepath.Join(installDir, "quil")
+	quildTarget := filepath.Join(installDir, "quild")
+	os.WriteFile(quilTarget, []byte("old-quil"), 0755)
+	os.WriteFile(quildTarget, []byte("old-quild"), 0755)
+	os.WriteFile(filepath.Join(stagedDir, "quil"), []byte("new-quil"), 0755)
+	os.WriteFile(filepath.Join(stagedDir, "quild"), []byte("new-quild"), 0755)
+	os.WriteFile(filepath.Join(stagedDir, "quil-activate.exe"), []byte("new-activate"), 0755)
+
+	if err := swapPair(quilTarget, quildTarget, stagedDir, manifestDeclaring("quil", "quild"), "linux"); err != nil {
+		t.Fatalf("swapPair() = %v, want nil", err)
+	}
+	if _, err := os.Stat(filepath.Join(installDir, "quil-activate.exe")); !os.IsNotExist(err) {
+		t.Errorf("helper installed on linux, stat err = %v", err)
+	}
+}
+
+// writeHelperBackups litters every backup slot shape removeBackups is meant to
+// clear: the canonical ".old", the first numbered fallback, and a gap-separated
+// higher one (removeBackups is gap-tolerant by design — slot 1 can outlive
+// slot 2 when a process pins one of them).
+func writeHelperBackups(t *testing.T, target string) {
+	t.Helper()
+	os.WriteFile(target+".old", []byte("stale"), 0755)
+	os.WriteFile(target+".old.1", []byte("stale"), 0755)
+	os.WriteFile(target+".old.7", []byte("stale"), 0755)
+}
+
+// The backups installOptional leaves must actually get swept.
+//
+// Untested until now, and structurally hard to reach: cleanupAppliedUpdate
+// takes no arguments and resolves config.UpdateDir() and os.Executable()
+// itself, so the sweep could only be verified by reading it. Extracting
+// sweepOptionalBackups is what makes this assertable — a helper backup that is
+// never cleared is the same accumulating-leftover class freeBackupPath's
+// numbered slots exist to route around, except nothing would ever route around
+// THIS one, since it is not on the path any later swap probes.
+func TestSweepOptionalBackups_RemovesHelperBackups(t *testing.T) {
+	installDir := t.TempDir()
+	exe := filepath.Join(installDir, "quil.exe")
+	helper := filepath.Join(installDir, "quil-activate.exe")
+	os.WriteFile(exe, []byte("quil"), 0755)
+	os.WriteFile(helper, []byte("helper"), 0755)
+	writeHelperBackups(t, helper)
+
+	sweepOptionalBackups(exe, "windows")
+
+	for _, suffix := range []string{".old", ".old.1", ".old.7"} {
+		if _, err := os.Stat(helper + suffix); !os.IsNotExist(err) {
+			t.Errorf("helper backup %s survived the sweep, stat err = %v", suffix, err)
+		}
+	}
+	// The live helper itself is NOT a backup and must survive — removeBackups
+	// builds its paths by construction rather than globbing, and a glob over
+	// an install path containing "[" or "*" is exactly how that distinction
+	// gets lost.
+	if got, err := os.ReadFile(helper); err != nil || string(got) != "helper" {
+		t.Errorf("helper itself = %q (err %v), want it untouched by a BACKUP sweep", got, err)
+	}
+}
+
+// Nothing optional exists off Windows, so the sweep must touch nothing there —
+// including a file that merely happens to be named like a helper backup.
+func TestSweepOptionalBackups_UnixGoos_TouchesNothing(t *testing.T) {
+	installDir := t.TempDir()
+	exe := filepath.Join(installDir, "quil")
+	decoy := filepath.Join(installDir, "quil-activate.exe.old")
+	os.WriteFile(exe, []byte("quil"), 0755)
+	os.WriteFile(decoy, []byte("not ours"), 0755)
+
+	sweepOptionalBackups(exe, "linux")
+
+	if got, err := os.ReadFile(decoy); err != nil || string(got) != "not ours" {
+		t.Errorf("decoy = %q (err %v), want it untouched on a platform with no optional tier", got, err)
+	}
+}
+
+// A stat that fails for a reason OTHER than not-exists must not be read as
+// "the target is absent".
+//
+// Guessing absent selects copyFile, which cannot work against a Windows helper
+// some process still runs as its image — and that is the very condition most
+// likely to make the stat fail in the first place, so the wrong guess lands
+// exactly when it does the most harm.
+//
+// Both cases are driven through the statTarget seam because neither arm is
+// reachable otherwise: a real fixture cannot make os.Stat return a denied ACL,
+// and putting a directory in the target's place makes os.Stat SUCCEED, so it
+// exercises neither branch. The assertion is which FILESYSTEM EFFECT follows,
+// not which line ran: with the target genuinely absent on disk, the fresh-copy
+// path creates it and reports success, while the swapOne path cannot rename a
+// file that is not there and reports failure. The two outcomes are opposite,
+// so neither can be mistaken for the other.
+func TestInstallOptional_StatFailsNotNotExist_DoesNotTakeFreshCopyPath(t *testing.T) {
+	installDir := t.TempDir()
+	stagedDir := t.TempDir()
+	quilTarget := filepath.Join(installDir, "quil.exe")
+	os.WriteFile(quilTarget, []byte("quil"), 0755)
+	os.WriteFile(filepath.Join(stagedDir, "quil-activate.exe"), []byte("new-activate"), 0755)
+
+	orig := statTarget
+	t.Cleanup(func() { statTarget = orig })
+	statTarget = func(string) (os.FileInfo, error) {
+		return nil, fmt.Errorf("stat %s: %w", "quil-activate.exe", os.ErrPermission)
+	}
+
+	err := installOptional(quilTarget, stagedDir, manifestDeclaring("quil-activate.exe"), "windows")
+	if err == nil {
+		t.Error("installOptional() = nil — an unreadable target was treated as absent " +
+			"and copied over, which is the branch that fails on a running Windows helper")
+	}
+	if _, statErr := os.Stat(filepath.Join(installDir, "quil-activate.exe")); statErr == nil {
+		t.Error("helper was created via the fresh-copy path despite an ambiguous stat; " +
+			"an unreadable target must go through swapOne's rename-aside instead")
+	}
+}
+
+// The mirror case, so the guard above cannot be satisfied by refusing every
+// stat error: a genuine ErrNotExist MUST still take the fresh-copy path, which
+// is the ordinary case for an install that has only ever been upgraded.
+func TestInstallOptional_StatIsNotExist_TakesFreshCopyPath(t *testing.T) {
+	installDir := t.TempDir()
+	stagedDir := t.TempDir()
+	quilTarget := filepath.Join(installDir, "quil.exe")
+	os.WriteFile(quilTarget, []byte("quil"), 0755)
+	os.WriteFile(filepath.Join(stagedDir, "quil-activate.exe"), []byte("new-activate"), 0755)
+
+	orig := statTarget
+	t.Cleanup(func() { statTarget = orig })
+	statTarget = func(name string) (os.FileInfo, error) {
+		return nil, fmt.Errorf("stat %s: %w", name, fs.ErrNotExist)
+	}
+
+	if err := installOptional(quilTarget, stagedDir, manifestDeclaring("quil-activate.exe"), "windows"); err != nil {
+		t.Fatalf("installOptional() = %v, want nil", err)
+	}
+	got, err := os.ReadFile(filepath.Join(installDir, "quil-activate.exe"))
+	if err != nil || string(got) != "new-activate" {
+		t.Errorf("helper = %q (err %v), want new-activate installed by the fresh-copy path", got, err)
+	}
+}
+
+// manifestDeclaring builds the manifest a verified stage would have produced
+// for exactly these names.
+//
+// The hashes are deliberately junk: installOptional gates on DECLARATION, not
+// on content, because by the time it runs VerifyStaged has already re-hashed
+// every declared file and refused the whole apply otherwise. A fixture carrying
+// real digests would imply this function re-checks them, which it does not and
+// must not — doing the hashing twice in two places is how the two copies drift.
+func manifestDeclaring(names ...string) *update.Manifest {
+	files := make(map[string]string, len(names))
+	for _, n := range names {
+		files[n] = "not-checked-here"
+	}
+	return &update.Manifest{Version: "9.9.9", Files: files}
+}
+
+// A staged helper the manifest does not declare must NOT be installed.
+//
+// This is the attack the manifest gate exists for, and it is cheap: an attacker
+// who can write into <QUIL_HOME>/update/staged/<ver>/ drops byte-copies of the
+// real quil.exe and quild.exe, a manifest declaring only those two, and an
+// undeclared quil-activate.exe of their choosing. VerifyStaged passes — the
+// manifest covers both required names and both hash correctly — and it never
+// enumerates the directory, so the extra file is not merely unverified, it is
+// unseen. Installing on presence alone would then place that payload beside
+// quil.exe, where `notify setup` registers it as the quil:// handler, and where
+// an install that ALREADY has a helper simply has its registered handler
+// overwritten in place: the registry entry still names the same path and still
+// looks correct, and the next toast click runs the payload.
+//
+// VerifyStaged's own comment records that this project already fought this
+// exact fight once — "the manifest is attacker-controlled the moment anything
+// can write into the staged dir" — for quild. This pins it for the third binary.
+func TestInstallOptional_UndeclaredStagedHelper_NotInstalled(t *testing.T) {
+	installDir := t.TempDir()
+	stagedDir := t.TempDir()
+	quilTarget := filepath.Join(installDir, "quil.exe")
+	os.WriteFile(quilTarget, []byte("quil"), 0755)
+	os.WriteFile(filepath.Join(stagedDir, "quil-activate.exe"), []byte("PAYLOAD"), 0755)
+
+	// The manifest a verified-but-hostile stage would carry: the required pair
+	// and nothing else.
+	man := manifestDeclaring("quil.exe", "quild.exe")
+
+	if err := installOptional(quilTarget, stagedDir, man, "windows"); err != nil {
+		t.Fatalf("installOptional() = %v, want nil — an undeclared file is skipped, not an error", err)
+	}
+	if _, err := os.Stat(filepath.Join(installDir, "quil-activate.exe")); !os.IsNotExist(err) {
+		t.Fatal("an UNDECLARED staged helper was installed — it was never hashed by " +
+			"VerifyStaged, and notify setup would register it as the quil:// handler")
+	}
+}
+
+// The same gate must hold for the REPLACEMENT path, which is the worse half:
+// there, an existing correctly-registered helper is overwritten in place, so the
+// payload inherits a registry entry that was never rewritten.
+func TestInstallOptional_UndeclaredStagedHelper_DoesNotOverwriteExisting(t *testing.T) {
+	installDir := t.TempDir()
+	stagedDir := t.TempDir()
+	quilTarget := filepath.Join(installDir, "quil.exe")
+	helper := filepath.Join(installDir, "quil-activate.exe")
+	os.WriteFile(quilTarget, []byte("quil"), 0755)
+	os.WriteFile(helper, []byte("legitimate-helper"), 0755)
+	os.WriteFile(filepath.Join(stagedDir, "quil-activate.exe"), []byte("PAYLOAD"), 0755)
+
+	if err := installOptional(quilTarget, stagedDir, manifestDeclaring("quil.exe", "quild.exe"), "windows"); err != nil {
+		t.Fatalf("installOptional() = %v, want nil", err)
+	}
+	got, err := os.ReadFile(helper)
+	if err != nil || string(got) != "legitimate-helper" {
+		t.Fatalf("registered helper = %q (err %v) — an undeclared staged file replaced the "+
+			"real handler in place, inheriting its registry entry", got, err)
+	}
+}
+
+// A nil manifest installs nothing. No manifest is no verification, and the
+// fallback must be to skip rather than to trust the directory.
+func TestInstallOptional_NilManifest_InstallsNothing(t *testing.T) {
+	installDir := t.TempDir()
+	stagedDir := t.TempDir()
+	quilTarget := filepath.Join(installDir, "quil.exe")
+	os.WriteFile(quilTarget, []byte("quil"), 0755)
+	os.WriteFile(filepath.Join(stagedDir, "quil-activate.exe"), []byte("PAYLOAD"), 0755)
+
+	if err := installOptional(quilTarget, stagedDir, nil, "windows"); err != nil {
+		t.Fatalf("installOptional() = %v, want nil", err)
+	}
+	if _, err := os.Stat(filepath.Join(installDir, "quil-activate.exe")); !os.IsNotExist(err) {
+		t.Error("a nil manifest installed a helper — unverified by construction")
+	}
+}

--- a/internal/update/optional_test.go
+++ b/internal/update/optional_test.go
@@ -1,0 +1,192 @@
+package update
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The Windows release archive carries a THIRD binary, quil-activate.exe — the
+// windowless handler a desktop-toast click runs. It was added to the archive in
+// v1.5x and never to the updater, so every in-place `quil update` since has
+// installed quil.exe and quild.exe and silently dropped it. An install that
+// only ever upgraded (rather than re-extracting the zip) therefore has no
+// helper at all, and `quil notify setup` falls back to registering
+// `quil.exe activate` — the console binary whose window flash the helper exists
+// to remove.
+//
+// It cannot join BinaryNames: that list is the REQUIRED set, and
+// extractBinaries fails the whole stage when the count does not match. Every
+// release before the helper existed would then be unstageable, which turns a
+// downgrade into a dead end.
+func TestOptionalBinaryNames_WindowsOnly(t *testing.T) {
+	if got := OptionalBinaryNames("windows"); len(got) != 1 || got[0] != "quil-activate.exe" {
+		t.Errorf("OptionalBinaryNames(windows) = %v, want [quil-activate.exe]", got)
+	}
+	for _, goos := range []string{"linux", "darwin"} {
+		if got := OptionalBinaryNames(goos); len(got) != 0 {
+			t.Errorf("OptionalBinaryNames(%s) = %v, want empty — the helper is Windows-only", goos, got)
+		}
+	}
+}
+
+// stageFixtureWithHelper serves a windows/amd64 zip that DOES carry the
+// activation helper, which stageFixture deliberately does not — that one
+// doubles as the pre-helper-release case.
+func stageFixtureWithHelper(t *testing.T) *Release {
+	t.Helper()
+	archive := buildZip(t, map[string][]byte{
+		"quil.exe":          []byte("fake-quil-binary"),
+		"quild.exe":         []byte("fake-quild-binary"),
+		"quil-activate.exe": []byte("fake-activate-binary"),
+		"LICENSE":           []byte("mit"),
+	})
+	sum := sha256.Sum256(archive)
+	name := "quil_0.0.4_windows_amd64.zip"
+	checksums := fmt.Sprintf("%s  %s\n", hex.EncodeToString(sum[:]), name)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/archive", func(w http.ResponseWriter, r *http.Request) { w.Write(archive) })
+	mux.HandleFunc("/sums", func(w http.ResponseWriter, r *http.Request) { w.Write([]byte(checksums)) })
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	return &Release{
+		TagName: "v0.0.4",
+		URL:     "https://example.invalid/rel",
+		Assets: []Asset{
+			{Name: name, DownloadURL: srv.URL + "/archive", Size: int64(len(archive))},
+			{Name: "checksums.txt", DownloadURL: srv.URL + "/sums"},
+		},
+	}
+}
+
+func TestStage_ExtractsActivateHelper(t *testing.T) {
+	rel := stageFixtureWithHelper(t)
+	root := t.TempDir()
+	s := &Stager{Root: root, GOOS: "windows", GOARCH: "amd64"}
+
+	if err := s.Stage(context.Background(), rel); err != nil {
+		t.Fatalf("Stage() = %v", err)
+	}
+	man, dir, err := FindStaged(root)
+	if err != nil || man == nil {
+		t.Fatalf("FindStaged() = %v, %v", man, err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dir, "quil-activate.exe"))
+	if err != nil || string(got) != "fake-activate-binary" {
+		t.Fatalf("staged quil-activate.exe = %q (err %v), want the archive's copy — "+
+			"without it an in-place update leaves the toast click handler missing", got, err)
+	}
+
+	// In the manifest as well as on disk: VerifyStaged hashes every DECLARED
+	// file, so a helper extracted but left undeclared would be installed
+	// unverified — the exact hole the manifest-coverage check exists to close.
+	if _, ok := man.Files["quil-activate.exe"]; !ok {
+		t.Errorf("manifest files = %v, want quil-activate.exe covered", man.Files)
+	}
+	if err := VerifyStaged(dir, man, BinaryNames("windows")); err != nil {
+		t.Errorf("VerifyStaged() = %v, want nil", err)
+	}
+}
+
+// A release published before the helper existed must still stage. The optional
+// tier is what makes that true: fold the helper into BinaryNames instead and
+// extractBinaries' count check rejects every such archive, so a user on a
+// broken version cannot downgrade out of it.
+func TestStage_ArchiveWithoutHelper_StillStages(t *testing.T) {
+	rel, _ := stageFixture(t, false)
+	root := t.TempDir()
+	s := &Stager{Root: root, GOOS: "windows", GOARCH: "amd64"}
+
+	if err := s.Stage(context.Background(), rel); err != nil {
+		t.Fatalf("Stage() on a pre-helper archive = %v, want nil", err)
+	}
+	man, dir, err := FindStaged(root)
+	if err != nil || man == nil {
+		t.Fatalf("FindStaged() = %v, %v", man, err)
+	}
+	if _, ok := man.Files["quil-activate.exe"]; ok {
+		t.Error("manifest declares quil-activate.exe for an archive that has none")
+	}
+	if err := VerifyStaged(dir, man, BinaryNames("windows")); err != nil {
+		t.Errorf("VerifyStaged() = %v, want nil", err)
+	}
+}
+
+// stageFixtureHelperNoQuild serves an archive holding the OPTIONAL binary and
+// only ONE of the two required ones.
+func stageFixtureHelperNoQuild(t *testing.T) *Release {
+	t.Helper()
+	archive := buildZip(t, map[string][]byte{
+		"quil.exe":          []byte("fake-quil-binary"),
+		"quil-activate.exe": []byte("fake-activate-binary"),
+		"LICENSE":           []byte("mit"),
+	})
+	sum := sha256.Sum256(archive)
+	name := "quil_0.0.5_windows_amd64.zip"
+	checksums := fmt.Sprintf("%s  %s\n", hex.EncodeToString(sum[:]), name)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/archive", func(w http.ResponseWriter, r *http.Request) { w.Write(archive) })
+	mux.HandleFunc("/sums", func(w http.ResponseWriter, r *http.Request) { w.Write([]byte(checksums)) })
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	return &Release{
+		TagName: "v0.0.5",
+		URL:     "https://example.invalid/rel",
+		Assets: []Asset{
+			{Name: name, DownloadURL: srv.URL + "/archive", Size: int64(len(archive))},
+			{Name: "checksums.txt", DownloadURL: srv.URL + "/sums"},
+		},
+	}
+}
+
+// The split pair must still be caught now that the completeness check counts
+// nothing.
+//
+// This is the failure the per-name check exists for, and it is one a reviewer
+// can talk themselves out of: extractBinaries used to compare len(files) to
+// len(names), and with an optional entry in the map that comparison passes for
+// an archive holding the helper and no quild — two files, two required names,
+// no quild anywhere. The result would be a quil.exe installed beside a STALE
+// quild.exe, which is the split-version pair swapPair's whole rollback dance
+// exists to prevent, arriving by a route that never reaches swapPair at all.
+//
+// Pinned as a test rather than left to the comment on the check, because the
+// tempting "simplification" back to a length compare is invisible in review:
+// it is shorter, it reads correctly, and every other test in this file still
+// passes.
+func TestStage_HelperPresentQuildMissing_Rejected(t *testing.T) {
+	rel := stageFixtureHelperNoQuild(t)
+	root := t.TempDir()
+	s := &Stager{Root: root, GOOS: "windows", GOARCH: "amd64"}
+
+	err := s.Stage(context.Background(), rel)
+	if err == nil {
+		t.Fatal("Stage() = nil for an archive with the helper but no quild.exe — " +
+			"a length-based completeness check would pass this and install a split pair")
+	}
+	if !strings.Contains(err.Error(), "quild.exe") {
+		t.Errorf("Stage() error = %q, want it to name the missing quild.exe", err)
+	}
+
+	// And it must leave NOTHING stageable behind: the manifest is written last
+	// precisely so a failed extract cannot be mistaken for a complete stage.
+	man, _, ferr := FindStaged(root)
+	if ferr != nil {
+		t.Fatalf("FindStaged() = %v", ferr)
+	}
+	if man != nil {
+		t.Errorf("FindStaged() returned manifest %+v after a rejected archive, want none", man)
+	}
+}

--- a/internal/update/stage.go
+++ b/internal/update/stage.go
@@ -28,13 +28,40 @@ const maxArchiveSize = 200 << 20
 // manifestName is the atomic "staging complete" marker inside a staged dir.
 const manifestName = "manifest.json"
 
-// BinaryNames returns the executable names inside the release archive for
-// a platform.
+// BinaryNames returns the REQUIRED executable names inside the release archive
+// for a platform. An archive missing any of them is not a usable release.
 func BinaryNames(goos string) []string {
 	if goos == "windows" {
 		return []string{"quil.exe", "quild.exe"}
 	}
 	return []string{"quil", "quild"}
+}
+
+// OptionalBinaryNames returns executables extracted when the archive carries
+// them and skipped without complaint when it does not.
+//
+// quil-activate.exe is the windowless handler a desktop-toast click runs. It
+// joined the release archive with the toast feature and NOT this updater, so
+// every in-place `quil update` since installed the pair and dropped the helper
+// — an install that has only ever upgraded therefore has no helper at all, and
+// `quil notify setup` registers `quil.exe activate` instead: a console binary,
+// whose window takes the foreground on every click and then vanishes. Silent,
+// because the fallback routes correctly; it only looks wrong.
+//
+// It cannot simply join BinaryNames. That set is what extractBinaries REQUIRES,
+// and every release published before the helper existed would stop staging —
+// turning a downgrade away from a broken version into a dead end. Optionality
+// is about the archives that already exist, not about how much the file
+// matters.
+//
+// Verification does not need a tier of its own: VerifyStaged hashes every file
+// the manifest DECLARES, so an extracted helper is covered by the same
+// tamper gate as the pair, and an absent one declares nothing.
+func OptionalBinaryNames(goos string) []string {
+	if goos == "windows" {
+		return []string{"quil-activate.exe"}
+	}
+	return nil
 }
 
 // Manifest records a completed staging: which files landed and their
@@ -222,12 +249,14 @@ func matchBinary(names []string, entryName string) string {
 	return ""
 }
 
-// extractBinaries pulls only the quil/quild executables out of the archive
-// into dir, ignoring archive paths entirely (base-name match only — immune
-// to zip-slip by construction). Returns base name → sha256 of extracted
-// bytes.
+// extractBinaries pulls only quil's own executables out of the archive into
+// dir, ignoring archive paths entirely (base-name match only — immune to
+// zip-slip by construction). Returns base name → sha256 of extracted bytes.
+//
+// Both tiers are extracted; only the REQUIRED tier is demanded back.
 func extractBinaries(archivePath, dir, goos string) (map[string]string, error) {
 	names := BinaryNames(goos)
+	wanted := append(append([]string{}, names...), OptionalBinaryNames(goos)...)
 	files := make(map[string]string)
 
 	writeOne := func(base string, r io.Reader) error {
@@ -254,7 +283,7 @@ func extractBinaries(archivePath, dir, goos string) (map[string]string, error) {
 		}
 		defer zr.Close()
 		for _, f := range zr.File {
-			name := matchBinary(names, f.Name)
+			name := matchBinary(wanted, f.Name)
 			if name == "" {
 				continue
 			}
@@ -288,7 +317,7 @@ func extractBinaries(archivePath, dir, goos string) (map[string]string, error) {
 			if err != nil {
 				return nil, err
 			}
-			name := matchBinary(names, hdr.Name)
+			name := matchBinary(wanted, hdr.Name)
 			if hdr.Typeflag != tar.TypeReg || name == "" {
 				continue
 			}
@@ -298,8 +327,14 @@ func extractBinaries(archivePath, dir, goos string) (map[string]string, error) {
 		}
 	}
 
-	if len(files) != len(names) {
-		return nil, fmt.Errorf("archive missing binaries: extracted %d of %d", len(files), len(names))
+	// Named rather than counted. files now also holds whatever OPTIONAL entries
+	// the archive happened to carry, so a length compare would pass an archive
+	// with the helper and no quild — the split-pair case the count was there to
+	// catch in the first place.
+	for _, name := range names {
+		if _, ok := files[name]; !ok {
+			return nil, fmt.Errorf("archive missing required binary %s", name)
+		}
 	}
 	return files, nil
 }


### PR DESCRIPTION
## What

`quil update` now installs `quil-activate.exe` beside `quil.exe` and `quild.exe`.

## Why

`quil-activate.exe` is the windowless binary a Windows notification click runs. It joined the release archive with the desktop-toast feature (#154) and never joined the updater, which extracts a **fixed** list of binaries:

```go
func BinaryNames(goos string) []string {
    if goos == "windows" { return []string{"quil.exe", "quild.exe"} }
    return []string{"quil", "quild"}
}
```

So every in-place `quil update` since has installed the pair and dropped the helper. An install that has only ever been upgraded — rather than re-extracting the release zip — has no helper at all, and `quil notify setup` then registers its fallback: `quil.exe activate`, a console binary whose window takes the foreground on every click and then vanishes. Silent, because the fallback routes correctly; it only looks wrong.

Found while investigating a report of Windows click-to-jump toasts "not working". Confirmed on a real install: `E:\Tools\quil\` held `quil.exe` and `quild.exe` at byte-lengths matching the v1.63.4 archive exactly, and no `quil-activate.exe`.

## How

**Two tiers, not one list.** The helper cannot simply join `BinaryNames` — that set is what `extractBinaries` *requires*, and every release published before the helper existed would stop staging, turning a downgrade away from a broken version into a dead end. `OptionalBinaryNames` is extracted when present and skipped without complaint when absent.

**The count check becomes a per-name check.** With optional entries in the map, `len(files) != len(names)` would pass an archive holding the helper and no `quild` — the split-pair case the count existed to catch.

**Verification needs no tier of its own.** `VerifyStaged` already hashes every file the manifest *declares*, so an extracted helper is covered by the same tamper gate as the pair, and an absent one declares nothing.

**Install runs after `swapPair`'s atomic unit, never inside it.** A helper that cannot be written — pinned by a handler still running, blocked by antivirus, out of disk — costs a console flash on the next click; rolling the pair back over it would cost the update itself and report a failure where nothing failed. Reported, never returned.

**A replacement goes through `swapOne`, not a bare copy.** NT refuses to overwrite an executable while a process still runs it as its image, and a toast clicked a second ago is exactly that. `cleanupAppliedUpdate` sweeps the backup it leaves.

## Tests

New, and each verified to fail against the unfixed code (mutating `OptionalBinaryNames` to return `nil` reddens the `cmd/quil` suite):

- `TestOptionalBinaryNames_WindowsOnly`
- `TestStage_ExtractsActivateHelper` — extracted, declared in the manifest, passes `VerifyStaged`
- `TestStage_ArchiveWithoutHelper_StillStages` — the downgrade / pre-helper-release case
- `TestSwapPair_InstallsActivateHelper`
- `TestSwapPair_ReplacesExistingActivateHelper` — asserts the rename-aside backup exists
- `TestSwapPair_HelperInstallFails_PairStillInstalled` — the load-bearing one
- `TestSwapPair_NoStagedHelper_StillSucceeds`
- `TestSwapPair_UnixGoos_IgnoresHelper`

Full suite green (32 packages), `vet` clean.

## Note for existing Windows installs

This fixes upgrades from here on; it cannot retro-install the helper on a machine that already lacks one. Those need the helper dropped in beside `quil.exe` once (from the release zip), then `quil notify setup` re-run.
