### PR TITLE
fix(site): restore the missing compare links and refresh the matrices

### DIFF
--- a/docs/competitive-analysis.md
+++ b/docs/competitive-analysis.md
@@ -93,7 +93,7 @@ Legend: ✅ full · 🟡 partial/different · ❌ absent
 | Snapshot restore after server restart | ✅ | ✅ | ✅ (ghost buffers) |
 | Survives full host reboot | ✅ | ✅ (tmux) | ✅ |
 | Named sessions (separate server namespaces) | ✅ | 🟡 (profiles) | ❌ |
-| Remote attach over SSH (thin client) | ✅ | 🟡 (SSH+web) | ❌ |
+| Remote attach over SSH (thin client) | ✅ | 🟡 (SSH+web) | ✅ (v1.44; several hosts at once since v1.47) |
 | Clipboard-image bridged into remote session | ✅ | ✅ (web) | ❌ |
 | Live server handoff (upgrade without killing panes) | ✅ | 🟡 (detached workers) | ❌ |
 | Web dashboard (browser terminal) | ❌ | ✅ (PWA) | ❌ |
@@ -110,9 +110,9 @@ Legend: ✅ full · 🟡 partial/different · ❌ absent
 | Runtime-updatable detection manifests | ✅ (remote fetch) | ❌ | ❌ |
 | Detection debugger (`agent explain`) | ✅ | ❌ | ❌ |
 | Model/context-token status display | 🟡 | ✅ | ✅ |
-| AI agents with detection | ~18 | ~13 | **2** |
+| AI agents with detection | 20+ | ~13 | **2** |
 | One-command agent integration installer | ✅ | ✅ | ❌ |
-| Native agent session restore | ✅ (14 agents) | ✅ (Claude+) | ✅ (claude, opencode) |
+| Native agent session restore | ✅ (most of its integrations) | ✅ (Claude+) | ✅ (claude, opencode) |
 | Session fork | ❌ | ✅ | ❌ |
 | Session import from disk | ❌ | ✅ (Claude) | ❌ |
 
@@ -183,13 +183,13 @@ current to-do list.
 | # | Feature | Source | Why it matters | Effort | Impact | Maps to |
 |---|---|---|---|:---:|:---:|---|
 | 1 | Screen-content agent state detection (no hooks) | herdr, aoe | Blocked/working/done inferred from terminal output for *any* agent, zero hooks. Quil only pattern-matches idle. | M | ★★★ | process-health |
-| 2 | Broad agent support + detection registry | herdr, aoe | They detect ~13–18 agents (Codex, Gemini, Cursor, Copilot, Droid, Devin…); Quil ships 2. Starkest gap. | M | ★★★ | community-plugins |
+| 2 | Broad agent support + detection registry | herdr, aoe | They detect 13–20+ agents (Codex, Gemini, Cursor, Copilot, Droid, Devin…); Quil ships 2. Starkest gap, and the one still widening — herdr's list grows most releases. | M | ★★★ | community-plugins |
 | 3 | ~~Git worktree-per-session~~ **SHIPPED** | herdr, aoe | Auto branch + worktree on session create, cleanup on delete. The #1 adoption driver for these tools. A tab can open onto a new worktree (placeholder pane + spinner while `git worktree add` runs), and closing it offers to remove the worktree, naming what it holds. | M | ★★★ | workspace-files |
 | 4 | Built-in diff viewer (review + edit + commit) | aoe | Review agent changes without leaving the TUI. Table stakes for "review what the agent did". | M | ★★★ | new |
 | 5 | Executable/scriptable plugins (actions, event hooks, link handlers) | herdr, aoe | Any-language plugins that run logic, not just declare pane types. Unlocks a real ecosystem. | M | ★★★ | community-plugins, cross-pane-events |
 | 6 | Plugin marketplace (GitHub-topic index) | herdr, aoe | Discover + `install owner/repo`. Already partially planned. | M | ★★ | community-plugins |
 | 7 | General shell CLI to script the multiplexer | herdr, aoe | `quil pane split`, `quil tab create` from any script. MCP serves AI; humans/scripts have nothing. | M | ★★ | new |
-| 8 | ~~Remote SSH thin-client attach (`--remote`)~~ **SHIPPED (v1.44)** | herdr | Local client of a remote server; bridges local clipboard image paste into remote agents. Quil went further than the gap asked: since v1.47 one client holds the local daemon and any number of remote ones at once. | M | ★★ | session-sharing |
+| 8 | ~~Remote SSH thin-client attach (`--remote`)~~ **SHIPPED (v1.44)** | herdr | Local client of a remote server. Since v1.47 one client holds the local daemon and any number of remote ones at once, which is more than the gap asked for. The clipboard-image half of this gap did **not** ship: the paste proxy writes the PNG to the client's own disk and types that path into the PTY, so in remote mode it names a file the server cannot read. | M | ★★ | session-sharing |
 | 9 | Web dashboard (browser terminal) | aoe | Real terminal + diffs in the browser, installable PWA. The largest surface Quil is missing. | L | ★★★ | new |
 | 10 | Remote phone access (tunnel + QR/passphrase + push) | aoe | Check on agents from a phone via Tailscale/Cloudflare with two-factor pairing. | L | ★★ | session-sharing |
 | 11 | Container sandboxing (Docker/Podman) + shared auth volumes | aoe | Isolate agents in containers; authenticate in-container without re-login. | L | ★★ | new |
@@ -237,16 +237,20 @@ Closing the most impactful gaps, roughly in ROI order:
    agents is the starkest deficit; both rivals detect many out of the box. A
    screen-content detector (like herdr's TOML manifests) would let Quil claim
    broad agent awareness without per-agent hooks.
-2. **Worktree-per-session + a diff viewer** (#3, #4) — the single most-cited
-   reason people adopt these tools ("parallel agents on branches, then review the
-   diff"). Quil has the git-discovery primitives already; the automation and
-   review layers are missing.
+2. **A diff viewer** (#4) — the other half of the most-cited reason people adopt
+   these tools ("parallel agents on branches, then review the diff"). The
+   worktree half of that pair (#3) has since shipped, which makes the review
+   layer the one that is now conspicuously missing: Quil can put an agent on its
+   own branch and can no longer show you what it did there.
 3. **A shell-scriptable CLI** (#7) — Quil's MCP is great for AI but leaves
    human/script orchestration unserved; a thin CLI over the existing daemon IPC is
    low effort.
-4. **Sound + OS notifications** (#14, #15) — small effort, immediately felt.
-5. **Web/remote access & sandboxing** (#9, #10, #11) — the largest builds; likely
+4. **Sound, and desktop notifications beyond Windows** (#14, #15) — small effort,
+   immediately felt. Windows toasts shipped; macOS and Linux did not, and neither
+   did sound on any platform.
+5. **Web/mobile access & sandboxing** (#9, #10, #11) — the largest builds; likely
    a deliberate "not now" given Quil's TUI/Windows-native focus, but this is where
-   aoe is pulling away for the mobile/remote crowd.
+   aoe is pulling away for the mobile crowd. Terminal-side remote attach (#8) is
+   no longer part of this cluster — it shipped in v1.44.
 </content>
 </invoke>

--- a/docs/competitive-analysis.md
+++ b/docs/competitive-analysis.md
@@ -33,8 +33,8 @@ architectural bet.
 | Web/browser UI | ❌ TUI only | ❌ (responsive TUI) | ✅ **React PWA dashboard** |
 | Container sandbox | ❌ | ❌ | ✅ Docker/Podman/Apple |
 | Remote phone access | ❌ | via SSH TUI | ✅ Tunnel + PWA + Web Push |
-| Git worktree-per-session | ❌ | ✅ | ✅ (+ multi-repo) |
-| AI agents supported | **2** deep + tools | **~18** detected, 14 integrations | **~13** terminal, 7 ACP |
+| Git worktree-per-session | ✅ | ✅ | ✅ (+ multi-repo) |
+| AI agents supported | **2** deep + tools | **20+** detected, native integrations for most | **~13** terminal, 7 ACP |
 | Scale | ~30–40k Go | ~170k Rust | ~292k Rust + large web app |
 | License / backing | Apache-2.0, product | Apache-2.0 (was AGPL-3.0 + commercial until 2026-07-22), solo + sponsors | MIT, Mozilla.ai community |
 
@@ -120,8 +120,8 @@ Legend: ✅ full · 🟡 partial/different · ❌ absent
 
 | Feature | herdr | aoe | Quil |
 |---|:---:|:---:|:---:|
-| Worktree-per-session (auto branch + worktree) | ✅ | ✅ | ❌ |
-| Multi-repo workspace (one session, N repos) | ❌ | ✅ | ❌ |
+| Worktree-per-session (auto branch + worktree) | ✅ | ✅ | ✅ (tab opens onto a new worktree; close offers removal) |
+| Multi-repo workspace (one session, N repos) | ❌ | ✅ | ✅ (projects, v1.47 — and they may span hosts) |
 | Built-in diff viewer (review + edit) | ❌ | ✅ | ❌ |
 | Inline diff comments → prompt to agent | ❌ | ✅ | ❌ |
 | Lazygit / git-tool integration | 🟡 (plugin) | ✅ (tool sessions) | ✅ (Alt+G overlay) |
@@ -154,7 +154,7 @@ Legend: ✅ full · 🟡 partial/different · ❌ absent
 |---|:---:|:---:|:---:|
 | Themes (multiple, light/dark auto) | ✅ (18) | ✅ (8) | 🟡 minimal |
 | Sound notifications | ✅ | ✅ | ❌ |
-| OS/terminal desktop notifications | ✅ | ✅ (push) | ❌ (in-TUI sidebar) |
+| OS/terminal desktop notifications | ✅ | ✅ (push) | 🟡 Windows toasts + click-to-route; no macOS/Linux |
 | In-TUI notification center | 🟡 | ✅ | ✅ |
 | Repo config + lifecycle hooks | 🟡 | ✅ | ❌ |
 | Profiles (per-project workspaces) | 🟡 | ✅ | ❌ |
@@ -174,23 +174,29 @@ The most interesting capabilities Quil lacks or only partially supports, ranked
 by a blend of strategic impact and how differentiating they are. Effort is a rough
 T-shirt size. "Maps to" links a gap to an existing roadmap item it extends.
 
+The ranking is kept as it was first written — re-scoring it every release would
+destroy the record of what looked most urgent at the time, which is the only
+reason a list like this is worth keeping. Rows that have since shipped are struck
+through and marked instead, so the table stays readable as history *and* as a
+current to-do list.
+
 | # | Feature | Source | Why it matters | Effort | Impact | Maps to |
 |---|---|---|---|:---:|:---:|---|
 | 1 | Screen-content agent state detection (no hooks) | herdr, aoe | Blocked/working/done inferred from terminal output for *any* agent, zero hooks. Quil only pattern-matches idle. | M | ★★★ | process-health |
 | 2 | Broad agent support + detection registry | herdr, aoe | They detect ~13–18 agents (Codex, Gemini, Cursor, Copilot, Droid, Devin…); Quil ships 2. Starkest gap. | M | ★★★ | community-plugins |
-| 3 | Git worktree-per-session | herdr, aoe | Auto branch + worktree on session create, cleanup on delete. The #1 adoption driver for these tools. | M | ★★★ | workspace-files |
+| 3 | ~~Git worktree-per-session~~ **SHIPPED** | herdr, aoe | Auto branch + worktree on session create, cleanup on delete. The #1 adoption driver for these tools. A tab can open onto a new worktree (placeholder pane + spinner while `git worktree add` runs), and closing it offers to remove the worktree, naming what it holds. | M | ★★★ | workspace-files |
 | 4 | Built-in diff viewer (review + edit + commit) | aoe | Review agent changes without leaving the TUI. Table stakes for "review what the agent did". | M | ★★★ | new |
 | 5 | Executable/scriptable plugins (actions, event hooks, link handlers) | herdr, aoe | Any-language plugins that run logic, not just declare pane types. Unlocks a real ecosystem. | M | ★★★ | community-plugins, cross-pane-events |
 | 6 | Plugin marketplace (GitHub-topic index) | herdr, aoe | Discover + `install owner/repo`. Already partially planned. | M | ★★ | community-plugins |
 | 7 | General shell CLI to script the multiplexer | herdr, aoe | `quil pane split`, `quil tab create` from any script. MCP serves AI; humans/scripts have nothing. | M | ★★ | new |
-| 8 | Remote SSH thin-client attach (`--remote`) | herdr | Local client of a remote server; bridges local clipboard image paste into remote agents. | M | ★★ | session-sharing |
+| 8 | ~~Remote SSH thin-client attach (`--remote`)~~ **SHIPPED (v1.44)** | herdr | Local client of a remote server; bridges local clipboard image paste into remote agents. Quil went further than the gap asked: since v1.47 one client holds the local daemon and any number of remote ones at once. | M | ★★ | session-sharing |
 | 9 | Web dashboard (browser terminal) | aoe | Real terminal + diffs in the browser, installable PWA. The largest surface Quil is missing. | L | ★★★ | new |
 | 10 | Remote phone access (tunnel + QR/passphrase + push) | aoe | Check on agents from a phone via Tailscale/Cloudflare with two-factor pairing. | L | ★★ | session-sharing |
 | 11 | Container sandboxing (Docker/Podman) + shared auth volumes | aoe | Isolate agents in containers; authenticate in-container without re-login. | L | ★★ | new |
-| 12 | Multi-repo workspaces | aoe | One session/branch spanning several repos. | M | ★★ | workspace-files |
+| 12 | ~~Multi-repo workspaces~~ **SHIPPED (v1.47)** | aoe | One session/branch spanning several repos. Quil's projects each own a root directory and their own tabs — and a project can belong to a different machine, which aoe's workspaces do not span. | M | ★★ | workspace-files |
 | 13 | Inline diff comments → prompt to agent | aoe | Annotate a diff; comments assemble into one prompt back to the agent. Tight review loop. | M | ★★ | (extends #4) |
 | 14 | Sound notifications | herdr, aoe | Audible cue when an agent needs you. Cheap, immediately felt. | S | ★★ | notification-center |
-| 15 | OS/desktop notifications (beyond in-TUI sidebar) | herdr, aoe | OSC/`notify-send`/`terminal-notifier` so alerts leave the TUI (works over SSH). | S | ★★ | notification-center |
+| 15 | ~~OS/desktop notifications (beyond in-TUI sidebar)~~ **PARTLY SHIPPED** | herdr, aoe | OSC/`notify-send`/`terminal-notifier` so alerts leave the TUI (works over SSH). Windows toasts land, and a click routes to the pane that raised it. macOS and Linux are still open — no transport there carries a click back to a pane. | S | ★★ | notification-center |
 | 16 | One-command agent integration installer | herdr, aoe | `quil integration install <agent>` writes the agent's hooks for you. | M | ★★ | (extends #1/#2) |
 | 17 | Themes + light/dark auto-switch | herdr, aoe | 8–18 presets, follows host OSC 10/11. Quil's theming is minimal. | S–M | ★★ | new |
 | 18 | Session fork | aoe | Branch a conversation into a new independent session, parent untouched. | M | ★★ | new |

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -7,6 +7,7 @@
  * verification of profile ownership — machine-readable only.
  */
 import { SITE } from "@/data/seo";
+import { compareNav } from "@/data/competitors";
 
 interface FooterLink {
   href: string;
@@ -30,14 +31,9 @@ const sections: FooterSection[] = [
   },
   {
     title: "Compare",
-    links: [
-      { href: "/vs/herdr/",   text: "vs herdr"           },
-      { href: "/vs/aoe/",     text: "vs Agent of Empires" },
-      { href: "/vs/tmux/",    text: "vs tmux"       },
-      { href: "/vs/zellij/",  text: "vs Zellij"     },
-      { href: "/vs/wezterm/", text: "vs WezTerm"    },
-      { href: "/vs/screen/",  text: "vs GNU Screen" },
-    ],
+    // Same derived list the header dropdown renders, so the two can no
+    // longer disagree about which comparisons exist.
+    links: compareNav.map(({ href, label }) => ({ href, text: label })),
   },
   {
     title: "Docs",

--- a/site/src/components/Header.astro
+++ b/site/src/components/Header.astro
@@ -12,6 +12,7 @@
  * that utility overrides aren't needed).
  */
 import { SITE } from "@/data/seo";
+import { compareNav } from "@/data/competitors";
 
 // Every internal href carries its trailing slash — see
 // scripts/check-trailing-slash.mjs for why a slashless one is a bug and
@@ -24,12 +25,11 @@ const navLinks = [
   { href: "/blog/",     label: "blog"     },
 ];
 
-const compareLinks = [
-  { href: "/vs/tmux/",    label: "vs tmux"       },
-  { href: "/vs/zellij/",  label: "vs Zellij"     },
-  { href: "/vs/wezterm/", label: "vs WezTerm"    },
-  { href: "/vs/screen/",  label: "vs GNU Screen" },
-];
+// Derived from src/data/competitors.ts, never hand-listed here. This used
+// to be a literal array and it fell four pages behind the data file —
+// herdr and Agent of Empires shipped with /vs/ pages, a footer link, and
+// a "see also" tile, but no entry in the one menu most visitors use.
+const compareLinks = compareNav;
 
 // Both sides are compared slash-stripped. The hrefs above are canonical
 // (trailing slash) while `pathname` may arrive either way depending on

--- a/site/src/content/blog/resume-claude-code-session-after-reboot.md
+++ b/site/src/content/blog/resume-claude-code-session-after-reboot.md
@@ -38,7 +38,7 @@ Claude Code keeps each conversation as a session on your local machine. The tran
 When you reboot:
 
 - Every terminal process dies, including `claude`.
-- Your terminal multiplexer (if you use one) dies too — `tmux` and `zellij` survive a disconnected SSH session, but **not** a full host reboot.
+- Your terminal multiplexer (if you use one) dies too. `tmux` survives a disconnected SSH session but **not** a reboot. `zellij` does better — it rebuilds the layout from its cache — but it gives you back the *shape* of the workspace, not the running work, and it has no idea a `claude` session was ever in that pane.
 - The transcript file survives on disk, but nothing reattaches to it automatically. You're staring at a clean shell.
 
 So the *data* is still there. The problem is reconnecting to it.

--- a/site/src/data/competitors.ts
+++ b/site/src/data/competitors.ts
@@ -30,10 +30,10 @@ export const competitorMatrix: CompareRow[] = [
     feature: "Survives a full host reboot",
     quil: "yes",
     tmux: "no",
-    zellij: "no",
+    zellij: "partial",
     wezterm: "no",
     screen: "no",
-    note: "Quil's defining capability. Everyone else loses the session on reboot.",
+    note: "Quil's defining capability. Zellij is the one honest partial: session serialization is on by default, so after a reboot it brings back the layout, the tabs and the working directories, and offers each pane's command behind a `Press ENTER to run` prompt. What it does not bring back is the work — no running processes, no scrollback unless you turned that on, and no idea an AI session ever existed. tmux, WezTerm and Screen lose the session outright; tmux-resurrect gets tmux to roughly where Zellij already is.",
   },
   {
     feature: "AI session auto-resume (Claude Code, OpenCode)",
@@ -244,7 +244,7 @@ export const competitors: Record<CompetitorInfo["slug"], CompetitorInfo> = {
       {
         question: "What is the best tmux alternative that survives a reboot?",
         answer:
-          "tmux, Zellij, WezTerm and GNU Screen all lose their sessions when the host reboots — their persistence only lasts while the server process is alive. Quil was built specifically for this gap: its daemon snapshots the whole workspace to disk continuously, so after a reboot you type one command and the layout, working directories, scrollback, and AI sessions come back in under 30 seconds.",
+          "tmux, WezTerm and GNU Screen lose the session when the host reboots — their persistence only lasts while the server process is alive. Zellij is the exception, and a partial one: it serializes the session by default, so a reboot returns the layout, the tabs and the directories, with each command waiting behind a `Press ENTER to run` prompt. Nothing is still running, and an AI session comes back as a command line to re-type. Quil was built for that second half: its daemon snapshots the whole workspace to disk continuously, so after a reboot you type one command and the layout, working directories, scrollback, and AI sessions come back in under 30 seconds.",
       },
     ],
   },
@@ -256,11 +256,11 @@ export const competitors: Record<CompetitorInfo["slug"], CompetitorInfo> = {
     description:
       "Modern Rust terminal multiplexer with a friendly UX, WASM plugins, and sane defaults. Released in 2021.",
     positioning:
-      "Zellij is the closest competitor on UX — both tools prioritise gentle defaults and a modern feel. Where they diverge: Zellij is a multiplexer first, Quil is a workflow orchestrator first. Quil's typed panes, AI session resume, and reboot persistence address a problem Zellij considers out of scope.",
+      "Zellij is the closest competitor on UX — both tools prioritise gentle defaults and a modern feel. Where they diverge: Zellij is a multiplexer first, Quil is a workflow orchestrator first. Zellij is also the only classic multiplexer that gives you anything back after a reboot, so the honest question is not whether a session returns but what returns with it — Zellij rebuilds the layout and waits for you to re-run each command, while Quil restores the running workspace and the AI conversation attached to it.",
     keyStrength:
       "Modern UX, clean WASM plugin model, excellent defaults, discoverable status bar. Zellij users rarely need to read a manual.",
     keyGap:
-      "No concept of reboot-proof workflows or AI session continuity. Zellij sessions are runtime-only; a host reboot is final.",
+      "Zellij serializes a session to its cache folder by default, so a reboot gives you the shape back — tabs, panes, directories, and each pane's command waiting behind a `Press ENTER to run` prompt. It does not give you the work back: nothing is still running, scrollback is off unless you enabled it, and an AI session is just a command line to re-type. Quil restores the running workspace, and resumes the Claude Code or OpenCode conversation with its current session id.",
     migrationNote:
       "Zellij users will feel at home in Quil — both tools use Alt-based keys and avoid prefix chords by default. The main adjustment is Quil's typed panes (Terminal / AI / SSH / etc.), which Zellij doesn't have.",
     faq: [
@@ -362,36 +362,36 @@ export const competitors: Record<CompetitorInfo["slug"], CompetitorInfo> = {
     slug: "herdr",
     name: "herdr",
     description:
-      "A Rust terminal multiplexer purpose-built for AI coding agents — 'tmux, rebuilt for agents.' Single binary, its own PTY and VT engine, a socket API agents can drive, and a language-agnostic plugin system. Quil's closest philosophical twin.",
+      "A Rust terminal multiplexer purpose-built for AI coding agents — 'the runtime your coding agents live on.' Single binary, its own PTY and VT engine, a socket API agents can drive, and a language-agnostic plugin system. Quil's closest philosophical twin.",
     positioning:
-      "herdr and Quil made almost the same bet: build your own multiplexer, keep it a single lightweight binary, and make it agent-aware. herdr is further ahead on agent breadth (it detects ~18 agents and ships 14 integrations) and scriptable plugins; Quil is further ahead on native Windows and on speaking MCP, the protocol AI assistants already understand. The honest read: herdr is the stronger Unix-first agent fleet manager today, Quil is the stronger Windows-native, MCP-native one.",
+      "herdr and Quil made almost the same bet: build your own multiplexer, keep it a single lightweight binary, and make it agent-aware. herdr is further ahead on agent breadth (20+ agents detected, with native integrations for most of them) and on scriptable plugins; Quil is further ahead on native Windows and on speaking MCP, the protocol AI assistants already understand. The honest read: herdr is the stronger Unix-first agent fleet manager today, Quil is the stronger Windows-native, MCP-native one.",
     keyStrength:
-      "Agent breadth and extensibility. Detects ~18 agents with screen-content heuristics, installs native integrations with one command, exposes a full socket API + CLI that agents and scripts can drive, and runs language-agnostic plugins with actions, event hooks, and a GitHub-topic marketplace.",
+      "Agent breadth and extensibility. Detects 20+ agents with screen-content heuristics, installs native integrations with one command, exposes a full socket API + CLI that agents and scripts can drive, and runs language-agnostic plugins with actions, event hooks, and a marketplace.",
     keyGap:
-      "Native Windows is still beta, there is no MCP server (agents drive it through a bespoke socket API + an installed skill instead of a protocol assistants already speak), and it has no pane-notes editor or per-pane memory reporting.",
+      "Native Windows is still beta, there is no MCP server — herdr's own pitch is that agents talk to each other through it without one, so they drive it through a bespoke socket API and an installed skill instead of a protocol assistants already speak — and it has no pane-notes editor or per-pane memory reporting.",
     migrationNote:
       "herdr uses a tmux-style prefix (Ctrl+B) where Quil uses direct Alt-based keys. Both keep agents alive on detach and restore AI sessions. If you're on Windows without WSL, Quil is the smoother path; if you drive many different agents from Unix and want to script the multiplexer from a shell, herdr is very strong.",
     quilHeadline: "Native Windows. MCP-native. Notes + memory built in.",
     matrix: [
       { feature: "Own multiplexer + PTY (not a tmux wrapper)", quil: "yes", them: "yes" },
       { feature: "Survives a full host reboot", quil: "yes", them: "yes" },
-      { feature: "AI session auto-resume", quil: "yes", them: "yes", note: "herdr restores native sessions for ~14 agents; Quil for Claude Code + OpenCode." },
+      { feature: "AI session auto-resume", quil: "yes", them: "yes", note: "herdr restores native sessions for most of the agents it integrates with; Quil for Claude Code + OpenCode." },
       { feature: "Native Windows (no WSL)", quil: "yes", them: "partial", note: "herdr's native Windows support is a ConPTY beta; Quil ships bundled ConPTY/OpenConsole and a Windows clipboard image-paste proxy." },
       { feature: "MCP server for AI agents", quil: "yes", them: "no", note: "herdr exposes a bespoke socket API + an installed agent skill instead of the MCP protocol." },
       { feature: "Pane notes editor", quil: "yes", them: "no" },
       { feature: "Per-pane memory reporting", quil: "yes", them: "no" },
-      { feature: "Screen-content agent detection (no hooks)", quil: "partial", them: "yes", note: "Quil pattern-matches idle only; herdr ships updatable detection manifests for ~18 agents." },
-      { feature: "Breadth of agents detected", quil: "partial", them: "yes", note: "Quil: 2 deep + tools. herdr: ~18." },
+      { feature: "Screen-content agent detection (no hooks)", quil: "partial", them: "yes", note: "Quil pattern-matches idle only; herdr ships updatable detection manifests for every agent it lists." },
+      { feature: "Breadth of agents detected", quil: "partial", them: "yes", note: "Quil: 2 deep (Claude Code, OpenCode) + tools. herdr: 20+." },
       { feature: "One-command agent integration installer", quil: "no", them: "yes" },
-      { feature: "Git worktree-per-session", quil: "no", them: "yes" },
+      { feature: "Git worktree-per-session", quil: "yes", them: "yes", note: "Quil opens a tab straight onto a new worktree — the pane is a placeholder with a spinner while `git worktree add` runs, so a slow monorepo checkout can never be mistaken for an agent started in the wrong tree — and closing that tab or pane offers to remove the worktree, naming what it holds and refusing to call a dirty one clean." },
       { feature: "Executable plugins (actions / event hooks / link handlers)", quil: "partial", them: "yes", note: "Quil plugins are declarative TOML pane types; herdr runs any-language plugins." },
       { feature: "Plugin marketplace", quil: "no", them: "yes" },
       { feature: "General CLI to script the multiplexer", quil: "no", them: "yes", note: "Quil scripts via MCP (for AI); herdr adds a shell CLI for humans." },
       { feature: "Remote SSH thin-client attach", quil: "yes", them: "yes", note: "`quil --remote <host>` since v1.44; opens no port, reconnects on its own after a dropped link, and installs itself on a bare server." },
       { feature: "Several hosts in one window at once", quil: "yes", them: "no", note: "Since v1.47 a Quil client holds the local daemon and any number of remote ones together, each project tagged with the machine that owns it and each host with its own reconnect state. herdr's remote attach drives one server per client." },
       { feature: "Named sessions / live server handoff", quil: "no", them: "yes" },
-      { feature: "Sound + desktop notifications", quil: "partial", them: "yes", note: "Quil has an in-TUI notification center but no sound or OS notifications." },
-      { feature: "Themes with light/dark auto-switch", quil: "partial", them: "yes" },
+      { feature: "Sound + desktop notifications", quil: "partial", them: "yes", note: "Quil raises real Windows toasts when an agent parks on a prompt or finishes a turn, and clicking one routes you to the pane that sent it. Still missing: sound, and macOS/Linux — herdr does all three, and can hand the notification to the outer terminal as well as the OS." },
+      { feature: "Themes with light/dark auto-switch", quil: "partial", them: "yes", note: "Quil ships no theme presets — it asks the terminal for its real foreground and background (OSC 10/11) and renders against those, so it follows your terminal instead of theming itself. herdr carries named themes and switches between a light and a dark one when the terminal reports the change." },
     ],
     faq: [
       {
@@ -437,14 +437,14 @@ export const competitors: Record<CompetitorInfo["slug"], CompetitorInfo> = {
       { feature: "Web dashboard (browser terminal + diffs, PWA)", quil: "no", them: "yes" },
       { feature: "Remote phone access (tunnel + QR/passphrase + Web Push)", quil: "no", them: "yes" },
       { feature: "ACP structured view (plan / tool / approve cards)", quil: "no", them: "yes" },
-      { feature: "Git worktree-per-session", quil: "no", them: "yes" },
+      { feature: "Git worktree-per-session", quil: "yes", them: "yes", note: "Was a genuine gap until recently. A Quil tab can now open straight onto a new worktree, showing a placeholder pane with a spinner while `git worktree add` runs so a slow checkout is never mistaken for an agent started in the main tree, and closing the tab or pane offers to remove the worktree — naming what it holds, and refusing to call a dirty one clean." },
       { feature: "Multi-repo workspaces", quil: "yes", them: "yes", note: "Was a genuine gap until v1.47. Quil projects each own a root directory and their own tabs, so several repositories sit side by side in one window — and a project can belong to a different machine, which AoE's workspaces do not span." },
       { feature: "Built-in diff viewer (review + edit)", quil: "no", them: "yes" },
       { feature: "Container sandboxing (Docker/Podman/Apple)", quil: "no", them: "yes" },
       { feature: "Screen-content agent detection (no hooks)", quil: "partial", them: "yes" },
       { feature: "Breadth of agents supported", quil: "partial", them: "yes", note: "Quil: 2 deep + tools. AoE: ~13 terminal + 7 ACP." },
       { feature: "Session fork / import from disk", quil: "no", them: "yes" },
-      { feature: "Sound + push notifications", quil: "partial", them: "yes", note: "Quil has an in-TUI notification center but no sound or push." },
+      { feature: "Sound + push notifications", quil: "partial", them: "yes", note: "Quil raises real Windows toasts when an agent parks on a prompt or finishes a turn, and clicking one routes you to the pane that sent it. Still missing: sound, macOS/Linux, and anything that reaches a phone — AoE's Web Push does, which is the point of its browser surface." },
       { feature: "Session lifecycle mgmt (auto-stop idle, groups, archive)", quil: "no", them: "yes" },
     ],
     faq: [
@@ -471,3 +471,36 @@ export const competitors: Record<CompetitorInfo["slug"], CompetitorInfo> = {
     ],
   },
 };
+
+/**
+ * Display order for the compare navigation. The header dropdown and the
+ * footer column both render from this, so adding a /vs/ page is one edit
+ * and it appears in both — the header used to carry its own hardcoded
+ * copy, which is how herdr and Agent of Empires came to be missing from
+ * the dropdown for months while the footer listed all six.
+ *
+ * Typed as a Record over the slug union rather than a plain array on
+ * purpose: a competitor added to `competitors` without a rank here is a
+ * build error, not a page that quietly never appears in the nav. That is
+ * the exact failure this export exists to end, so it must not be
+ * reintroducible by omission.
+ */
+const compareNavOrder: Record<CompetitorInfo["slug"], number> = {
+  herdr: 1,
+  aoe: 2,
+  tmux: 3,
+  zellij: 4,
+  wezterm: 5,
+  screen: 6,
+};
+
+/** Ordered `{ href, label }` pairs for every /vs/ page. Hrefs carry the
+ *  trailing slash — see scripts/check-trailing-slash.mjs for why. */
+export const compareNav: { href: string; label: string }[] = (
+  Object.keys(competitors) as CompetitorInfo["slug"][]
+)
+  .sort((a, b) => compareNavOrder[a] - compareNavOrder[b])
+  .map((slug) => ({
+    href: `/vs/${slug}/`,
+    label: `vs ${competitors[slug].name}`,
+  }));

--- a/site/src/data/competitors.ts
+++ b/site/src/data/competitors.ts
@@ -33,7 +33,7 @@ export const competitorMatrix: CompareRow[] = [
     zellij: "partial",
     wezterm: "no",
     screen: "no",
-    note: "Quil's defining capability. Zellij is the one honest partial: session serialization is on by default, so after a reboot it brings back the layout, the tabs and the working directories, and offers each pane's command behind a `Press ENTER to run` prompt. What it does not bring back is the work — no running processes, no scrollback unless you turned that on, and no idea an AI session ever existed. tmux, WezTerm and Screen lose the session outright; tmux-resurrect gets tmux to roughly where Zellij already is.",
+    note: "Quil's defining capability. Zellij is the one honest partial: session serialization is on by default, so after a reboot it brings back the layout, the tabs and the working directories, and offers each pane's command behind a “Press ENTER to run” prompt. What it does not bring back is the work — no running processes, no scrollback unless you turned that on, and no idea an AI session ever existed. tmux, WezTerm and Screen lose the session outright; tmux-resurrect gets tmux to roughly where Zellij already is.",
   },
   {
     feature: "AI session auto-resume (Claude Code, OpenCode)",
@@ -244,7 +244,7 @@ export const competitors: Record<CompetitorInfo["slug"], CompetitorInfo> = {
       {
         question: "What is the best tmux alternative that survives a reboot?",
         answer:
-          "tmux, WezTerm and GNU Screen lose the session when the host reboots — their persistence only lasts while the server process is alive. Zellij is the exception, and a partial one: it serializes the session by default, so a reboot returns the layout, the tabs and the directories, with each command waiting behind a `Press ENTER to run` prompt. Nothing is still running, and an AI session comes back as a command line to re-type. Quil was built for that second half: its daemon snapshots the whole workspace to disk continuously, so after a reboot you type one command and the layout, working directories, scrollback, and AI sessions come back in under 30 seconds.",
+          "tmux, WezTerm and GNU Screen lose the session when the host reboots — their persistence only lasts while the server process is alive. Zellij is the exception, and a partial one: it serializes the session by default, so a reboot returns the layout, the tabs and the directories, with each command waiting behind a “Press ENTER to run” prompt. Nothing is still running, and an AI session comes back as a command line to re-type. Quil was built for that second half: its daemon snapshots the whole workspace to disk continuously, so after a reboot you type one command and the layout, working directories, scrollback, and AI sessions come back in under 30 seconds.",
       },
     ],
   },
@@ -260,7 +260,7 @@ export const competitors: Record<CompetitorInfo["slug"], CompetitorInfo> = {
     keyStrength:
       "Modern UX, clean WASM plugin model, excellent defaults, discoverable status bar. Zellij users rarely need to read a manual.",
     keyGap:
-      "Zellij serializes a session to its cache folder by default, so a reboot gives you the shape back — tabs, panes, directories, and each pane's command waiting behind a `Press ENTER to run` prompt. It does not give you the work back: nothing is still running, scrollback is off unless you enabled it, and an AI session is just a command line to re-type. Quil restores the running workspace, and resumes the Claude Code or OpenCode conversation with its current session id.",
+      "Zellij serializes a session to its cache folder by default, so a reboot gives you the shape back — tabs, panes, directories, and each pane's command waiting behind a “Press ENTER to run” prompt. It does not give you the work back: nothing is still running, scrollback is off unless you enabled it, and an AI session is just a command line to re-type. Quil restores the running workspace, and resumes the Claude Code or OpenCode conversation with its current session id.",
     migrationNote:
       "Zellij users will feel at home in Quil — both tools use Alt-based keys and avoid prefix chords by default. The main adjustment is Quil's typed panes (Terminal / AI / SSH / etc.), which Zellij doesn't have.",
     faq: [
@@ -383,7 +383,7 @@ export const competitors: Record<CompetitorInfo["slug"], CompetitorInfo> = {
       { feature: "Screen-content agent detection (no hooks)", quil: "partial", them: "yes", note: "Quil pattern-matches idle only; herdr ships updatable detection manifests for every agent it lists." },
       { feature: "Breadth of agents detected", quil: "partial", them: "yes", note: "Quil: 2 deep (Claude Code, OpenCode) + tools. herdr: 20+." },
       { feature: "One-command agent integration installer", quil: "no", them: "yes" },
-      { feature: "Git worktree-per-session", quil: "yes", them: "yes", note: "Quil opens a tab straight onto a new worktree — the pane is a placeholder with a spinner while `git worktree add` runs, so a slow monorepo checkout can never be mistaken for an agent started in the wrong tree — and closing that tab or pane offers to remove the worktree, naming what it holds and refusing to call a dirty one clean." },
+      { feature: "Git worktree-per-session", quil: "yes", them: "yes", note: "Quil opens a tab straight onto a new worktree — the pane is a placeholder with a spinner while git worktree add runs, so a slow monorepo checkout can never be mistaken for an agent started in the wrong tree — and closing that tab or pane offers to remove the worktree, naming what it holds and refusing to call a dirty one clean." },
       { feature: "Executable plugins (actions / event hooks / link handlers)", quil: "partial", them: "yes", note: "Quil plugins are declarative TOML pane types; herdr runs any-language plugins." },
       { feature: "Plugin marketplace", quil: "no", them: "yes" },
       { feature: "General CLI to script the multiplexer", quil: "no", them: "yes", note: "Quil scripts via MCP (for AI); herdr adds a shell CLI for humans." },
@@ -437,7 +437,7 @@ export const competitors: Record<CompetitorInfo["slug"], CompetitorInfo> = {
       { feature: "Web dashboard (browser terminal + diffs, PWA)", quil: "no", them: "yes" },
       { feature: "Remote phone access (tunnel + QR/passphrase + Web Push)", quil: "no", them: "yes" },
       { feature: "ACP structured view (plan / tool / approve cards)", quil: "no", them: "yes" },
-      { feature: "Git worktree-per-session", quil: "yes", them: "yes", note: "Was a genuine gap until recently. A Quil tab can now open straight onto a new worktree, showing a placeholder pane with a spinner while `git worktree add` runs so a slow checkout is never mistaken for an agent started in the main tree, and closing the tab or pane offers to remove the worktree — naming what it holds, and refusing to call a dirty one clean." },
+      { feature: "Git worktree-per-session", quil: "yes", them: "yes", note: "Was a genuine gap until recently. A Quil tab can now open straight onto a new worktree, showing a placeholder pane with a spinner while git worktree add runs so a slow checkout is never mistaken for an agent started in the main tree, and closing the tab or pane offers to remove the worktree — naming what it holds, and refusing to call a dirty one clean." },
       { feature: "Multi-repo workspaces", quil: "yes", them: "yes", note: "Was a genuine gap until v1.47. Quil projects each own a root directory and their own tabs, so several repositories sit side by side in one window — and a project can belong to a different machine, which AoE's workspaces do not span." },
       { feature: "Built-in diff viewer (review + edit)", quil: "no", them: "yes" },
       { feature: "Container sandboxing (Docker/Podman/Apple)", quil: "no", them: "yes" },

--- a/site/src/data/faq.ts
+++ b/site/src/data/faq.ts
@@ -15,7 +15,7 @@ export const homeFaq: FaqItem[] = [
   {
     question: "How is Quil different from tmux or Zellij?",
     answer:
-      "tmux and Zellij are terminal multiplexers — they survive network disconnects but not full host reboots. Quil survives reboots. It also understands pane types (a Claude Code pane resumes differently than an SSH pane), ships an MCP server for AI agents, and tracks per-pane notes alongside your work. For a deeper comparison, see /vs/tmux or /vs/zellij.",
+      "tmux and Zellij are terminal multiplexers — they survive network disconnects, but not a host reboot with your work still running. tmux loses the session outright; Zellij rebuilds the layout from its cache and waits for you to press ENTER on each command again. Quil brings the running workspace back. It also understands pane types (a Claude Code pane resumes differently than an SSH pane), ships an MCP server for AI agents, and tracks per-pane notes alongside your work. For a deeper comparison, see /vs/tmux or /vs/zellij.",
   },
   {
     question: "Can I use Quil on a remote server over SSH?",

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -90,8 +90,18 @@ const topFeatures = [
   },
 ];
 
+// Cells are "yes" | "no" | "partial", the same three states /vs/ pages use.
+// `.cmp-table .partial` already exists in ember.css, so a partial styles
+// itself — this table used to render every non-"yes" as ✕, which is what
+// let the home page keep saying Zellij has no reboot story after the
+// comparison data stopped saying it.
 const compareRows = [
-  { feature: "Host reboot survival",     values: ["yes", "no",  "no",  "no" ] },
+  // Zellij is a genuine partial: session serialization is on by default and
+  // restores the layout, tabs and directories. It does not restore running
+  // processes, and it has no notion of an AI session. The footnote under the
+  // table carries that distinction — a bare ~ with no explanation is the
+  // other way to be wrong here.
+  { feature: "Host reboot survival",     values: ["yes", "no",  "partial", "no" ] },
   { feature: "AI session resume",        values: ["yes", "no",  "no",  "no" ] },
   // Not "does it have a sidebar" — the claim is that the multiplexer knows an
   // agent is mid-turn vs waiting on a permission prompt vs done. That needs a
@@ -114,7 +124,7 @@ const compareTiles = [
   { slug: "herdr",   label: "herdr",             blurb: "The closest rival: a Rust agent multiplexer. Broader agent support; no native Windows, no MCP." },
   { slug: "aoe",     label: "Agent of Empires",  blurb: "A tmux-based agent manager with a web dashboard. Richer remote; WSL2-only, no MCP." },
   { slug: "tmux",    label: "tmux",       blurb: "The 2007 standard. Still the answer if you just need tabs on a remote host." },
-  { slug: "zellij",  label: "Zellij",     blurb: "The modern Rust option. Friendly UX, WASM plugins, no reboot story." },
+  { slug: "zellij",  label: "Zellij",     blurb: "The modern Rust option. Friendly UX, WASM plugins. A reboot returns the layout, not the work." },
   { slug: "wezterm", label: "WezTerm",    blurb: "A terminal emulator with multiplexer bolted on. Use both — they complement." },
   { slug: "screen",  label: "GNU Screen", blurb: "1987. Still on every Unix host. Not a dev-experience tool anymore." },
 ];
@@ -335,11 +345,12 @@ const revTimestamp = new Date().toISOString().slice(0, 10).replace(/-/g, "");
             Different <span class="flame-text">category.</span>
           </h2>
           <p style="margin-top:20px; color:var(--ink-2); font-size:16px; line-height:1.65; max-width:52ch;">
-            tmux and Zellij survive network disconnects but not host
-            reboots. WezTerm is a terminal emulator that happens to
-            multiplex. Screen is 38 years old. Quil is a workflow
-            orchestrator that treats your terminal as the source of
-            truth.
+            tmux survives a network disconnect but not a host reboot.
+            Zellij rebuilds the layout after one and waits for you to
+            re-run each command. WezTerm is a terminal emulator that
+            happens to multiplex. Screen is 38 years old. Quil is a
+            workflow orchestrator that treats your terminal as the
+            source of truth.
           </p>
 
           <div style="margin-top:24px; padding:16px 18px; border:1px solid var(--line-2); background:var(--bg-2);">
@@ -370,13 +381,22 @@ const revTimestamp = new Date().toISOString().slice(0, 10).replace(/-/g, "");
                   <td class="feat">{row.feature}</td>
                   {row.values.map((val) => (
                     <td class="val">
-                      <b class={val === "yes" ? "yes" : "no"}>{val === "yes" ? "✓" : "✕"}</b>
+                      <b class={val}>
+                        {val === "yes" ? "✓" : val === "partial" ? "~" : "✕"}
+                      </b>
                     </td>
                   ))}
                 </tr>
               ))}
             </tbody>
           </table>
+
+          <p style="margin-top:14px; font-size:12px; color:var(--ink-4); font-style:italic; max-width:64ch;">
+            ~ Zellij serializes a session by default, so a reboot returns the
+            layout, the tabs and the directories, each command waiting behind a
+            "Press ENTER to run" prompt. What it does not return is the running
+            work. <a href="/vs/zellij/" style="color:var(--flame);">vs Zellij →</a>
+          </p>
         </div>
 
         <div class="compare-tiles">


### PR DESCRIPTION
## Summary

- **The compare dropdown listed four of the six `/vs/` pages.** `Header.astro` kept its own hand-written array while `Footer.astro` and `ComparePage.astro` derived theirs from `competitors.ts`, so herdr and Agent of Empires had a page, a footer link and a "see also" tile, but no entry in the menu most visitors use. Both components now render from one ordered `compareNav` export — typed as a `Record` over the slug union rather than an array, so a competitor added without a nav rank is a build error rather than a page that quietly never appears.
- **The matrices claimed Quil lacks what it now ships.** Git worktree-per-session and desktop notifications were both marked absent on the herdr and aoe pages. herdr's own figures moved too (20+ agents detected, new tagline); exact counts are now ranges, which is what a competitor shipping weekly can be described by without going stale again.
- **Zellij's "survives a full host reboot" is `partial`, not `no`.** Session serialization is on by default and does restore the layout, tabs and working directories, with each command behind a `Press ENTER to run` prompt. What it does not restore is the running work — which is the distinction these pages exist to draw. The same overclaim appeared in the tmux FAQ, the home FAQ and one blog line; all four now agree.

`docs/competitive-analysis.md` carried both stale Quil facts plus two of its own (multi-repo workspaces, remote attach). Shipped rows are struck through and marked rather than re-scored, so the ranking stays readable as a record of what looked most urgent when it was written.

### On changing a claim in a competitor's favour

Zellij's row is the only one that moves against us, and it is the one worth being strict about. A reader can disprove "Zellij restores nothing after a reboot" with a single reboot, and a table caught wrong once is not read carefully again. The honest partial is also the stronger argument: Zellij gives back the *shape* of the workspace, Quil gives back the *work*, and saying so out loud is more persuasive than a column of red crosses.

## Verification

- `npm run build` in `site/` — passes. That chain runs `check-header-stacking.mjs`, `check-trailing-slash.mjs`, `astro check`, then `astro build`. 15 pages built.
- Rendered `/vs/herdr/` and `/vs/zellij/` in a browser against `astro preview`: all six entries in the dropdown, no overflow (`.dd-menu` has no height cap and the longest new label sits under its 200px `min-width`), and the menu now auto-opens on `/vs/herdr/` — it did not before, because `compareOpen` reads the same array that was missing the entry.
- Competitor claims re-checked against primary sources, not memory: [herdr configuration](https://herdr.dev/docs/configuration/) and [supported agents](https://herdr.dev/docs/agents/), the [AoE README](https://github.com/agent-of-empires/agent-of-empires) and [HTTP API docs](https://www.agent-of-empires.com/docs/api/), and [Zellij session resurrection](https://zellij.dev/documentation/session-resurrection). Confirmed still accurate and left alone: herdr has no MCP server and its native Windows is still beta; AoE is still tmux-based, WSL2-only on Windows, and exposes a REST API rather than MCP; Zellij's command palette is still a community plugin.

## Release impact

None. The diff is confined to `site/` and `docs/`, both on the shared denylist in `release.yml` and `ci.yml`, so the release job skips before it reads the commit type and no changelog fragment is required (`CONTRIBUTING.md`: site-only and docs-only PRs are exempt). `package-lock.json` is untouched — deps were installed with `npm ci`, not `npm install`.
