### PR TITLE
fix(daemon): keep CRLF-terminated lines in task results and excerpts

### DIFF
--- a/changelog.d/fixed-excerpt-crlf.md
+++ b/changelog.d/fixed-excerpt-crlf.md
@@ -1,0 +1,10 @@
+---
+headline: Task results and event excerpts show real terminal output again
+---
+- **`delegate_task` results and notification excerpts were empty or a stray fragment
+  for real terminal output.** The excerpt helper treated the carriage return that ends
+  every PTY line (`\r\n`) as an overwrite and dropped the line, so `get_task` /
+  `wait_task` returned no `result` for a shell command and `task_done`, `agent_idle`
+  and `output_idle` events carried a blank or meaningless `excerpt`. A trailing carriage
+  return is now trimmed before the overwrite reset; a carriage return with text after
+  it still collapses to what the terminal shows.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -5738,11 +5738,19 @@ func (d *Daemon) analyzeIdleTitle(pane *Pane) (title, severity, excerpt string) 
 // actually SEES is the trailing segment after the last `\r`. Without this
 // reset, excerpts capture text the user can never see (e.g. the prompt
 // rune that was immediately overwritten) and miss the text they DO see.
+//
+// The `\r` of a CRLF line ending is NOT an overwrite: a PTY terminates every
+// line with `\r\n`, so after the split each line ends in `\r` with nothing
+// after it. Applying the reset to that CR emptied every line of real terminal
+// output — a delegated shell command came back with no result and every
+// task_done / agent_idle excerpt was blank or a stray fragment (measured
+// 2026-09-10 on a remote host). Trailing CRs are trimmed first; only a CR
+// with text after it is the overwrite the reset exists for.
 func lastNLines(text string, n int) string {
 	lines := strings.Split(text, "\n")
 	var result []string
 	for i := len(lines) - 1; i >= 0 && len(result) < n; i-- {
-		line := lines[i]
+		line := strings.TrimRight(lines[i], "\r")
 		if cr := strings.LastIndex(line, "\r"); cr >= 0 {
 			line = line[cr+1:]
 		}

--- a/internal/daemon/event_excerpt_followup_test.go
+++ b/internal/daemon/event_excerpt_followup_test.go
@@ -176,6 +176,44 @@ func TestLastNLines_NoCarriageReturnUntouched(t *testing.T) {
 	}
 }
 
+// A PTY ends every line with CRLF, so after the split on `\n` each line
+// carries a trailing `\r`. That CR terminates the line; it overwrites
+// nothing. Treating it as an overwrite reset emptied every line of real
+// terminal output — a delegated `echo` came back with no result, and every
+// task_done / agent_idle excerpt on a remote host was blank or a fragment
+// (observed 2026-09-10 on omarchy). ansi.Strip keeps `\r` (it passes C0
+// controls through), so the excerpt path sees exactly this shape.
+func TestLastNLines_KeepsCRLFTerminatedLines(t *testing.T) {
+	t.Parallel()
+	in := "TASK-MARKER omarchy 20:24:48\r\n7.2.3-arch1-3\r\n\r\n~ ❯ "
+	got := lastNLines(in, 30)
+	want := "TASK-MARKER omarchy 20:24:48\n7.2.3-arch1-3\n~ ❯"
+	if got != want {
+		t.Errorf("lastNLines CRLF: got %q, want %q", got, want)
+	}
+	// The overwrite reset still applies to a CR INSIDE a CRLF line.
+	in = "%          \r \r\ruser@host: /path\r\nnext\r\n"
+	got = lastNLines(in, 5)
+	want = "user@host: /path\nnext"
+	if got != want {
+		t.Errorf("lastNLines CR-reset then CRLF: got %q, want %q", got, want)
+	}
+}
+
+// The same through the ring buffer, as finishTask and the event enrichers
+// call it: a shell's CRLF output must produce the lines the user sees.
+func TestPaneOutputExcerpt_CRLFTerminalOutput(t *testing.T) {
+	t.Parallel()
+	pane := &Pane{OutputBuf: ringbuf.NewRingBuffer(4096)}
+	pane.OutputBuf.Write([]byte("$ uname -r\r\n7.2.3-arch1-3\r\n$ "))
+
+	got := paneOutputExcerpt(pane, 30)
+	want := "$ uname -r\n7.2.3-arch1-3\n$"
+	if got != want {
+		t.Errorf("paneOutputExcerpt CRLF: got %q, want %q", got, want)
+	}
+}
+
 func TestIsPromptOnlyExcerpt(t *testing.T) {
 	t.Parallel()
 	tests := []struct {


### PR DESCRIPTION
## Summary

`delegate_task` results and notification excerpts were empty or a stray fragment for real terminal output.

`lastNLines` (`internal/daemon/daemon.go`) applies terminal carriage-return semantics per line: text after the last `\r` is what the user sees. A PTY terminates every line with `\r\n`, so after the split on `\n` each line ends in `\r` with nothing after it, and the reset emptied it. Every test of the helper used `\n`-only input, so the suite never saw the shape the daemon actually receives (`ansi.Strip` passes C0 controls through).

Measured 2026-09-10 on a remote host (v1.72.1): a delegated `sleep 3; echo …; uname -r` came back `done` with no `result`; a delegated prompt to a Claude Code pane came back with `result: "← for agents"`; the `task_done`, `agent_idle` and `output_idle` events carried the same blank or fragment `excerpt`. The bug predates the task tools — it affects every event excerpt since the CR-reset was added.

Fix: trim trailing `\r` before the overwrite reset. A CR with text after it (`prompt   \r \r\ruser@host`) still collapses to the visible tail, which the existing test pins.

## Test plan

- [x] `TestLastNLines_KeepsCRLFTerminatedLines` and `TestPaneOutputExcerpt_CRLFTerminalOutput` fail on master with the live-observed outputs (`"~ ❯"`, `""`, `"$"`) and pass with the fix
- [x] Existing CR-reset and no-CR tests unchanged and green
- [x] `go test -tags=integration -race -timeout 300s ./...` in `golang:1.25`: all packages pass
- [x] Changelog fragment `changelog.d/fixed-excerpt-crlf.md`
