### PR TITLE
perf(tui): report CPU, goroutine and GC accounting in the perf log

### DIFF
--- a/.claude/rules/tui-rendering.md
+++ b/.claude/rules/tui-rendering.md
@@ -16,6 +16,8 @@ paths:
   - "**/internal/config/bindings*.go"
   - "**/internal/tui/oscfilter.go"
   - "**/internal/tui/splitdrag*.go"
+  - "**/internal/tui/perf*.go"
+  - "**/internal/tui/frame_*_test.go"
   - "**/internal/clipboard/**"
 ---
 
@@ -314,3 +316,64 @@ equivalence test fails, DELETE the helper rather than adjusting the test.
 **Image paste proxy**: `clipboard.ReadImage()` reads `CF_DIBV5`/`CF_DIB` on Windows (Unix is a stub), `dib.go` parses the DIB into an `image.Image` (24bpp BI_RGB, 32bpp BI_RGB and BI_BITFIELDS, top-down + bottom-up, all-zero-alpha promotion). `pasteClipboard` falls through to image when text is empty: saves PNG to `config.PasteDir()` (`~/.quil/paste/quil-paste-<timestamp>.png`) and types the path into the PTY. Works around the upstream Claude Code Windows clipboard bug (anthropics/claude-code#32791). Paste keys: `Ctrl+V` (kb.Paste — eaten by Windows Terminal), `Ctrl+Alt+V` and `F8` are hardcoded aliases; `F8` is the recommended Windows trigger because it has no AltGr ambiguity
 
 
+
+## Frame-cost instrumentation (`internal/tui/perf*.go`)
+
+`eventLoopStats` (`perf.go`) writes one INFO line every 5 s. Its shape:
+
+```
+perf window=5s | view(n= skipped= hidden= avg= max=) | pane-out(bytes= max-vt=) |
+  key-backlog-max=N | rt(cpu=/ gor= heap= gc= pause= assist=) | MsgType(n= avg= max=)
+```
+
+`rt(...)` (`perfruntime.go`) exists because the rest of the line can say a frame took
+900 ms but not WHY a frame doing the same work cost fourteen times more. Three
+hypotheses for the 2026-09 production stall — GC pressure, a large live VT heap, an
+expensive renderer state — each had to be reproduced in a benchmark before they could be
+ruled out, because the log could not separate them. **Read `cpu` against the View+Update
+time on the same line**: comparable means the work genuinely cost more (look inside
+quil); far below means the process was not running (look outside it).
+
+Three rules the fields obey, all load-bearing:
+
+- **`cpu` comes from the OS** — `getrusage(2)` / `GetProcessTimes`, in `perfcpu_unix.go`
+  and `perfcpu_windows.go`. NOT from `/cpu/classes/total` minus `/cpu/classes/idle`.
+  Those are a snapshot `work.cpuStats.accumulate` writes only from
+  `gcMarkTermination`, so they advance when a GC cycle COMPLETES and never otherwise.
+  Measured on Go 1.25: four goroutines burning CPU for 3 s with the collector off report
+  `0.000s`. A TUI collecting every ~9 minutes would have printed `cpu=0s/5s` in ~99
+  windows out of 100 — which this line's own reading rule calls "the process was off the
+  CPU". `TestProcessCPU_Advances_WithoutAGarbageCollection` fails against that
+  implementation and is the guard against reintroducing it.
+- **Two sentinels, never a zero.** `?` = could not be measured (metric absent, or a
+  counter that fell, meaning the samples did not come from one continuous run). `-` =
+  nothing was published to report; assist is accounted at mark termination, so a window
+  with no completed cycle has no assist figure. A `0s` in either position would be a
+  finding the reading does not support.
+- **Deltas, except `heap` and `gor`.** A cumulative counter on a process up for days
+  cannot show that this window differed from the last. `heap` is the heap the PREVIOUS
+  GC marked, so it holds between cycles — a step function by design, and `gc=` on the
+  same line says when it last moved. `resetCounters` must never zero `lastRuntime`: it is
+  the delta baseline, and zeroing it makes every later line read `?` while still looking
+  plausible.
+
+Sampled with `runtime/metrics`, not `runtime.ReadMemStats` — the latter stops the world,
+and instrumentation that pauses the program is a poor way to investigate pauses.
+`histogramTotal` sums with each bucket's UPPER bound: the bias is identical in both
+samples of a delta, so it cancels, and the +Inf final bucket must fall back to its lower
+bound or the duration conversion produces garbage that also poisons the next window.
+
+**Two reproduction harnesses**, both `t.Skip`-gated so they never join `dev.sh test` or
+CI (the large one holds ~1 GB and runs for minutes):
+
+| Env var | Test | Answers |
+|---|---|---|
+| `QUIL_GC_REPRO` | `TestFrameLatencyVsLiveHeap` | Does live heap size move frame latency? Three arms: 2000-line scrollback, 100-line, and 2000 at GOGC=10. |
+| `QUIL_STATE_SWEEP` | `TestFrameCostByModelState` | Does any model state (all panes blocked, notification sidebar open, scrolled back, selection held, wide-canvas off, 96 tabs) multiply frame cost? |
+
+Run them with a direct `docker run … -e QUIL_GC_REPRO=1`; `dev.sh test` passes no env
+vars and takes only one package argument. A frame classified as GC-affected is one where
+a cycle was IN PROGRESS (`/gc/cycles/started` > `/gc/cycles/total`), not merely one where
+a cycle finished — assists are charged across the whole mark phase, and the narrower test
+files every assisted frame but the last under "clean", biasing the result toward
+acquitting GC.

--- a/changelog.d/internal-perf-runtime-accounting.md
+++ b/changelog.d/internal-perf-runtime-accounting.md
@@ -1,0 +1,28 @@
+- **The TUI's 5-second perf summary now reports runtime accounting.** Each line
+  carries an `rt(...)` section: CPU time actually used during the window, live
+  heap, goroutine count, and the window's GC cycles, pause total and mark-assist
+  time.
+
+  The log could already say a frame took 900 ms. It could not say why a frame
+  doing the same work cost fourteen times more, and that gap is expensive: three
+  separate explanations for a production stall each had to be reproduced in a
+  benchmark before they could be ruled out, because nothing in the log could
+  distinguish them. CPU used, compared against the time the same window spent in
+  `View` and `Update`, separates "the work genuinely cost more" from "the process
+  was not running" — which are investigations in different places.
+
+  CPU comes from the operating system (`getrusage`, or `GetProcessTimes` on
+  Windows) rather than from Go's `/cpu/classes` metrics. Those advance only when
+  a garbage-collection cycle completes: measured on Go 1.25, three seconds of
+  saturated CPU with the collector off reports zero. A TUI collecting every few
+  minutes would have printed a confident `cpu=0s` in almost every window.
+
+  Two sentinels, never a fabricated zero: `?` means the figure could not be
+  measured, `-` means nothing was published to report.
+
+- **Two gated reproduction harnesses for frame cost** (`QUIL_GC_REPRO`,
+  `QUIL_STATE_SWEEP`). One builds a production-shaped workspace — 48 panes at the
+  adaptive scrollback depth, ~1 GB live — and measures frame latency against GC
+  activity; the other sweeps the model states a TUI can sit in for minutes and
+  reports each one's frame cost against a baseline. Both are skipped unless their
+  environment variable is set, so neither joins the ordinary test loop or CI.

--- a/internal/tui/frame_gc_repro_test.go
+++ b/internal/tui/frame_gc_repro_test.go
@@ -1,0 +1,594 @@
+package tui
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"runtime"
+	"runtime/debug"
+	"runtime/metrics"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/artyomsv/quil/internal/config"
+)
+
+// Reproduction harness for the production TUI stall.
+//
+// The symptom, measured from ~71 000 perf-log windows across two production
+// sessions: a frame normally costs 2-5 ms, but in episodes the SAME frame costs
+// 100-966 ms, and one 5 s perf ticker fired 8.1 s late — so the whole process
+// waits, not just the renderer. The episodes are not a leak (a session sat at
+// 75% slow frames in hour 31 and 0.0% in hour 34) and they carry LESS pane
+// output than a healthy window, not more. The one workload signal that tracks
+// them is that agents are mid-turn: workSpinnerTickMsg appears in 100% of slow
+// windows against 71% of healthy ones.
+//
+// The hypothesis under test is that the live VT heap is the cause: 48 panes
+// each holding the adaptive 2000-line scrollback keep ~1 GB live, and a
+// renderer that allocates per frame is then charged GC mark assists, which show
+// up as a frame that waits.
+//
+// The experiment is a CONTROL, not a stress test. Every arm builds the same
+// workspace, drives the same frames, and does byte-for-byte the same per-frame
+// work — View renders the visible screen, whose size does not depend on how
+// deep the scrollback behind it is. What varies is how many scrollback lines
+// are retained (the live heap) and, in the last arm, GOGC.
+//
+// Gated behind QUIL_GC_REPRO because the large arms hold ~1 GB and the run
+// takes minutes: it must never join the ordinary `dev.sh test` loop or CI.
+// Run it with:
+//
+//	docker run --rm -v "$PWD:/src" -v quil-gomod:/go/pkg/mod \
+//	  -v quil-gocache:/root/.cache/go-build -w //src -e QUIL_GC_REPRO=1 \
+//	  golang:1.25-alpine go test ./internal/tui/ -run TestFrameLatencyVsLiveHeap -v -timeout 40m
+const gcReproEnv = "QUIL_GC_REPRO"
+
+// reproPanes matches the production workspace the stall was measured on: 48
+// tabs, one pane each. Pane COUNT is what drives the adaptive scrollback depth
+// in production, so it is not a free parameter here.
+const reproPanes = 48
+
+// reproTermWidth/Height are the terminal the frames are rendered at. Scrollback
+// memory is per CELL, so the emulator width is as load-bearing as the depth —
+// filling a 2000-line scrollback on an 80-column grid would under-report the
+// live heap by more than half.
+const (
+	reproTermWidth  = 200
+	reproTermHeight = 50
+)
+
+// reproFrames is how many frames each arm drives.
+//
+// Sized from the first run of this harness rather than guessed: a frame
+// allocates ~350 KB, so at GOGC=100 over a ~1 GB live heap the collector does
+// not run until ~1 GB has been allocated — about 3000 frames. 12 000 frames is
+// several natural cycles, which is the minimum that can answer what a cycle
+// costs. The first version used 1200 and observed ZERO cycles; it measured the
+// absence of GC and would have read as "GC is innocent".
+const reproFrames = 12000
+
+// gcSnapshot is the subset of runtime/metrics that decides this question.
+//
+// ReadMemStats is deliberately NOT the primary source: it stops the world, and
+// a harness that perturbs the very pauses it measures cannot answer whether the
+// pauses are real. runtime/metrics reads without a stop-the-world. MemStats is
+// still sampled once per arm, for the live-heap number that is comparable with
+// the private-bytes figure taken from production.
+type gcSnapshot struct {
+	cycles     uint64        // /gc/cycles/total:gc-cycles
+	liveBytes  uint64        // /gc/heap/live:bytes
+	assistCPU  float64       // /cpu/classes/gc/mark/assist:cpu-seconds
+	gcTotalCPU float64       // /cpu/classes/gc/total:cpu-seconds
+	pauseTotal time.Duration // sum over /gc/pauses:seconds
+	allocBytes uint64        // /gc/heap/allocs:bytes
+
+	// Raw histogram state, kept so the PEAK can be computed over the delta
+	// between two snapshots.
+	//
+	// Reducing to a peak at read time was wrong and produced a number that read
+	// as this arm's worst pause while actually being the worst pause since the
+	// process started — including workspace construction, the forced settling
+	// collections, and every previous arm. The symptom was three arms printing
+	// an identical "worst pause bucket 1.835ms" and nobody noticing, because a
+	// cumulative maximum looks exactly like a real one.
+	//
+	// Counts are COPIED: metrics.Read documents that it may reuse the histogram
+	// it returns, so holding the slice would make the "before" snapshot mutate
+	// into the "after" one.
+	pauseBuckets, schedBuckets []float64
+	pauseCounts, schedCounts   []uint64
+}
+
+// copyHistogram snapshots a histogram's counts and bucket bounds.
+func copyHistogram(h *metrics.Float64Histogram) (buckets []float64, counts []uint64) {
+	if h == nil {
+		return nil, nil
+	}
+	return append([]float64(nil), h.Buckets...), append([]uint64(nil), h.Counts...)
+}
+
+// deltaPeak returns the largest bucket that gained a sample between two
+// readings of the same histogram — the worst value observed in that interval,
+// rather than the worst ever observed.
+func deltaPeak(buckets []float64, before, after []uint64) time.Duration {
+	var peak time.Duration
+	for i := range after {
+		gained := after[i]
+		if i < len(before) {
+			if after[i] <= before[i] {
+				continue
+			}
+			gained = after[i] - before[i]
+		}
+		if gained == 0 || i+1 >= len(buckets) {
+			continue
+		}
+		upper := buckets[i+1]
+		if upper > 1e18 || upper != upper { // +Inf or NaN
+			upper = buckets[i]
+		}
+		if d := time.Duration(upper * float64(time.Second)); d > peak {
+			peak = d
+		}
+	}
+	return peak
+}
+
+// gcMetricNames are read as one batch. Any name the running Go version does not
+// know comes back KindBad and is reported as absent rather than as zero — a
+// silent zero would read as "no assist time" and answer the question wrongly.
+var gcMetricNames = []string{
+	"/gc/cycles/total:gc-cycles",
+	"/gc/heap/live:bytes",
+	"/cpu/classes/gc/mark/assist:cpu-seconds",
+	"/cpu/classes/gc/total:cpu-seconds",
+	"/gc/pauses:seconds",
+	"/sched/latencies:seconds",
+	"/gc/heap/allocs:bytes",
+}
+
+// cycleMetric is read on its own once per frame. The full batch above includes
+// two histograms, and reading those 12 000 times would put the harness's own
+// cost inside the frame timings it exists to measure.
+//
+// Completed cycles are all Go offers. `metrics.All()` on Go 1.25 has
+// /gc/cycles/automatic, /forced and /total — every one a COMPLETION count — and
+// runtime.MemStats carries no in-progress flag either. See gcProximityFrames
+// for what this harness does about that.
+const cycleMetric = "/gc/cycles/total:gc-cycles"
+
+// readCycles samples the completed-GC-cycle counter.
+//
+// Returns ok=false rather than zero when the metric is unavailable. Zero here
+// would be the fabricated-zero failure the rest of this file is written to
+// avoid: run.cycles and gcFrames would both read 0 and the headline table would
+// report "no GC ran" for a run nobody measured. That guard is not theoretical —
+// it is what caught a first attempt at this classification reading a metric
+// name (/gc/cycles/started) that does not exist on any Go version.
+func readCycles() (uint64, bool) {
+	s := []metrics.Sample{{Name: cycleMetric}}
+	metrics.Read(s)
+	if s[0].Value.Kind() != metrics.KindUint64 {
+		return 0, false
+	}
+	return s[0].Value.Uint64(), true
+}
+
+// readGC samples the metrics above. missing names the metrics this Go build did
+// not supply, so a caller can say so instead of reporting a fabricated zero.
+func readGC() (gcSnapshot, []string) {
+	samples := make([]metrics.Sample, len(gcMetricNames))
+	for i, n := range gcMetricNames {
+		samples[i].Name = n
+	}
+	metrics.Read(samples)
+
+	var s gcSnapshot
+	var missing []string
+	for _, sample := range samples {
+		if sample.Value.Kind() == metrics.KindBad {
+			missing = append(missing, sample.Name)
+			continue
+		}
+		switch sample.Name {
+		case "/gc/cycles/total:gc-cycles":
+			s.cycles = sample.Value.Uint64()
+		case "/gc/heap/live:bytes":
+			s.liveBytes = sample.Value.Uint64()
+		case "/gc/heap/allocs:bytes":
+			s.allocBytes = sample.Value.Uint64()
+		case "/cpu/classes/gc/mark/assist:cpu-seconds":
+			s.assistCPU = sample.Value.Float64()
+		case "/cpu/classes/gc/total:cpu-seconds":
+			s.gcTotalCPU = sample.Value.Float64()
+		case "/gc/pauses:seconds":
+			h := sample.Value.Float64Histogram()
+			s.pauseTotal = histogramTotal(h)
+			s.pauseBuckets, s.pauseCounts = copyHistogram(h)
+		case "/sched/latencies:seconds":
+			s.schedBuckets, s.schedCounts = copyHistogram(sample.Value.Float64Histogram())
+		}
+	}
+	return s, missing
+}
+
+// reproArm is one leg of the control: same frames, same per-frame work.
+type reproArm struct {
+	name       string
+	scrollback int
+	// gogc is the GC percentage this arm runs at. 100 is what production uses
+	// (quil sets none). A lower value is a SENSITIVITY arm — it does not
+	// reproduce production's configuration, it forces cycles to happen often
+	// enough to measure what one cycle costs at this heap size.
+	gogc int
+}
+
+// buildReproModel builds a workspace shaped like the production one and fills
+// every pane's scrollback to the given depth. The panes are returned so the
+// caller can Dispose them.
+//
+// Order matters twice. The emulator is resized to the real terminal geometry
+// BEFORE any output is written, because x/vt lays out each scrollback line at
+// the width in force when the line scrolled off — filling first and resizing
+// after would retain 80-column lines and understate the heap. And the depth is
+// published through SetScrollbackLines before the panes are constructed,
+// because SetScrollbackSize is applied at emulator CREATION: x/vt reslices its
+// backing array rather than reallocating, so a depth set afterwards frees
+// nothing (see adaptiveScrollbackLines).
+func buildReproModel(tb testing.TB, scrollback, paneCount int) (Model, []*PaneModel) {
+	tb.Helper()
+
+	prev := explicitScrollback.Load()
+	SetScrollbackLines(scrollback)
+	tb.Cleanup(func() { explicitScrollback.Store(prev) })
+
+	projects := 3
+	ps := make([]*ProjectModel, projects)
+	for i := range ps {
+		ps[i] = &ProjectModel{ID: fmt.Sprintf("proj-%d", i), Name: fmt.Sprintf("project-%d", i)}
+	}
+
+	// Each pane is filled with 25% MORE lines than the scrollback holds, so
+	// every arm ends with a scrollback that is genuinely full and evicting.
+	// Filling exactly to the depth would leave the large arm one line short of
+	// the steady state the production panes have been in for hours.
+	fillLines := scrollback + scrollback/4
+
+	panes := make([]*PaneModel, 0, paneCount)
+	for i := 0; i < paneCount; i++ {
+		pane := NewPaneModel(fmt.Sprintf("pane-%d", i), 500*512)
+		// The pane area, not the terminal: one pane per tab, minus the project
+		// sidebar and the pane's own border.
+		pane.ResizeVT(reproTermWidth-defaultSidebarWidth-2, reproTermHeight-chromeHeight-2)
+		pane.Type = "claude-code"
+		pane.WideCanvas = true
+		for l := 0; l < fillLines; l++ {
+			pane.AppendOutput([]byte(realisticPaneLines[l%len(realisticPaneLines)]))
+		}
+		// Mid-turn, like the ~25 working panes the stall episodes coincide
+		// with. This is what keeps the work spinner running, and the spinner is
+		// what makes production rebuild a frame five times a second.
+		pane.working = true
+		pane.turnActive = true
+
+		tab := tabWith(pane)
+		tab.Name = fmt.Sprintf("tab-%d", i)
+		ps[i%projects].tabs = append(ps[i%projects].tabs, tab)
+		panes = append(panes, pane)
+	}
+
+	m := Model{
+		cfg:           config.Default(),
+		projects:      ps,
+		activeProject: 0,
+		sidebarOpen:   true,
+		sidebarWidth:  defaultSidebarWidth,
+		width:         reproTermWidth,
+		height:        reproTermHeight,
+		termFocused:   true,
+		notifications: NewNotificationCenter(30, 50),
+		mcpHighlights: map[string]bool{},
+		perfStats:     newEventLoopStats(),
+	}
+	m.viewCache = &viewCacheBox{}
+	return m, panes
+}
+
+// gcProximityFrames is how many frames before a completed cycle count as
+// GC-adjacent.
+//
+// A PROXIMITY WINDOW, not phase detection, and the distinction is forced rather
+// than chosen: Go exposes no "GC is running" signal. `metrics.All()` on Go 1.25
+// offers only completed-cycle counters (/gc/cycles/automatic, /forced, /total)
+// and runtime.MemStats has no in-progress flag either.
+//
+// That matters because the narrow question — "did a cycle finish during THIS
+// frame?" — marks exactly one frame per cycle and files every other assisted
+// frame under "clean". Mark assists are charged across the whole concurrent
+// mark phase, which spans many frames, so the narrow test biases the comparison
+// toward acquitting GC. Since the mark phase cannot be observed, the honest
+// substitute is a generous window ending at the completion: at these frame
+// rates a mark phase over a ~1 GB heap is far shorter than 100 frames, so the
+// window contains it, at the cost of also containing innocent frames. That
+// error direction is the safe one — it can only make GC look WORSE.
+const gcProximityFrames = 100
+
+// frameRun is what one arm's animation produced.
+type frameRun struct {
+	sorted []time.Duration
+	// order holds the same durations in the order they were measured, which is
+	// what the proximity pass needs and what sorting destroys.
+	order []time.Duration
+	// cycleAt holds the frame index each completed cycle was observed at.
+	cycleAt []int
+
+	gcFrames int
+	// gcMax is the worst frame within gcProximityFrames of a completed cycle;
+	// cleanMax the worst of the rest. If GC is the mechanism, the two are far
+	// apart. If they are the same, the tail is not made of GC.
+	//
+	// NEITHER is what the falsification rests on. That rests on the OVERALL max
+	// in the percentile line, which needs no classification to be believed.
+	gcMax, cleanMax time.Duration
+	cycles          uint64
+}
+
+// classify fills gcFrames/gcMax/cleanMax from order and cycleAt.
+func (r *frameRun) classify() {
+	near := make([]bool, len(r.order))
+	for _, at := range r.cycleAt {
+		lo := at - gcProximityFrames
+		if lo < 0 {
+			lo = 0
+		}
+		for i := lo; i <= at && i < len(near); i++ {
+			near[i] = true
+		}
+	}
+	for i, d := range r.order {
+		if near[i] {
+			r.gcFrames++
+			if d > r.gcMax {
+				r.gcMax = d
+			}
+		} else if d > r.cleanMax {
+			r.cleanMax = d
+		}
+	}
+}
+
+// driveFrames runs the animation production runs.
+//
+// The per-frame work is deliberately identical in every arm: the work spinner
+// advances (which is what invalidates the render caches in production), and
+// every eighth frame the active pane receives one line of output. Neither
+// depends on scrollback depth, so a latency difference between arms is
+// attributable to the heap and to GOGC, and to nothing else.
+func driveFrames(tb testing.TB, m *Model, frames int) frameRun {
+	tb.Helper()
+	durations := make([]time.Duration, 0, frames)
+	active := m.activeTabModel().Leaves()[0]
+
+	_ = m.View() // prime every pane cache; the first frame is not a sample
+
+	first, ok := readCycles()
+	if !ok {
+		tb.Fatal("the completed-GC-cycle counter is unavailable — this harness cannot classify " +
+			"frames without it, and reporting zero cycles would read as 'no GC ran'")
+	}
+	lastFinished := first
+	var run frameRun
+
+	for i := 0; i < frames; i++ {
+		m.workSpinnerFrame++
+		for _, tab := range m.allTabs() {
+			if tab.Root == nil {
+				continue
+			}
+			for _, p := range tab.Leaves() {
+				if p != nil && p.working {
+					p.workFrame = m.workSpinnerFrame
+				}
+			}
+		}
+		if i%8 == 0 {
+			active.AppendOutput([]byte(realisticPaneLines[i%len(realisticPaneLines)]))
+		}
+
+		start := time.Now()
+		_ = m.View()
+		d := time.Since(start)
+		durations = append(durations, d)
+
+		// Read AFTER the frame is timed, so the metrics call is never inside a
+		// sample. It perturbs the FOLLOWING frame, identically in every arm, so
+		// the control holds.
+		if finished, ok := readCycles(); ok && finished != lastFinished {
+			lastFinished = finished
+			run.cycleAt = append(run.cycleAt, i)
+		}
+	}
+	run.cycles = lastFinished - first
+	run.order = durations
+	run.classify()
+
+	sorted := append([]time.Duration(nil), durations...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	run.sorted = sorted
+	return run
+}
+
+// pct returns the p-th percentile of an already-sorted slice.
+func pct(sorted []time.Duration, p float64) time.Duration {
+	if len(sorted) == 0 {
+		return 0
+	}
+	i := int(p / 100 * float64(len(sorted)))
+	if i >= len(sorted) {
+		i = len(sorted) - 1
+	}
+	return sorted[i]
+}
+
+// TestFrameLatencyVsLiveHeap answers one falsifiable question: does the live VT
+// heap reproduce the production tail — occasional View calls of 100 ms and up
+// while the work per frame is unchanged?
+//
+// It asserts nothing about absolute timings, because a container's frame cost
+// is not the user's. What it reports is the SHAPE: each arm's tail, the live
+// heap it holds, how many GC cycles ran, and whether the worst frames are the
+// ones a cycle completed in. A confirmation looks like a large-heap arm whose
+// worst frames are one to two orders above its own median AND land on GC
+// frames. Anything else falsifies the hypothesis, which is equally a result.
+func TestFrameLatencyVsLiveHeap(t *testing.T) {
+	if os.Getenv(gcReproEnv) == "" {
+		t.Skipf("set %s=1 to run the live-heap reproduction (holds ~1 GB, takes minutes)", gcReproEnv)
+	}
+
+	arms := []reproArm{
+		// The floor of the adaptive policy (minAdaptiveScrollbackLines) is what
+		// 48 production panes actually get, at the GOGC production runs.
+		{name: "large-heap/gogc-100", scrollback: 2000, gogc: 100},
+		// Same panes, same frames, a heap too small to matter.
+		{name: "small-heap/gogc-100", scrollback: 100, gogc: 100},
+		// Sensitivity, not a reproduction: GOGC low enough that cycles are
+		// frequent, so the cost of ONE cycle over a ~1 GB live heap is measured
+		// directly rather than inferred from how rarely it happened.
+		{name: "large-heap/gogc-10", scrollback: 2000, gogc: 10},
+	}
+
+	type result struct {
+		arm       reproArm
+		run       frameRun
+		live      uint64
+		heapAlloc uint64
+		before    gcSnapshot
+		after     gcSnapshot
+		buildTime time.Duration
+	}
+	var results []result
+
+	for _, arm := range arms {
+		buildStart := time.Now()
+		m, panes := buildReproModel(t, arm.scrollback, reproPanes)
+		buildTime := time.Since(buildStart)
+
+		// Settle before measuring: the fill above is a huge allocation burst,
+		// and a cycle still draining from it would be charged to the first
+		// frames of the run rather than to the fill that caused it.
+		//
+		// GOGC is process-global, so the restore is registered with t.Cleanup
+		// as well as run at the end of the loop body: a t.Fatal mid-arm would
+		// otherwise leave the whole test binary at the sensitivity arm's
+		// GOGC=10, and every test scheduled after it would run under a
+		// collector nobody configured.
+		prevGOGC := debug.SetGCPercent(arm.gogc)
+		t.Cleanup(func() { debug.SetGCPercent(prevGOGC) })
+		runtime.GC()
+		runtime.GC()
+
+		before, missing := readGC()
+		if len(missing) > 0 {
+			t.Logf("NOTE: this Go build does not supply %v — those columns are absent, not zero", missing)
+		}
+
+		run := driveFrames(t, &m, reproFrames)
+		after, _ := readGC()
+
+		var ms runtime.MemStats
+		runtime.ReadMemStats(&ms)
+
+		results = append(results, result{
+			arm: arm, run: run, live: after.liveBytes, heapAlloc: ms.HeapAlloc,
+			before: before, after: after, buildTime: buildTime,
+		})
+
+		// Dispose every pane before the next arm builds. Without this the arms
+		// are not independent: each emulator is held live by its own
+		// drainVTResponses goroutine, so dropping the Model frees nothing and
+		// the "small heap" arm runs on top of the large arm's gigabyte. The
+		// first version of this harness omitted it and reported the SMALL arm
+		// holding MORE live heap than the large one, which is the shape of a
+		// broken control rather than a finding.
+		for _, p := range panes {
+			p.Dispose()
+		}
+		debug.SetGCPercent(prevGOGC)
+		runtime.GC()
+		debug.FreeOSMemory()
+	}
+
+	t.Logf("workspace: %d panes, %dx%d terminal, %d frames per arm",
+		reproPanes, reproTermWidth, reproTermHeight, reproFrames)
+	for _, r := range results {
+		s := r.run.sorted
+		t.Logf("")
+		t.Logf("=== %s ===", r.arm.name)
+		t.Logf("  live heap        %.0f MB (MemStats HeapAlloc %.0f MB), fill took %v",
+			float64(r.live)/(1<<20), float64(r.heapAlloc)/(1<<20), r.buildTime.Round(time.Millisecond))
+		t.Logf("  frame p50 %v  p90 %v  p99 %v  p99.9 %v  max %v",
+			pct(s, 50).Round(time.Microsecond), pct(s, 90).Round(time.Microsecond),
+			pct(s, 99).Round(time.Microsecond), pct(s, 99.9).Round(time.Microsecond),
+			s[len(s)-1].Round(time.Microsecond))
+		t.Logf("  tail ratio max/p50 %.1fx", float64(s[len(s)-1])/float64(pct(s, 50)))
+		t.Logf("  GC cycles during run %d, frames within %d of one %d/%d",
+			r.run.cycles, gcProximityFrames, r.run.gcFrames, reproFrames)
+		t.Logf("  worst frame within %d frames of a completed cycle %v, worst frame outside that window %v",
+			gcProximityFrames, r.run.gcMax.Round(time.Microsecond), r.run.cleanMax.Round(time.Microsecond))
+		t.Logf("  mark-assist CPU %.3fs, GC CPU total %.3fs, GC pause total %v, worst pause IN THIS ARM %v",
+			r.after.assistCPU-r.before.assistCPU, r.after.gcTotalCPU-r.before.gcTotalCPU,
+			(r.after.pauseTotal - r.before.pauseTotal).Round(time.Microsecond),
+			deltaPeak(r.after.pauseBuckets, r.before.pauseCounts, r.after.pauseCounts).Round(time.Microsecond))
+		t.Logf("  allocated during run %.0f MB, worst scheduler latency IN THIS ARM %v",
+			float64(r.after.allocBytes-r.before.allocBytes)/(1<<20),
+			deltaPeak(r.after.schedBuckets, r.before.schedCounts, r.after.schedCounts).Round(time.Microsecond))
+	}
+}
+
+// TestDeltaPeak_IgnoresSamplesFromBeforeTheInterval is the guard for the bug
+// this replaced.
+//
+// The previous code reduced each histogram to a peak AT READ TIME, so the
+// "worst pause" printed beside an arm was the worst since the process started —
+// workspace construction, the forced settling collections, and every earlier
+// arm included. Three arms printed an identical 1.835 ms and it read as a real
+// measurement, because a cumulative maximum looks exactly like one.
+//
+// Not gated: pure, instant, and it is the assertion that keeps the reporting
+// honest, so it belongs in the ordinary suite rather than behind QUIL_GC_REPRO.
+func TestDeltaPeak_IgnoresSamplesFromBeforeTheInterval(t *testing.T) {
+	// Buckets: [0,1ms) [1ms,10ms) [10ms,100ms)
+	buckets := []float64{0, 0.001, 0.01, 0.1}
+
+	t.Run("a big sample already present is not attributed to this interval", func(t *testing.T) {
+		before := []uint64{5, 0, 3} // three 100 ms-bucket pauses, all historical
+		after := []uint64{9, 0, 3}  // only the 1 ms bucket gained
+		if got := deltaPeak(buckets, before, after); got != time.Millisecond {
+			t.Errorf("deltaPeak() = %v, want 1ms — a pre-existing sample leaked into the interval", got)
+		}
+	})
+
+	t.Run("a big sample gained during the interval is reported", func(t *testing.T) {
+		before := []uint64{5, 0, 3}
+		after := []uint64{5, 0, 4}
+		if got := deltaPeak(buckets, before, after); got != 100*time.Millisecond {
+			t.Errorf("deltaPeak() = %v, want 100ms", got)
+		}
+	})
+
+	t.Run("no change at all reports nothing", func(t *testing.T) {
+		counts := []uint64{5, 2, 3}
+		if got := deltaPeak(buckets, counts, counts); got != 0 {
+			t.Errorf("deltaPeak() = %v, want 0 — an unchanged histogram has no peak for this interval", got)
+		}
+	})
+
+	t.Run("an infinite final bound falls back to its lower bound", func(t *testing.T) {
+		inf := []float64{0, 0.001, math.Inf(1)}
+		if got := deltaPeak(inf, []uint64{0, 0}, []uint64{0, 1}); got != time.Millisecond {
+			t.Errorf("deltaPeak() = %v, want 1ms — the +Inf bound leaked into the duration", got)
+		}
+	})
+}

--- a/internal/tui/frame_state_sweep_test.go
+++ b/internal/tui/frame_state_sweep_test.go
@@ -1,0 +1,215 @@
+package tui
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"runtime/debug"
+	"testing"
+	"time"
+
+	"github.com/artyomsv/quil/internal/ipc"
+)
+
+// State sweep for the production TUI stall.
+//
+// The live-heap reproduction (frame_gc_repro_test.go) falsified GC. What the
+// perf log says next is that in a slow window View is ~8x slower AND Update is
+// ~8x slower, on the same work — so whatever it is raises the cost of the whole
+// frame rather than one renderer stage. The slow windows also come in BURSTS
+// (runs of up to 33 consecutive 5 s windows, where random scatter at the
+// observed 5.8% rate predicts runs of 4 at most), which is the shape of a STATE
+// the model enters and later leaves, not of a random event.
+//
+// This sweep drives identical frames against one model state at a time and
+// reports each state's frame cost against a baseline. It is looking for a state
+// that costs an order of magnitude, because that is the size of the effect the
+// production log shows. A state that costs 20% is not the answer.
+//
+// Same gate as the heap reproduction, and deliberately much cheaper: the heap
+// is irrelevant here (that is what the other test established), so the
+// scrollback is shallow and the run is short.
+const stateSweepEnv = "QUIL_STATE_SWEEP"
+
+// sweepFrames is per state. Short, because this is a search for an
+// order-of-magnitude effect rather than a measurement of a small one.
+const sweepFrames = 1500
+
+// sweepState is one model configuration to measure. mutate runs after the
+// workspace is built and before any frame is drawn.
+type sweepState struct {
+	name string
+	// panes overrides the workspace size for this state. Zero means reproPanes.
+	panes  int
+	mutate func(m *Model, panes []*PaneModel)
+}
+
+// TestFrameCostByModelState measures the frame cost of each model state a
+// production TUI can be sitting in for minutes at a time.
+//
+// It asserts nothing: absolute frame cost in a container is not the user's, and
+// the question is comparative. What it reports is each state's p50 and max
+// against the baseline, so a state that multiplies frame cost stands out
+// without a threshold anyone has to justify.
+func TestFrameCostByModelState(t *testing.T) {
+	if os.Getenv(stateSweepEnv) == "" {
+		t.Skipf("set %s=1 to run the model-state frame sweep", stateSweepEnv)
+	}
+
+	states := []sweepState{
+		{name: "baseline", mutate: func(*Model, []*PaneModel) {}},
+
+		// Every pane parked waiting on the user. This is what the daemon
+		// announces in the mass "Waiting for input" bursts that precede the
+		// longest stalls in the log — 30 panes flipping within three seconds.
+		{name: "all-panes-blocked", mutate: func(m *Model, panes []*PaneModel) {
+			for _, p := range panes {
+				p.blockedSince = time.Now()
+				p.blockedReason = "Bash"
+				p.working = false
+				p.turnActive = false
+			}
+		}},
+
+		// Work finished unnoticed on every pane: green borders plus the
+		// sidebar's per-pane attention marks.
+		{name: "all-panes-unseen", mutate: func(m *Model, panes []*PaneModel) {
+			for _, p := range panes {
+				p.unseen = true
+			}
+		}},
+
+		// The notification sidebar open and full. It is composited over the
+		// frame on EVERY View, so a costly one is paid per frame for as long as
+		// the user leaves it open — which is the burst shape.
+		{name: "notif-sidebar-open-full", mutate: func(m *Model, panes []*PaneModel) {
+			m.notifications.visible = true
+			for i := 0; i < 50; i++ {
+				m.notifications.AddEvent(ipc.PaneEventPayload{
+					ID:        fmt.Sprintf("ev-%d", i),
+					PaneID:    panes[i%len(panes)].ID,
+					PaneName:  fmt.Sprintf("pane %d", i),
+					Type:      "output_idle",
+					Title:     "Waiting for input",
+					Message:   "claude-code is waiting for input on a long-running turn",
+					Severity:  "info",
+					Timestamp: time.Now().Unix(),
+				})
+			}
+		}},
+
+		// Scrolled back into history. maxScroll and the scrollback slice are
+		// walked per frame, and the pane render cache keys on scrollBack, so a
+		// user parked in history rebuilds from a different code path than the
+		// live-tail one every other measurement here uses.
+		{name: "active-pane-scrolled-back", mutate: func(m *Model, panes []*PaneModel) {
+			// maxScroll(), not a literal: a literal larger than the buffer
+			// still works (ScrollUp clamps) but reads like a bug to the next
+			// person, and it silently stops meaning "as far back as it goes"
+			// the moment sweepScrollback changes.
+			p := m.activeTabModel().Leaves()[0]
+			p.ScrollUp(p.maxScroll())
+		}},
+
+		// A selection held open across frames. renderContent honours it per
+		// row, and it invalidates the pane cache while it is being dragged.
+		{name: "selection-held", mutate: func(m *Model, panes []*PaneModel) {
+			active := m.activeTabModel().Leaves()[0]
+			m.selection = &Selection{
+				PaneID: active.ID,
+				Anchor: SelectionAnchor{Line: 0, Col: 0},
+				Cursor: SelectionAnchor{Line: 40, Col: 150},
+			}
+		}},
+
+		// Wide canvas OFF, which puts the pane into the wrapped-preview render
+		// instead of the native one.
+		//
+		// The emulator is deliberately left at the wide size buildReproModel
+		// gave it. In production, clearing WideCanvas also resizes the VT, so
+		// this arm measures a preview render over a WIDER grid than production
+		// would have — the pessimistic side, which is the right one for a
+		// search whose question is "can any state cost an order of magnitude".
+		{name: "wide-canvas-off", mutate: func(m *Model, panes []*PaneModel) {
+			for _, p := range panes {
+				p.WideCanvas = false
+			}
+		}},
+
+		// Twice the workspace. The sidebar and tab bar walk every tab in the
+		// workspace on every frame, so this is the one state whose cost is
+		// known in advance to grow — it is the control that proves the sweep
+		// can detect a real effect at all.
+		{name: "96-tabs", panes: reproPanes * 2, mutate: func(*Model, []*PaneModel) {}},
+	}
+
+	type row struct {
+		name           string
+		panes          int
+		p50, p99, peak time.Duration
+	}
+	var rows []row
+	var basis time.Duration
+
+	for _, st := range states {
+		panesWanted := reproPanes
+		if st.panes > 0 {
+			panesWanted = st.panes
+		}
+		m, panes := buildReproModel(t, sweepScrollback, panesWanted)
+		st.mutate(&m, panes)
+
+		// Settle before measuring, as the heap reproduction does. Building and
+		// filling a fresh 48-pane workspace is a large allocation burst, and
+		// the previous state's disposed one is still garbage: without this, a
+		// collection caused by setup — or by the state before — lands inside
+		// this state's frames and shows up in ITS p99 and max, which are then
+		// compared against a baseline that did not pay for it. Two passes
+		// because the first can resurrect finalizable objects into the second's
+		// work.
+		runtime.GC()
+		runtime.GC()
+
+		run := driveFrames(t, &m, sweepFrames)
+		s := run.sorted
+		r := row{name: st.name, panes: panesWanted, p50: pct(s, 50), p99: pct(s, 99), peak: s[len(s)-1]}
+		if st.name == "baseline" {
+			basis = r.p50
+		}
+		rows = append(rows, r)
+
+		// Dispose AND collect. Each pane's emulator is held live by its own
+		// drainVTResponses goroutine, so dropping the Model frees nothing;
+		// leaving the corpse for the next state to collect is what puts one
+		// state's garbage inside another state's measurement.
+		for _, p := range panes {
+			p.Dispose()
+		}
+		runtime.GC()
+		debug.FreeOSMemory()
+	}
+
+	// The multiplier column is meaningless without a baseline, and a baseline
+	// only exists if the "baseline" state ran. Reordering the slice would
+	// otherwise silently print "—" for every row above it and no one would be
+	// told the comparison had stopped happening.
+	if basis <= 0 {
+		t.Fatalf("no baseline p50 recorded — the sweep needs a state named %q", "baseline")
+	}
+
+	t.Logf("%d frames per state, %dx%d terminal (pane count per row)",
+		sweepFrames, reproTermWidth, reproTermHeight)
+	t.Logf("%-28s %6s %10s %10s %10s %8s", "state", "panes", "p50", "p99", "max", "vs base")
+	for _, r := range rows {
+		t.Logf("%-28s %6d %10v %10v %10v %7.2fx", r.name, r.panes,
+			r.p50.Round(time.Microsecond), r.p99.Round(time.Microsecond),
+			r.peak.Round(time.Microsecond), float64(r.p50)/float64(basis))
+	}
+}
+
+// sweepScrollback is the per-pane depth every state is built at.
+//
+// Shallow deliberately: the heap reproduction established that scrollback depth
+// does not move frame cost, so paying 16 s of fill per state here would buy
+// nothing and would make the sweep too slow to iterate on.
+const sweepScrollback = 200

--- a/internal/tui/perf.go
+++ b/internal/tui/perf.go
@@ -84,6 +84,11 @@ type eventLoopStats struct {
 	// maxSinceKey correctly.
 	sinceLastKey int64
 	maxSinceKey  int64
+
+	// lastRuntime is the runtime/metrics reading taken at the previous flush.
+	// The perf line reports DELTAS against it — see perfruntime.go for why a
+	// cumulative counter cannot answer the question this log is read to answer.
+	lastRuntime runtimeSample
 }
 
 type perfBucket struct {
@@ -94,8 +99,9 @@ type perfBucket struct {
 
 func newEventLoopStats() *eventLoopStats {
 	return &eventLoopStats{
-		lastFlush: time.Now(),
-		byType:    make(map[string]*perfBucket),
+		lastFlush:   time.Now(),
+		byType:      make(map[string]*perfBucket),
+		lastRuntime: readRuntimeSample(),
 	}
 }
 
@@ -199,7 +205,14 @@ func (s *eventLoopStats) flush() {
 	if s == nil {
 		return
 	}
-	window := time.Since(s.lastFlush)
+	// ONE instant closes this window and opens the next. Taking `window` here
+	// and letting resetCounters call time.Now() again at the bottom would leave
+	// the log write itself outside both windows, so the CPU delta would cover a
+	// longer span than the `window` it is printed against — and cpu/window
+	// would read high by exactly the cost of a blocking disk write, which is
+	// one of the things this line exists to detect.
+	now := time.Now()
+	window := now.Sub(s.lastFlush)
 	breakdown := s.formatBreakdown()
 
 	var viewAvg time.Duration
@@ -207,15 +220,24 @@ func (s *eventLoopStats) flush() {
 		viewAvg = time.Duration(s.viewTotalNs / s.viewCount)
 	}
 
-	logger.Info("perf window=%s | view(n=%d skipped=%d hidden=%d avg=%s max=%s) | pane-out(bytes=%d max-vt=%s) | key-backlog-max=%d | %s",
+	// Sampled before the log call rather than inside it, so the CPU the
+	// formatting itself costs lands in the NEXT window rather than in the one
+	// being reported.
+	rt := readRuntimeSample()
+	runtimeSection := formatRuntimeDelta(s.lastRuntime, rt, window)
+
+	logger.Info("perf window=%s | view(n=%d skipped=%d hidden=%d avg=%s max=%s) | pane-out(bytes=%d max-vt=%s) | key-backlog-max=%d | %s | %s",
 		window.Round(time.Millisecond),
 		s.viewCount, s.viewSkipped, s.viewHidden, viewAvg, time.Duration(s.viewMaxNs),
 		s.paneOutBytes, time.Duration(s.paneOutMaxNs),
 		s.maxSinceKey,
+		runtimeSection,
 		breakdown,
 	)
 
+	s.lastRuntime = rt
 	s.resetCounters()
+	s.lastFlush = now
 }
 
 // formatBreakdown sorts active buckets by total time desc and renders them
@@ -246,8 +268,14 @@ func (s *eventLoopStats) formatBreakdown() string {
 
 // resetCounters zeros every accumulator and rebuilds the bucket map so
 // types that stop appearing get garbage-collected instead of accumulating
-// zombie entries forever. sinceLastKey is intentionally preserved — see
-// the field comment.
+// zombie entries forever.
+//
+// TWO fields are intentionally preserved. sinceLastKey, for the reason in its
+// field comment. And lastRuntime, which is a delta BASELINE rather than an
+// accumulator: zeroing it would make every runtime figure on the next line
+// unreportable, and the line would go on looking plausible while saying "?"
+// forever. lastFlush is likewise owned by flush(), which sets it to the same
+// instant it closed the window with.
 func (s *eventLoopStats) resetCounters() {
 	s.byType = make(map[string]*perfBucket, len(s.byType))
 	s.paneOutBytes = 0
@@ -258,7 +286,6 @@ func (s *eventLoopStats) resetCounters() {
 	s.viewSkipped = 0
 	s.viewHidden = 0
 	s.maxSinceKey = 0
-	s.lastFlush = time.Now()
 }
 
 // trimMsgType strips the package-qualified prefix from a Go type string,

--- a/internal/tui/perfcpu_unix.go
+++ b/internal/tui/perfcpu_unix.go
@@ -1,0 +1,28 @@
+//go:build !windows
+
+package tui
+
+import (
+	"syscall"
+	"time"
+)
+
+// processCPU returns the CPU time this process has consumed, user plus system.
+//
+// RUSAGE_SELF covers every thread of the process, which is what the perf line
+// wants: the question is what the whole TUI spent, not what one goroutine's
+// thread did.
+//
+// Timeval's Usec field is int64 on Linux and int32 on Darwin, so both fields go
+// through an explicit conversion rather than being added as-is.
+func processCPU() (time.Duration, bool) {
+	var ru syscall.Rusage
+	if err := syscall.Getrusage(syscall.RUSAGE_SELF, &ru); err != nil {
+		return 0, false
+	}
+	tv := func(sec, usec int64) time.Duration {
+		return time.Duration(sec)*time.Second + time.Duration(usec)*time.Microsecond
+	}
+	return tv(int64(ru.Utime.Sec), int64(ru.Utime.Usec)) +
+		tv(int64(ru.Stime.Sec), int64(ru.Stime.Usec)), true
+}

--- a/internal/tui/perfcpu_windows.go
+++ b/internal/tui/perfcpu_windows.go
@@ -1,0 +1,34 @@
+//go:build windows
+
+package tui
+
+import (
+	"syscall"
+	"time"
+)
+
+// processCPU returns the CPU time this process has consumed, user plus kernel.
+//
+// GetProcessTimes is the Windows counterpart to getrusage(2). It is already in
+// the syscall package, so this needs no CGo and no new dependency — matching
+// how internal/clipboard and internal/notify reach Win32.
+//
+// The handle is the pseudo-handle GetCurrentProcess returns: a constant, not a
+// real object, so it must NOT be closed. Closing it is harmless on paper but
+// the call is documented as unnecessary, and a Close here would read as though
+// a resource were being managed.
+func processCPU() (time.Duration, bool) {
+	h, err := syscall.GetCurrentProcess()
+	if err != nil {
+		return 0, false
+	}
+	var creation, exit, kernel, user syscall.Filetime
+	if err := syscall.GetProcessTimes(h, &creation, &exit, &kernel, &user); err != nil {
+		return 0, false
+	}
+	// Filetime.Nanoseconds converts the 100-ns FILETIME ticks. Kernel and user
+	// are both counted: a frame blocked in a console write spends its time in
+	// the kernel, and excluding that would hide exactly the case this figure
+	// was added to identify.
+	return time.Duration(kernel.Nanoseconds() + user.Nanoseconds()), true
+}

--- a/internal/tui/perfruntime.go
+++ b/internal/tui/perfruntime.go
@@ -1,0 +1,255 @@
+package tui
+
+import (
+	"fmt"
+	"runtime"
+	"runtime/metrics"
+	"time"
+)
+
+// Runtime accounting for the perf summary.
+//
+// The perf log could already say how long a frame took. It could not say WHY a
+// frame that did the same work took fourteen times longer, and that gap cost a
+// whole investigation: three separate hypotheses (GC pressure, a large live VT
+// heap, an expensive renderer state) each had to be reproduced from scratch in
+// a benchmark before they could be ruled out, because the log held no evidence
+// that could distinguish them.
+//
+// The number that separates the remaining explanations is CPU TIME USED per
+// window, read against the time the same window spent inside View and Update.
+//
+// **The comparison is ASYMMETRIC, and saying so is load-bearing.** `cpu` is
+// PROCESS-wide — every goroutine, including the IPC reader, Bubble Tea's own
+// renderer and input goroutines, and any `tea.Cmd` in flight — while View+Update
+// is wall time on the event-loop goroutine alone. Go exposes no per-goroutine
+// CPU counter, and the event-loop goroutine is not pinned to an OS thread, so
+// GetThreadTimes/RUSAGE_THREAD cannot stand in for one without a
+// runtime.LockOSThread this diagnostic has no business adding. What survives
+// that mismatch is one direction of the inference, not both:
+//
+//   - cpu ≪ time in View+Update → CONCLUSIVE. Process CPU is an upper bound on
+//     any single goroutine's CPU, so if the WHOLE process used far less CPU than
+//     the event loop spent inside View and Update, the event loop cannot have
+//     been executing for most of that wall time. Look outside quil: descheduled,
+//     throttled, or blocked.
+//   - cpu ≥ time in View+Update → NOT conclusive on its own. Busy background
+//     goroutines lift the figure whether or not the event loop was running. Read
+//     it beside gor= and the per-message table rather than as proof that the
+//     work itself got more expensive.
+//
+// The useful direction is the conclusive one, which is why the field is worth
+// having: the open question about the 2026-09 stall is precisely whether the
+// process was running.
+//
+// PER WINDOW, not per frame, and not by choice. Windows accrues process times
+// against the scheduler tick (~15.6 ms by default), so a 3 ms frame measures as
+// 0 or as one whole tick. Over five seconds the quantisation averages out; over
+// one frame it is pure noise, and the two extra syscalls would sit in the render
+// hot path to produce it.
+//
+// Everything else here is context for that number and costs one sampling call
+// per five seconds: goroutine count (a leak slows every scheduling decision
+// uniformly, which looks exactly like the case above), live heap, and the three
+// GC figures whose absence made the GC hypothesis take a benchmark to falsify.
+//
+// **CPU comes from the OS, not from runtime/metrics, and that is the whole
+// point of this file working at all.** The obvious implementation reads
+// `/cpu/classes/total` minus `/cpu/classes/idle`. Those are NOT live counters:
+// `cpuStatsAggregate.compute` copies a snapshot that `work.cpuStats.accumulate`
+// only ever writes from `gcMarkTermination`, so the values advance when a GC
+// CYCLE COMPLETES and at no other time. Measured on Go 1.25, four goroutines
+// burning CPU for three seconds:
+//
+//	GC OFF : wall 3s  cpu-used delta 0.000s   gc cycles 0
+//	GC ON  : wall 3s  cpu-used delta 40.793s  gc cycles 2207
+//
+// A TUI holding a ~1 GB live heap and allocating ~350 KB per frame at ~5 fps
+// completes a cycle roughly every nine minutes, so about ninety-nine windows in
+// a hundred would have printed `cpu=0s/5s` — which the reading rule above calls
+// "the process was OFF the CPU", the exact opposite of the truth — and the
+// hundredth would print the accumulated CPU of all the others. The instrument
+// would have aimed the next investigation away from the answer, confidently.
+// getrusage(2) and GetProcessTimes both advance continuously; see perfcpu_unix.go
+// and perfcpu_windows.go.
+//
+// runtime/metrics rather than runtime.ReadMemStats for the rest, deliberately:
+// ReadMemStats stops the world, and instrumentation that pauses the program is
+// a poor way to investigate pauses. The one exception is NumGoroutine, a plain
+// counter read.
+
+// runtimeMetricNames are the metrics sampled at each flush.
+//
+// Only the two live counters and the two GC-published levels are here. The
+// /cpu/classes/* family is deliberately ABSENT — see the CPU note above for the
+// measurement showing why reading it per window would be worse than reading
+// nothing.
+var runtimeMetricNames = []string{
+	"/gc/cycles/total:gc-cycles",
+	"/gc/pauses:seconds",
+	"/cpu/classes/gc/mark/assist:cpu-seconds",
+	"/gc/heap/live:bytes",
+}
+
+// runtimeSample is one reading. The have* flags exist because a metric this Go
+// build does not supply comes back as KindBad, and rendering that as 0 would
+// print a confident "no assist time" for a figure that was never read — the
+// exact failure this whole file exists to prevent.
+type runtimeSample struct {
+	// cpuUsed is user+system CPU consumed by the whole process since it
+	// started, read from the OS.
+	cpuUsed time.Duration
+
+	gcCycles   uint64
+	gcAssist   float64
+	gcPause    time.Duration
+	heapLive   uint64
+	goroutines int
+
+	haveCPU    bool
+	haveCycles bool
+	havePause  bool
+	haveAssist bool
+	haveLive   bool
+}
+
+// readRuntimeSample takes one reading.
+//
+// A package var so tests can drive formatRuntimeDelta with constructed samples
+// instead of whatever the test binary's own runtime happens to be doing.
+var readRuntimeSample = func() runtimeSample {
+	samples := make([]metrics.Sample, len(runtimeMetricNames))
+	for i, n := range runtimeMetricNames {
+		samples[i].Name = n
+	}
+	metrics.Read(samples)
+
+	s := runtimeSample{goroutines: runtime.NumGoroutine()}
+	s.cpuUsed, s.haveCPU = processCPU()
+
+	for _, sample := range samples {
+		if sample.Value.Kind() == metrics.KindBad {
+			continue
+		}
+		switch sample.Name {
+		case "/gc/cycles/total:gc-cycles":
+			s.gcCycles, s.haveCycles = sample.Value.Uint64(), true
+		case "/cpu/classes/gc/mark/assist:cpu-seconds":
+			s.gcAssist, s.haveAssist = sample.Value.Float64(), true
+		case "/gc/heap/live:bytes":
+			s.heapLive, s.haveLive = sample.Value.Uint64(), true
+		case "/gc/pauses:seconds":
+			s.gcPause, s.havePause = histogramTotal(sample.Value.Float64Histogram()), true
+		}
+	}
+	return s
+}
+
+// histogramTotal sums a runtime/metrics duration histogram.
+//
+// Each bucket contributes its UPPER bound, so the total over-estimates by at
+// most one bucket width. Two reasons that is the right direction. First, this
+// figure is read to decide whether GC pauses are large enough to matter, and an
+// under-estimate would answer "no" for the wrong reason. Second, and more
+// usefully: what the perf line prints is a DELTA of two of these totals, and
+// both carry the same systematic over-estimate on the same historical samples,
+// so the bias cancels and only the window's new samples are approximated at all.
+//
+// The last bucket's upper bound is +Inf and falls back to its lower bound, the
+// only finite thing known about it. Without that, `time.Duration(+Inf * 1e9)`
+// converts to a garbage value which then also poisons the NEXT window, because
+// formatRuntimeDelta compares the two totals before subtracting.
+func histogramTotal(h *metrics.Float64Histogram) time.Duration {
+	if h == nil {
+		return 0
+	}
+	var total time.Duration
+	for i, count := range h.Counts {
+		if count == 0 {
+			continue
+		}
+		if i+1 >= len(h.Buckets) {
+			// Unreachable under the documented contract (len(Buckets) is
+			// len(Counts)+1). Guarded anyway because this runs on the Bubble
+			// Tea program goroutine, where a panic takes the user's whole
+			// session down — a truncated diagnostic is the better failure.
+			break
+		}
+		upper := h.Buckets[i+1]
+		if upper > 1e18 || upper != upper { // +Inf or NaN
+			upper = h.Buckets[i]
+		}
+		total += time.Duration(count) * time.Duration(upper*float64(time.Second))
+	}
+	return total
+}
+
+// formatRuntimeDelta renders the runtime section of one perf line.
+//
+// Every figure except heap and goroutines is a DELTA over the window, because a
+// cumulative counter on a process that has been up for days cannot show that
+// this window was different from the last one — which is the only question the
+// perf log is ever asked.
+//
+// Two distinct sentinels, because two distinct things go unreported:
+//
+//	?  the figure could not be measured (metric absent, or a counter that fell,
+//	   meaning the samples did not come from one continuous run)
+//	-  nothing was published to report: assist is accounted at mark termination,
+//	   so a window in which no GC cycle completed has no assist figure to give.
+//	   Printing 0s there would claim the collector charged the mutator nothing,
+//	   which is a finding, and not one this reading supports.
+//
+// heap is the heap the PREVIOUS GC marked live, so it holds the same value for
+// every window between cycles. That is a step function by design, not a stuck
+// reading; `gc=` on the same line says when it last moved.
+func formatRuntimeDelta(prev, cur runtimeSample, window time.Duration) string {
+	cpu := "?"
+	if prev.haveCPU && cur.haveCPU && cur.cpuUsed >= prev.cpuUsed {
+		cpu = (cur.cpuUsed - prev.cpuUsed).Round(time.Millisecond).String()
+	}
+
+	cycles := "?"
+	cycled := false
+	if prev.haveCycles && cur.haveCycles && cur.gcCycles >= prev.gcCycles {
+		n := cur.gcCycles - prev.gcCycles
+		cycles = fmt.Sprintf("%d", n)
+		cycled = n > 0
+	}
+
+	pause := "?"
+	if prev.havePause && cur.havePause && cur.gcPause >= prev.gcPause {
+		pause = (cur.gcPause - prev.gcPause).Round(time.Microsecond).String()
+	}
+
+	assist := "?"
+	if prev.haveAssist && cur.haveAssist && cur.gcAssist >= prev.gcAssist {
+		if cycled {
+			d := time.Duration((cur.gcAssist - prev.gcAssist) * float64(time.Second))
+			assist = d.Round(time.Microsecond).String()
+		} else {
+			assist = "-"
+		}
+	}
+
+	heap := "?"
+	if cur.haveLive {
+		heap = formatHeapBytes(cur.heapLive)
+	}
+
+	return fmt.Sprintf("rt(cpu=%s/%s gor=%d heap=%s gc=%s pause=%s assist=%s)",
+		cpu, window.Round(time.Millisecond), cur.goroutines, heap, cycles, pause, assist)
+}
+
+// formatHeapBytes renders a heap size without collapsing a small one to "0MB".
+//
+// A file whose whole argument is "never print a confident zero" must not print
+// one itself: integer megabytes turn every heap under a megabyte into 0MB,
+// which reads as a failed measurement rather than a small heap.
+func formatHeapBytes(b uint64) string {
+	const mb = 1 << 20
+	if b < mb {
+		return fmt.Sprintf("%dKB", b>>10)
+	}
+	return fmt.Sprintf("%dMB", b/mb)
+}

--- a/internal/tui/perfruntime_test.go
+++ b/internal/tui/perfruntime_test.go
@@ -1,0 +1,344 @@
+package tui
+
+import (
+	"bytes"
+	"io"
+	"math"
+	"runtime/metrics"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/artyomsv/quil/internal/logger"
+)
+
+// captureLoggedLine runs fn with the package logger pointed at a buffer and
+// returns what was written.
+//
+// The logger has no getter for its current sink, so this cannot restore what
+// was there before. What it can do is restore the LEVEL to something equivalent
+// to the pre-test state: before any Init, `logAt` returns on a nil handler and
+// never formats anything, so the closest available equivalent is a level that
+// filters Info out before the Sprintf. Leaving it at "info" would silently
+// change every later test in the package into one that formats every
+// `logger.Info` argument it reaches.
+func captureLoggedLine(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf bytes.Buffer
+	logger.Init("info", &buf)
+	t.Cleanup(func() { logger.Init("error", io.Discard) })
+	fn()
+	return buf.String()
+}
+
+// sampleAt builds a runtimeSample with every metric marked present. Tests that
+// care about an ABSENT metric clear the flag themselves, so the absent case is
+// always written explicitly rather than inherited from a zero value.
+func sampleAt(cpu time.Duration, cycles uint64, assist float64, pause time.Duration, live uint64, gor int) runtimeSample {
+	return runtimeSample{
+		cpuUsed: cpu, gcCycles: cycles,
+		gcAssist: assist, gcPause: pause, heapLive: live, goroutines: gor,
+		haveCPU: true, haveCycles: true, havePause: true, haveAssist: true, haveLive: true,
+	}
+}
+
+func TestFormatRuntimeDelta_LongUptime_ReportsWindowDeltas(t *testing.T) {
+	// A process up for a long time: large cumulative counters, small change
+	// across this one window. Reporting the totals would drown the change.
+	prev := sampleAt(66*time.Minute+40*time.Second, 900, 12.0, 30*time.Second, 500<<20, 100)
+	cur := sampleAt(66*time.Minute+41*time.Second+500*time.Millisecond, 902, 12.004,
+		30*time.Second+1500*time.Microsecond, 998<<20, 142)
+
+	got := formatRuntimeDelta(prev, cur, 5*time.Second)
+
+	for _, want := range []string{"cpu=1.5s/5s", "gor=142", "heap=998MB", "gc=2", "pause=1.5ms", "assist=4ms"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("formatRuntimeDelta() = %q, missing %q", got, want)
+		}
+	}
+	// A leaked cumulative total would render as the whole-uptime figure. Both
+	// strings below are what a leak actually PRINTS, not what the struct holds
+	// — an earlier version asserted on the raw seconds ("4000"), which the
+	// duration formatter can never emit, so that half of the check could not
+	// fail whatever the code did.
+	for _, leak := range []string{"1h6m41.5s", "gc=902"} {
+		if strings.Contains(got, leak) {
+			t.Errorf("formatRuntimeDelta() = %q — leaked a cumulative total (%q)", got, leak)
+		}
+	}
+}
+
+func TestFormatRuntimeDelta_MetricUnavailable_RendersQuestionMark(t *testing.T) {
+	// The whole point of the have* flags: a Go build that does not supply a
+	// metric must not produce a confident "0", which would read as a finding
+	// ("no GC assist time") drawn from a value nobody measured.
+	prev := sampleAt(100*time.Second, 10, 1.0, time.Second, 1<<20, 5)
+	cur := sampleAt(105*time.Second, 11, 1.5, 2*time.Second, 2<<20, 6)
+	cur.haveAssist = false
+	cur.haveCPU = false
+	cur.haveLive = false
+
+	got := formatRuntimeDelta(prev, cur, 5*time.Second)
+
+	for _, want := range []string{"cpu=?", "assist=?", "heap=?"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("formatRuntimeDelta() = %q, missing %q", got, want)
+		}
+	}
+	// The metrics that WERE available must still be reported.
+	if !strings.Contains(got, "gc=1") {
+		t.Errorf("formatRuntimeDelta() = %q — dropped an available metric alongside the missing ones", got)
+	}
+}
+
+func TestFormatRuntimeDelta_FirstSampleUnavailable_RendersQuestionMark(t *testing.T) {
+	// The mirror of the case above, and the one that actually happens: the
+	// FIRST reading, taken in newEventLoopStats, is the one most likely to have
+	// failed. Both guards are `prev.haveX && cur.haveX`, so a test that only
+	// ever clears cur leaves half of each guard unexercised.
+	prev := sampleAt(100*time.Second, 10, 1.0, time.Second, 1<<20, 5)
+	prev.haveCPU = false
+	prev.haveAssist = false
+	prev.havePause = false
+	cur := sampleAt(105*time.Second, 11, 1.5, 2*time.Second, 2<<20, 6)
+
+	got := formatRuntimeDelta(prev, cur, 5*time.Second)
+
+	for _, want := range []string{"cpu=?", "assist=?", "pause=?"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("formatRuntimeDelta() = %q, missing %q", got, want)
+		}
+	}
+	// heap comes from cur alone — a level, not a delta — so an unreadable first
+	// sample must not suppress it.
+	if !strings.Contains(got, "heap=2MB") {
+		t.Errorf("formatRuntimeDelta() = %q — heap needs no prior sample and must survive one", got)
+	}
+}
+
+func TestFormatRuntimeDelta_CounterReset_RefusesNegativeDelta(t *testing.T) {
+	// These counters only rise. A fall means the two samples did not come from
+	// one continuous run, and the honest render is "unknown" — clamping to zero
+	// would publish "this window used no CPU", which is a conclusion rather
+	// than a missing reading.
+	prev := sampleAt(4000*time.Second, 900, 12.0, 30*time.Second, 500<<20, 100)
+	cur := sampleAt(10*time.Second, 3, 0.1, time.Second, 400<<20, 90)
+
+	got := formatRuntimeDelta(prev, cur, 5*time.Second)
+
+	for _, want := range []string{"cpu=?", "gc=?", "pause=?", "assist=?"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("formatRuntimeDelta() = %q, missing %q", got, want)
+		}
+	}
+	// heap is a LEVEL, not a delta, so it is always reportable.
+	if !strings.Contains(got, "heap=400MB") {
+		t.Errorf("formatRuntimeDelta() = %q — heap is a level and must survive a counter reset", got)
+	}
+}
+
+func TestFormatRuntimeDelta_NoCycleCompleted_MarksAssistUnpublished(t *testing.T) {
+	// Mark-assist CPU is accounted at mark termination. A window in which no
+	// cycle completed therefore has no assist figure to give, and "0s" there
+	// would assert the collector charged the mutator nothing — a finding this
+	// reading does not support. It gets its own sentinel, distinct from the "?"
+	// that means the metric could not be read at all.
+	prev := sampleAt(100*time.Second, 42, 3.0, time.Second, 8<<20, 20)
+	cur := sampleAt(101*time.Second, 42, 3.0, time.Second, 8<<20, 20)
+
+	got := formatRuntimeDelta(prev, cur, 5*time.Second)
+
+	if !strings.Contains(got, "assist=-") {
+		t.Errorf("formatRuntimeDelta() = %q, want assist=- when no GC cycle completed", got)
+	}
+	if strings.Contains(got, "assist=0s") {
+		t.Errorf("formatRuntimeDelta() = %q — printed a measured-looking zero for an unpublished figure", got)
+	}
+	if !strings.Contains(got, "gc=0") || !strings.Contains(got, "cpu=1s/") {
+		t.Errorf("formatRuntimeDelta() = %q — the live figures must still be reported", got)
+	}
+}
+
+func TestFormatHeapBytes_SubMegabyte_DoesNotCollapseToZero(t *testing.T) {
+	// The one remaining place this file could print a confident zero.
+	if got := formatHeapBytes(700 << 10); got != "700KB" {
+		t.Errorf("formatHeapBytes(700KB) = %q, want 700KB", got)
+	}
+	if got := formatHeapBytes(3 << 20); got != "3MB" {
+		t.Errorf("formatHeapBytes(3MB) = %q, want 3MB", got)
+	}
+}
+
+func TestHistogramTotal_InfiniteLastBucket_UsesFiniteBound(t *testing.T) {
+	// The branch no constructed-sample test can reach through
+	// formatRuntimeDelta: the runtime's final bucket has an upper bound of
+	// +Inf, and time.Duration(+Inf * 1e9) converts to a garbage value that
+	// would also poison the NEXT window, since formatRuntimeDelta compares the
+	// two totals before subtracting. A mutation run proved this branch was
+	// unguarded by any test: replacing the +Inf check with `if false` left the
+	// whole package green.
+	h := &metrics.Float64Histogram{
+		Buckets: []float64{0, 0.001, math.Inf(1)},
+		Counts:  []uint64{0, 2}, // two pauses in the [1ms, +Inf) bucket
+	}
+	if got := histogramTotal(h); got != 2*time.Millisecond {
+		t.Errorf("histogramTotal() = %v, want 2ms — the +Inf bound leaked into the duration", got)
+	}
+	if got := histogramTotal(nil); got != 0 {
+		t.Errorf("histogramTotal(nil) = %v, want 0", got)
+	}
+}
+
+func TestHistogramTotal_ShortBuckets_DoesNotPanic(t *testing.T) {
+	// Unreachable under the documented contract, which is exactly why it is
+	// worth a test: this runs on the Bubble Tea program goroutine, where a
+	// panic ends the user's session. A truncated diagnostic is the better
+	// failure.
+	h := &metrics.Float64Histogram{
+		Buckets: []float64{0, 0.001},
+		Counts:  []uint64{1, 5}, // one count too many for the bucket list
+	}
+	if got := histogramTotal(h); got != time.Millisecond {
+		t.Errorf("histogramTotal() = %v, want 1ms — the in-contract prefix should still be summed", got)
+	}
+}
+
+// TestEventLoopStats_Flush_EmitsRuntimeSection checks the wiring, not the
+// formatter. The formatter is exercised directly above; what this covers is
+// that flush() calls it, puts the result on the line, AND advances its delta
+// baseline — the "on switch" a bottom-up test suite never touches.
+func TestEventLoopStats_Flush_EmitsRuntimeSection(t *testing.T) {
+	prevRead := readRuntimeSample
+	t.Cleanup(func() { readRuntimeSample = prevRead })
+
+	n := 0
+	readRuntimeSample = func() runtimeSample {
+		n++
+		// Each reading is one second of CPU and one GC cycle beyond the last.
+		return sampleAt(time.Duration(n)*time.Second, uint64(n), 0, 0, 777<<20, 33)
+	}
+
+	out := captureLoggedLine(t, func() {
+		s := newEventLoopStats() // reading 1
+		s.recordView(3 * time.Millisecond)
+		s.flush() // reading 2, emits
+		s.recordView(3 * time.Millisecond)
+		s.flush() // reading 3 — must be compared against reading 2, not reading 1
+	})
+
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("want 2 perf lines, got %d: %q", len(lines), out)
+	}
+	if !strings.Contains(lines[0], "rt(") {
+		t.Fatalf("flush() line = %q — no runtime section, so the perf log still cannot say why a frame was slow", lines[0])
+	}
+	for _, want := range []string{"gor=33", "heap=777MB", "gc=1"} {
+		if !strings.Contains(lines[0], want) {
+			t.Errorf("first flush line = %q, missing %q", lines[0], want)
+		}
+	}
+	// The second window is one cycle and one second of CPU beyond the FIRST
+	// FLUSH. Measuring it against the construction-time sample instead would
+	// say gc=2 and cpu=2s — every window reporting the total since startup,
+	// which is the failure the delta design exists to prevent and which looks
+	// entirely plausible in a log. Dropping `s.lastRuntime = rt` from flush()
+	// leaves the whole package green without this assertion.
+	for _, want := range []string{"gc=1", "cpu=1s/"} {
+		if !strings.Contains(lines[1], want) {
+			t.Errorf("second flush line = %q, missing %q — flush did not advance its delta baseline", lines[1], want)
+		}
+	}
+	if n != 3 {
+		t.Errorf("readRuntimeSample called %d times, want 3 (one at construction, one per flush)", n)
+	}
+}
+
+// TestReadRuntimeSample_ThisGoVersion_ResolvesEveryMetric is the guard against
+// a typo in runtimeMetricNames.
+//
+// A misspelled name is not an error anywhere — metrics.Read returns KindBad,
+// the formatter honestly renders "?", and the perf log then reports "unknown"
+// forever for a metric the runtime was supplying all along. That failure is
+// invisible in production and invisible in every other test here, because they
+// all drive the formatter with constructed samples.
+func TestReadRuntimeSample_ThisGoVersion_ResolvesEveryMetric(t *testing.T) {
+	s := readRuntimeSample()
+
+	for _, c := range []struct {
+		name string
+		have bool
+	}{
+		{"processCPU (getrusage / GetProcessTimes)", s.haveCPU},
+		{"/gc/cycles/total:gc-cycles", s.haveCycles},
+		{"/gc/pauses:seconds", s.havePause},
+		{"/cpu/classes/gc/mark/assist:cpu-seconds", s.haveAssist},
+		{"/gc/heap/live:bytes", s.haveLive},
+	} {
+		if !c.have {
+			t.Errorf("%s not supplied — check the name in runtimeMetricNames against this Go version", c.name)
+		}
+	}
+	if s.goroutines < 1 {
+		t.Errorf("goroutines = %d, want at least the test's own", s.goroutines)
+	}
+}
+
+// TestProcessCPU_Advances_WithoutAGarbageCollection is the regression test for
+// the defect that made the first version of this file useless.
+//
+// The obvious CPU source is runtime/metrics' /cpu/classes/total minus
+// /cpu/classes/idle. Those values are a snapshot taken at gcMarkTermination, so
+// they do not move unless a GC CYCLE COMPLETES. Measured on Go 1.25, four
+// goroutines burning CPU for three seconds with the collector off reported
+// 0.000s used. In a TUI that collects roughly every nine minutes that is a
+// permanent, confident zero — and the perf line reads a near-zero cpu as "the
+// process was not running", the exact opposite of the truth.
+//
+// This test burns CPU with the collector disabled and requires the figure to
+// move. It fails against the metrics-based implementation and passes against
+// the OS one.
+func TestProcessCPU_Advances_WithoutAGarbageCollection(t *testing.T) {
+	before, ok := processCPU()
+	if !ok {
+		t.Skip("processCPU unavailable on this platform")
+	}
+
+	// Deliberately NOT debug.SetGCPercent(-1): this test runs in the shared
+	// package binary, and switching the collector off process-wide would
+	// change every test scheduled after it. Busy work that allocates nothing
+	// starves the collector of any reason to run just as effectively.
+	cyclesBefore := readCyclesForTest()
+	x := 0
+	deadline := time.Now().Add(150 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		for i := 0; i < 200000; i++ {
+			x += i
+		}
+	}
+	_ = x
+
+	after, ok := processCPU()
+	if !ok {
+		t.Fatal("processCPU stopped reporting mid-test")
+	}
+	if after <= before {
+		t.Fatalf("processCPU did not advance across %v of busy work: before=%v after=%v — "+
+			"the CPU source is not a live counter", 150*time.Millisecond, before, after)
+	}
+	if got := readCyclesForTest() - cyclesBefore; got != 0 {
+		t.Logf("note: %d GC cycle(s) ran during the busy loop; the assertion above no longer "+
+			"distinguishes a live counter from a GC-published one", got)
+	}
+}
+
+// readCyclesForTest reads the completed-cycle counter so the test above can say
+// whether its own premise held.
+func readCyclesForTest() uint64 {
+	s := []metrics.Sample{{Name: "/gc/cycles/total:gc-cycles"}}
+	metrics.Read(s)
+	if s[0].Value.Kind() != metrics.KindUint64 {
+		return 0
+	}
+	return s[0].Value.Uint64()
+}


### PR DESCRIPTION
## Why

Investigating the production TUI stall (frames of 100-966 ms against a 2-5 ms median, in a 48-tab / 48-pane workspace) showed that `quil.log`'s perf summary can say **how long** a frame took but not **why** a frame doing the same work cost fourteen times more.

That gap made the investigation expensive. Three explanations each had to be reproduced in a benchmark before they could be ruled out, because nothing in the log could distinguish them:

| hypothesis | how it was ruled out | result |
|---|---|---|
| GC mark assists over a large live heap | controlled 3-arm reproduction, 12 000 frames per arm | **falsified** — a 998 MB live heap runs 4 GC cycles in 12 000 frames, charging 3 ms of assist total |
| live VT scrollback size | same reproduction, 2000 vs 100 lines per pane | **falsified** — frame p50 3.06 ms vs 3.02 ms |
| an expensive renderer/model state | state sweep over 8 states | **falsified** — worst state costs 1.44x; the log needs 8-14x |

The falsification rests on the **overall maximum frame** in each arm, which needs no classification and no attribution to be believed: **16.8 ms**, **13.7 ms**, and **17.9 ms** even with 44 forced GC cycles over a gigabyte. Production sees 100-966 ms.

Meanwhile the log shows the slowdown is uniform: in a slow window `View` is ~8x slower, `Update` is ~8x slower, and even a single VT write — a small, allocation-free operation — goes from 132 us to 473 us on the same chunk count. Slow windows cluster in bursts of up to 33 consecutive 5-second windows, where random scatter at the observed 5.8% rate predicts runs of at most 4.

None of that could be read from the log as shipped. This PR makes it readable.

## What changed

Each 5 s perf line gains an `rt(...)` section:

```
perf window=5s | view(...) | pane-out(...) | key-backlog-max=0 |
  rt(cpu=1.5s/5s gor=142 heap=998MB gc=2 pause=1.5ms assist=4ms) | WorkspaceStateMsg(...)
```

### The CPU comparison is asymmetric, deliberately

`cpu` is the CPU time actually **used** during the window, read from the OS. It is **process-wide** — the IPC reader, Bubble Tea's renderer and input goroutines, any `tea.Cmd` in flight — while View+Update is wall time on the event-loop goroutine alone. Go exposes no per-goroutine CPU counter, and that goroutine is not pinned to an OS thread, so `GetThreadTimes` / `RUSAGE_THREAD` cannot substitute without a `runtime.LockOSThread` that has no business in the render loop.

What survives that mismatch is one direction of the inference, not both:

- `cpu` far BELOW the time in View+Update → **conclusive**. Process CPU is an upper bound on any single goroutine's CPU, so if the whole process used far less CPU than the event loop spent inside View and Update, the event loop cannot have been executing for most of that wall time. Look outside quil.
- `cpu` at or above it → **not conclusive**. Busy background goroutines lift it either way. Read it beside `gor=` and the per-message table, not as proof that the work got more expensive.

The conclusive direction is the one the open question needs: whether the process was running at all.

### CPU comes from the OS, and that is the whole point

The obvious implementation reads `/cpu/classes/total` minus `/cpu/classes/idle`. **Those are not live counters.** `cpuStatsAggregate.compute` copies a snapshot that `work.cpuStats.accumulate` writes only from `gcMarkTermination`, so they advance when a GC cycle *completes* and at no other time. Measured on Go 1.25, four goroutines burning CPU for three seconds:

```
GC OFF : wall 3s  cpu-used delta 0.000s   gc cycles 0
GC ON  : wall 3s  cpu-used delta 40.793s  gc cycles 2207
```

A TUI collecting roughly every nine minutes would have printed `cpu=0s/5s` in about ninety-nine windows in a hundred — which the rule above calls "the process was off the CPU", the opposite of the truth. `TestProcessCPU_Advances_WithoutAGarbageCollection` fails against the metrics-based implementation (`before=0s after=0s`) and passes against the OS one.

Per **window**, not per frame: Windows accrues process times against the ~15.6 ms scheduler tick, so a 3 ms frame would measure as 0 or as one whole tick.

### Other design notes

- **`runtime/metrics`, not `runtime.ReadMemStats`,** for everything else. ReadMemStats stops the world; instrumentation that pauses the program is a poor way to investigate pauses.
- **Deltas, not totals.** A cumulative counter on a process up for days cannot show that this window differed from the last. `heap` is the exception — a level — and it is the heap the *previous* GC marked, so it steps rather than drifts.
- **Two sentinels, never a zero.** `?` = could not be measured. `-` = nothing was published to report; assist is accounted at mark termination, so a window with no completed cycle has no assist figure.
- **A test asserts every metric name resolves on this Go version.** A typo returns `KindBad`, the formatter honestly renders `?`, and the log then reports "unknown" forever for a metric the runtime was supplying all along.
- **`histogramTotal` cannot panic.** It runs on the Bubble Tea program goroutine, where a panic ends the session, so the bucket index is guarded even though the contract makes it unreachable. Its `+Inf` fallback is required: converting an infinite bound to a Duration produces garbage that also poisons the next window.

## Reproduction harnesses

Two `t.Skip`-gated harnesses, so neither joins `dev.sh test` or CI:

- `QUIL_GC_REPRO=1` — a production-shaped workspace (48 panes, 200x50, full adaptive scrollback, ~1 GB live), frame percentiles against GC activity.
- `QUIL_STATE_SWEEP=1` — identical frames against one model state at a time (all panes blocked, all unseen, notification sidebar open and full, scrolled back, selection held, wide canvas off, 96 tabs).

Both report **per-interval** figures. Pause and scheduler-latency peaks are computed over the delta between two histogram readings rather than reduced at read time: the cumulative form printed the worst pause since process start beside each arm, and the symptom was three arms reporting an identical `1.835ms` that read as a real measurement. The sweep now collects between states, since a workspace disposed but uncollected put one state's garbage inside the next state's frames.

Go publishes **no "GC in progress" signal** — every `/gc/cycles/*` metric counts completions, and `runtime.MemStats` has no in-progress flag. A first attempt read `/gc/cycles/started`, which is not a real metric name; the harness's fail-loud guard caught it rather than silently reporting zero cycles. Frames are therefore marked GC-adjacent by **proximity** to a completed cycle (100 frames), labelled as a window rather than as phase detection, erring toward including innocent frames — which can only make GC look worse.

Two earlier versions are recorded as cautions in the comments: one drove 1200 frames and observed **zero** GC cycles (measuring the absence of GC, which reads as innocence), and one had a broken control reporting the *small* heap holding *more* live memory than the large one — panes are kept alive by their own `drainVTResponses` goroutine, so dropping the `Model` frees nothing without `Dispose`.

## Testing

- `./scripts/dev.sh test internal/tui`, `./scripts/dev.sh vet`, and `GOOS=windows go vet` (CI never compiles the Windows file) — all green.
- `./scripts/dev.sh test-race internal/tui` — green.
- Both harnesses clean: `TestFrameLatencyVsLiveHeap` 156 s, `TestFrameCostByModelState` 60 s.
- **Mutation-verified.** Three mutations that survived an earlier version of this suite are now killed, each re-run to confirm: disabling the `+Inf` bucket guard, dropping `s.lastRuntime = rt` (which silently turns every window into a since-startup total), and reverting `processCPU` to the metrics source.

## Review

Four Greptile P2 findings, all answered on their threads. Three were real and are fixed with tests (CPU scope mismatch, cumulative peaks, cross-state GC bleed); the fourth described the GC classification as it stood in `db43093` and had already been fixed.

## Not in this PR

The root cause of the stall itself. Three hypotheses are falsified with measurements; the evidence points at something raising the cost of every instruction the process executes rather than at quil's own logic. The `cpu=` field is what settles that, and it needs a build running in production to speak.
