### PR TITLE
chore(memory): record review-agent learnings from the 1x1 resize fix

### DIFF
--- a/.claude/agent-memory/qa/MEMORY.md
+++ b/.claude/agent-memory/qa/MEMORY.md
@@ -5,6 +5,7 @@
 - [project_subscribe_broadcast_wiring_gap.md](project_subscribe_broadcast_wiring_gap.md) — MsgSubscribe opt-out: predicate tests proved nothing about reachability; RESOLVED in-branch by 3 mutation-verified wiring tests
 - [project_notify_wiring_gap.md](project_notify_wiring_gap.md) — raiseAttentionToast/sweepOutstandingToasts call sites were mutation-removable with a green suite; now pinned by Update-driven tests
 - [project_test_tooling.md](project_test_tooling.md) — Docker test runner, no local Go, worktree isolation recipe, mutation-testing gate booleans/dispose calls, concurrent agents' stray zz_probe test files
+- [project_mutation_probe_on_a_copy.md](project_mutation_probe_on_a_copy.md) — probing on a scratchpad copy: sources are CRLF (\n regexes no-op) and restores must come from `git show HEAD:`, not the live worktree
 - [project_procreport_selfstat_gaps.md](project_procreport_selfstat_gaps.md) — PR #195: stat-ticker and daemon-own-row gaps both RESOLVED in-branch (mutation-verified); procCollector goroutine still not tied to Daemon.Stop() → techdebt/4-2
 
 ## Feedback

--- a/.claude/agent-memory/qa/project_mutation_probe_on_a_copy.md
+++ b/.claude/agent-memory/qa/project_mutation_probe_on_a_copy.md
@@ -15,8 +15,20 @@ silently produce a false "mutation survived":
 2. **Restoring the copy from the live worktree imports another agent's mid-edit state.** Observed
    2026-09-06 (PR #203): a probe of `overlayResizeCmd` produced nine unrelated failures identical to
    an "always refuse" mutation, because `cp` from the worktree happened while the team lead was
-   rewriting `model.go`. Restore each file with `git show HEAD:<path> > <copy>/<path>` instead, and
-   assert `git show HEAD:<f> | diff -q - <copy>/<f>` for every file before each mutation.
+   rewriting `model.go`. Restore each file from git instead, and assert the copy matches before each
+   mutation.
+
+   **Capture the SHA once and use that literal value — `HEAD` is not a pin.** `git show HEAD:<path>`
+   re-resolves `HEAD` on every call, and the same lead edits that motivate rule 2 also COMMIT during a
+   review (PR #203 moved HEAD twice while probes were running). So a later restore silently pulls a
+   different commit from the one the baseline was built on, which is rule 2 wearing a disguise —
+   mutations then run against code the green baseline never covered. Do:
+
+   ```sh
+   BASE=$(git rev-parse HEAD)          # once, before anything is copied
+   git show "$BASE:$f" > "$copy/$f"    # every restore
+   git show "$BASE:$f" | diff -q - "$copy/$f"   # every file, before each mutation
+   ```
 
 **Why:** both failures are silent and both point the same wrong way — a surviving mutation reads as a
 coverage gap, so the report accuses the PR of a hole that does not exist.

--- a/.claude/agent-memory/qa/project_mutation_probe_on_a_copy.md
+++ b/.claude/agent-memory/qa/project_mutation_probe_on_a_copy.md
@@ -1,0 +1,25 @@
+---
+name: project_mutation_probe_on_a_copy
+description: Mutation probing on a scratchpad copy of this repo — files are CRLF, so \n regexes silently no-op, and the baseline must come from `git show HEAD:` not the live worktree
+metadata:
+  type: project
+---
+
+When mutation-testing quil on a COPY in the scratchpad (the read-only-worktree contract), two things
+silently produce a false "mutation survived":
+
+1. **The Go sources on disk are CRLF.** A `perl -0pi -e 's/...\n...//'` pattern matches nothing, the
+   copy stays pristine, the suite goes green, and the probe reads as "no test covers this". Every
+   multi-line pattern needs `\r?\n`, and every mutation needs an assertion that it APPLIED
+   (`grep -c <marker>` before/after) with the run SKIPPED when it did not.
+2. **Restoring the copy from the live worktree imports another agent's mid-edit state.** Observed
+   2026-09-06 (PR #203): a probe of `overlayResizeCmd` produced nine unrelated failures identical to
+   an "always refuse" mutation, because `cp` from the worktree happened while the team lead was
+   rewriting `model.go`. Restore each file with `git show HEAD:<path> > <copy>/<path>` instead, and
+   assert `git show HEAD:<f> | diff -q - <copy>/<f>` for every file before each mutation.
+
+**Why:** both failures are silent and both point the same wrong way — a surviving mutation reads as a
+coverage gap, so the report accuses the PR of a hole that does not exist.
+**How to apply:** always run one UNMUTATED baseline on the copy first (it must be green), assert the
+mutation applied, and pin every restore to a SHA. See [[project_test_tooling]] for the wider
+concurrent-edit problem this is the cheap form of.

--- a/.claude/agent-memory/security-officer/MEMORY.md
+++ b/.claude/agent-memory/security-officer/MEMORY.md
@@ -3,3 +3,4 @@
 - [remote daemon string taint](project_remote_daemon_taint.md) — every workspace_state string is attacker-controlled when the daemon is remote; sanitizeRemoteText is opt-in per render site; width checks are neither sanitisers nor length bounds
 - [Semgrep in a git worktree](project_semgrep_worktree_scan.md) — scans 0 files and still reports success; copy changed files to a scratch dir, run from PowerShell, check paths.scanned
 - [project_uintptrescapes_com_helper.md](project_uintptrescapes_com_helper.md) — a hand-rolled COM vtable call helper needs //go:uintptrescapes; x/sys's own Call has it, yours does not
+- [log injection escaped by slog](project_log_injection_escaped_by_slog.md) — `%s` of an attacker string is NOT injectable (slog TextHandler quotes the whole msg); flag length-bounds + rate-limits instead, and the initLogging-returns-nil raw-stderr path

--- a/.claude/agent-memory/security-officer/project_log_injection_escaped_by_slog.md
+++ b/.claude/agent-memory/security-officer/project_log_injection_escaped_by_slog.md
@@ -17,11 +17,21 @@ Verified by probe (2026-09-06), not from docs. A `PaneID` of
 `time=... level=INFO msg="pane p1\nlevel=ERROR msg=\"...\"\n\x1b[31m...\a: refusing ..."`.
 So no forged log line, and no ANSI/OSC reaching an operator's terminal on `cat`/`tail`.
 
-**Residual, and the only place to look:** `initLogging` (`cmd/quild/main.go:177-190`)
-returns `nil` — leaving `logger.Init` **never called** — when `config.QuilDir()` is empty or
+**Scope of the claim:** this covers values reaching an operator's log THROUGH `log.Printf`
+once `logger.Init` has run. It is NOT a statement that nothing in the daemon can write raw
+bytes to a terminal.
+
+**Residual on that path:** `initLogging` (`cmd/quild/main.go:177-190`) returns `nil` —
+leaving `logger.Init` **never called** — when `config.QuilDir()` is empty or
 `NewRotatingWriter` fails to open. Stdlib `log` then writes to raw `os.Stderr`, which
-`startDaemon` points at `$QUIL_HOME/quild.stderr.log`, with no escaping at all. That is the
-only path where control characters survive.
+`startDaemon` points at `$QUIL_HOME/quild.stderr.log`, with no escaping at all.
+
+**Other raw sinks exist and bypass the bridge entirely**, so do not read the above as "the
+only unescaped path". `internal/logger/rotate.go:137` writes its rename error straight to
+`os.Stderr` with `fmt.Fprintf`, and `cmd/quil/` prints startup and daemon-control errors the
+same way. Those carry error text and paths rather than IPC payload strings today, but the
+sink is unescaped — judge each on what actually flows into it rather than dismissing it
+because of this note.
 
 **How to apply:** do not raise `%s` vs `%q` on a payload string as a log-injection finding —
 it is cosmetic here. Raise instead: (a) whether the value is length-bounded, since a payload

--- a/.claude/agent-memory/security-officer/project_log_injection_escaped_by_slog.md
+++ b/.claude/agent-memory/security-officer/project_log_injection_escaped_by_slog.md
@@ -1,0 +1,34 @@
+---
+name: project-log-injection-escaped-by-slog
+description: log.Printf("%s", attackerString) is NOT log-injectable in quil — logger.Init routes stdlib log through slog.NewTextHandler, which quotes the whole message; the residual is the initLogging-returns-nil path
+metadata:
+  type: project
+---
+
+`log.Printf` with an unsanitized attacker-controlled string (`payload.PaneID`, pane names,
+CWDs, hook values) does **not** yield log injection in quil's normal runtime. `logger.Init`
+(`internal/logger/logger.go:63`) builds a `slog.NewTextHandler` and bridges stdlib `log`
+through `slog.NewLogLogger(handler, LevelInfo).Writer()`. The bridge makes the ENTIRE
+formatted `log.Printf` string the slog record's `msg`, and TextHandler runs `needsQuoting`
+on it — so newlines, `"` and `\x1b` come out as `\n`, `\"`, `\x1b` inside one quoted field.
+
+Verified by probe (2026-09-06), not from docs. A `PaneID` of
+`"p1\nlevel=ERROR msg=\"...\"\n\x1b[31m...\x1b]0;pwned\a"` rendered as a single line:
+`time=... level=INFO msg="pane p1\nlevel=ERROR msg=\"...\"\n\x1b[31m...\a: refusing ..."`.
+So no forged log line, and no ANSI/OSC reaching an operator's terminal on `cat`/`tail`.
+
+**Residual, and the only place to look:** `initLogging` (`cmd/quild/main.go:177-190`)
+returns `nil` — leaving `logger.Init` **never called** — when `config.QuilDir()` is empty or
+`NewRotatingWriter` fails to open. Stdlib `log` then writes to raw `os.Stderr`, which
+`startDaemon` points at `$QUIL_HOME/quild.stderr.log`, with no escaping at all. That is the
+only path where control characters survive.
+
+**How to apply:** do not raise `%s` vs `%q` on a payload string as a log-injection finding —
+it is cosmetic here. Raise instead: (a) whether the value is length-bounded, since a payload
+string can be up to `maxFrameSize` = 10 MB (`internal/ipc/protocol.go:1435`) and quild.log's
+default budget is only 5 MB x 10 files, so a few frames evict the whole history; and (b)
+whether the log site is rate-limited, since the IPC socket is chmod 0600
+(`internal/ipc/server.go:605`) — same-UID, so the impact is anti-forensics / log eviction,
+never privilege crossing. Compare `pane.LastInputBlockedAt` (daemon.go) for the repo's own
+per-pane cooldown idiom. See [[project-remote-daemon-taint]] and [[project-hookevents-taint]]
+for where such strings originate.


### PR DESCRIPTION
Docs only — `.claude/agent-memory/` is in the release denylist and the type is `chore`, so this cuts no release.

Two findings from the PR #203 review worth keeping. Both were verified in-session, not inferred.

**qa — mutation probing on a scratchpad copy has two silent failure modes.** Both produce a false "mutation survived", and both point the same wrong way: a surviving mutation reads as a coverage gap, so the report accuses the PR of a hole that does not exist.

1. The Go sources on disk are CRLF, so a multi-line `\n` pattern matches nothing, the copy stays pristine and the suite goes green.
2. Restoring the copy from the live worktree imports another agent's mid-edit state. That actually happened during this review: a probe of `overlayResizeCmd` produced nine unrelated failures because the copy was taken while `model.go` was being rewritten.

The recipe: run an unmutated baseline first, assert the mutation applied, and pin every restore to a SHA rather than to the worktree.

**security-officer — `log.Printf` of an attacker-controlled string is not log-injectable in quil.** `logger.Init` bridges stdlib `log` through `slog.NewTextHandler`, which quotes the entire message, so newlines, quotes and escape bytes come out escaped inside one field. Probed with a hostile pane id rather than read from docs.

What is worth raising instead on such a log site is length bounds and rate limits: a payload string can reach the 10 MB frame cap while `quild.log` keeps only 5 MB x 10 files, so a few frames evict the whole history — anti-forensics, never privilege crossing, since the socket is chmod 0600. The residual is the `initLogging`-returns-nil path, which writes to raw stderr with no escaping; that is pre-existing and affects every log site in the file equally.

Note: `chore/review-agent-memory` (another worktree, PR for #205's learnings) also appends to `.claude/agent-memory/qa/MEMORY.md`. Different line, but whichever merges second may need a rebase.
